### PR TITLE
Allow configuring concentrator OldestSpanCutoff

### DIFF
--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -8,6 +8,7 @@ api_key=apikey_2
 
 [trace.concentrator]
 bucket_size_seconds=5
+oldest_span_cutoff_seconds=30
 quantiles=0,0.25,0.5,0.75,0.90,0.95,0.99,1
 
 [graph.networktopology]

--- a/config/agent.go
+++ b/config/agent.go
@@ -33,7 +33,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		APIEnabled:  true,
 
 		BucketInterval:   time.Duration(5) * time.Second,
-		OldestSpanCutoff: time.Duration(5 * time.Second).Nanoseconds(),
+		OldestSpanCutoff: time.Duration(30 * time.Second).Nanoseconds(),
 
 		ExtraAggregators: []string{},
 
@@ -59,6 +59,10 @@ func NewAgentConfig(conf *File) (*AgentConfig, error) {
 
 	if v, e := conf.GetInt("trace.concentrator", "bucket_size_seconds"); e == nil {
 		c.BucketInterval = time.Duration(v) * time.Second
+	}
+
+	if v, e := conf.GetInt("trace.concentrator", "oldest_span_cutoff_seconds"); e == nil {
+		c.OldestSpanCutoff = time.Duration(v * time.Second).Nanoseconds()
 	}
 
 	if v, e := conf.GetStrArray("trace.concentrator", "extra_aggregators", ","); e == nil {


### PR DESCRIPTION
This was hardcoded at 5 before.
This controls basically how far back in time we allow a span to be added
to an older bucket, this has 2 consequences: spans older than oldest
span cutoff are dropped, and we wait at least oldest span cutoff to
flush any bucket to make sure no spans will be added to them.

Our bucket was 10s large, meaning we would drop as late spans half of
them.
