### PR TITLE
Introduce Sampler based on stats quantiles

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,7 +40,8 @@ func NewAgent(conf *config.File) *Agent {
 		conf.GetIntDefault("trace.concentrator", "bucket_size", 5),
 		conf.GetFloat64Default("trace.concentrator", "quantile_precision", 0),
 		exit, &exitGroup)
-	w := NewWriter(endpoint, exit, &exitGroup)
+	w := NewWriter(endpoint, exit, &exitGroup,
+		conf.GetIntDefault("trace.sampler", "min_span_by_distribution", 5))
 
 	return &Agent{
 		Config:       conf,

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/raclette/model"
+)
+
+// Sampler chooses wich spans to write to the API
+type Sampler struct {
+	TraceIDBySpanID map[model.SID]model.TID
+	SpansByTraceID  map[model.TID][]*model.Span
+}
+
+// NewSampler creates a new empty sampler
+func NewSampler() *Sampler {
+	return &Sampler{
+		TraceIDBySpanID: map[model.SID]model.TID{},
+		SpansByTraceID:  map[model.TID][]*model.Span{},
+	}
+}
+
+// IsEmpty tells if the sampler contains no span
+func (s *Sampler) IsEmpty() bool {
+	return len(s.TraceIDBySpanID) == 0
+}
+
+// AddSpan adds a span to the sampler internal momory
+func (s *Sampler) AddSpan(span *model.Span) {
+	s.TraceIDBySpanID[span.SpanID] = span.TraceID
+	spans, ok := s.SpansByTraceID[span.TraceID]
+	if !ok {
+		s.SpansByTraceID[span.TraceID] = []*model.Span{span}
+	} else {
+		s.SpansByTraceID[span.TraceID] = append(spans, span)
+	}
+}
+
+// GetSamples returns a list of representative spans to write
+func (s *Sampler) GetSamples(sb *model.StatsBucket, minSpanByDistribution int) []*model.Span {
+	qn := float64(1) / float64(minSpanByDistribution-1)
+	quantiles := make([]float64, minSpanByDistribution)
+	for i := 0; i < minSpanByDistribution; i++ {
+		quantiles[i] = float64(i) * qn
+	}
+
+	// Look at the stats to find representative spans
+	spanIDs := []model.SID{}
+	for _, c := range sb.Counts {
+		d := c.Distribution
+		if d != nil {
+			for _, q := range quantiles {
+				_, sIDs := d.Quantile(q)
+
+				if len(sIDs) > 0 { // TODO: not sure this condition is required
+					spanIDs = append(spanIDs, sIDs[0])
+				}
+			}
+		}
+	}
+
+	// Then find the trace IDs thanks to a spanID -> traceID map
+	traceIDSet := map[model.TID]interface{}{}
+	for _, spanID := range spanIDs {
+		traceIDSet[s.TraceIDBySpanID[spanID]] = nil
+	}
+
+	// Then get the traces (ie. set of spans) thanks to a traceID -> []spanID map
+	spans := []*model.Span{}
+	for traceID := range traceIDSet {
+		spans = append(spans, s.SpansByTraceID[traceID]...)
+	}
+
+	log.Infof("Sampled %d traces out of %d, %d spans out of %d",
+		len(traceIDSet), len(s.SpansByTraceID), len(spans), len(s.TraceIDBySpanID))
+
+	return spans
+}

--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -4,3 +4,6 @@ endpoint = http://localhost:5000/api/v0.1
 [trace.concentrator]
 bucket_size = 5
 quantile_precision = 0.01
+
+[trace.sampler]
+min_span_by_distribution = 5

--- a/model/payload.go
+++ b/model/payload.go
@@ -1,8 +1,8 @@
 package model
 
-// SpanPayload is the payload sent to the API of mothership with raw traces
-type SpanPayload struct {
+// Payload is the payload sent to the API of mothership with raw traces
+type Payload struct {
 	APIKey string       `json:"api_key"`
-	Spans  []Span       `json:"spans"`
+	Spans  []*Span      `json:"spans"`
 	Stats  *StatsBucket `json:"stats"`
 }

--- a/model/stats.go
+++ b/model/stats.go
@@ -104,41 +104,28 @@ func NewStatsBucket(eps float64) *StatsBucket {
 }
 
 // HandleSpan adds the span to this bucket stats
-func (sb *StatsBucket) HandleSpan(s *Span) bool {
-	keep := false
-
+func (sb *StatsBucket) HandleSpan(s *Span) {
 	// FIXME: clean and implement generic way of generating tag sets and metric names
 
 	// by service
 	sTag := Tag{Name: "service", Value: s.Service}
 	byS := []Tag{sTag}
-	if sb.addInDimension(s, &byS) {
-		keep = true
-	}
+	sb.addInDimension(s, &byS)
 
 	// by (service, resource)
 	rTag := Tag{Name: "resource", Value: s.Resource}
 	bySR := []Tag{sTag, rTag}
-	if sb.addInDimension(s, &bySR) {
-		keep = true
-	}
-
-	return keep
+	sb.addInDimension(s, &bySR)
 }
 
-func (sb *StatsBucket) addInDimension(s *Span, tags *[]Tag) bool {
+func (sb *StatsBucket) addInDimension(s *Span, tags *[]Tag) {
 	// FIXME: here add the ability to add more than the DefaultMetrics?
-	keep := false
 	for _, m := range DefaultMetrics {
-		if sb.addToCount(m, s, tags) {
-			keep = true
-		}
+		sb.addToCount(m, s, tags)
 	}
-
-	return keep
 }
 
-func (sb *StatsBucket) addToCount(metric string, s *Span, tags *[]Tag) bool {
+func (sb *StatsBucket) addToCount(metric string, s *Span, tags *[]Tag) {
 	ckey := CountKey(metric, *tags)
 
 	_, ok := sb.Counts[ckey]
@@ -146,5 +133,5 @@ func (sb *StatsBucket) addToCount(metric string, s *Span, tags *[]Tag) bool {
 		sb.Counts[ckey] = NewCount(metric, tags, sb.Eps)
 	}
 
-	return sb.Counts[ckey].Add(s)
+	sb.Counts[ckey].Add(s)
 }


### PR DESCRIPTION
Idea: only write spans considered as representative ie. from specific quantiles of the different distributions.

Implementation: For now, the writer has an instance of `Sampler` per `WriterBuffer`. We add all the incoming spans into this Sampler. Then when it's time to flush, run `GetSamples` which returns all the spans of traces containing an "interesting" span. A span is interesting if it represents a quantile of a distribution. The quantiles we look at comes from the config `min_span_by_distribution`. (examples: `[0, 0.5, 1]` if equals 3, `[0, 0.25, 0.50, 0.75, 1]` if equals 5, etc...).

We will probably want to move this Sampler into an independent worker. But it will require to change the WriterBuffer.
