### PR TITLE
OrgID in Edge struct + missing trace-agent.ini configuration

### DIFF
--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -1,3 +1,6 @@
+[graph.networktopology]
+trace_ports_list = 22,80,443,2181,6379,6380,6381,6382,6383,9092,5433,9200,7000,9042
+
 [trace.api]
 endpoint = http://localhost:8012/api/v0.1
 enabled=true

--- a/model/graph.go
+++ b/model/graph.go
@@ -14,9 +14,10 @@ type Node struct {
 
 // Edge is an edge of the graph: relation between 2 nodes with a type
 type Edge struct {
-	From Node
-	To   Node
-	Type string
+	From  Node
+	To    Node
+	Type  string
+	OrgID int32
 }
 
 // Key returns a serialized representation of the edge


### PR DESCRIPTION
Extend Edge struct by org_id
