### PR TITLE
Add BySlices() slicing summary by ranges & weights

### DIFF
--- a/quantile/summary.go
+++ b/quantile/summary.go
@@ -206,12 +206,20 @@ func (s *Summary) Quantile(q float64) (int64, []uint64) {
 	panic("not reached")
 }
 
+// SummarySlice reprensents how many values are in a [Start, End] range
 type SummarySlice struct {
 	Start  int64
 	End    int64
 	Weight int
 }
 
+// BySlices returns a slice of Summary slices that represents weighted ranges of
+// values
+// e.g.    [0, 1]  : 3
+//		   [1, 23] : 12 ...
+// The number of intervals is related to the precision kept in the internal
+// data structure to ensure epsilon*s.N precision on quantiles, but it's bounded.
+// The weights are not exact, they're only upper bounds (see GK paper).
 func (s *Summary) BySlices() []SummarySlice {
 	var slices []SummarySlice
 

--- a/quantile/summary_test.go
+++ b/quantile/summary_test.go
@@ -164,9 +164,6 @@ func TestSummaryBySlices(t *testing.T) {
 
 	for i := 0; i < 10000; i++ {
 		s.Insert(int64(i), uint64(i))
-		if i%1000 == 0 {
-			fmt.Println(i)
-		}
 	}
 
 	slices := s.BySlices()


### PR DESCRIPTION
Basically instead of using Quantile() and integrate, you can use
BySlices() and build directly a bar chart distribution like graph.
