### PR TITLE
Leo/cleanup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -72,7 +72,7 @@ func (a *Agent) runFlusher() {
 	for {
 		select {
 		case <-ticker.C:
-			log.Debug("Trigger a flush")
+			log.Debug("tick - agent triggering flush")
 			a.Quantizer.out <- model.NewTraceFlushMarker()
 
 			// Collect and merge partial flushs
@@ -97,11 +97,12 @@ func (a *Agent) runFlusher() {
 				}
 			}()
 			wg.Wait()
+			log.Debugf("tock - all routines flushed (%d stats, %d/%d spans/traces)", len(p.Stats), len(p.Spans), len(p.Traces))
 
 			if !p.IsEmpty() {
 				a.Writer.in <- p
 			} else {
-				log.Debug("Empty payload, skipping")
+				log.Debug("flush produced an empty payload, skipping")
 			}
 		case <-a.exit:
 			ticker.Stop()
@@ -112,7 +113,7 @@ func (a *Agent) runFlusher() {
 
 // Start starts all components
 func (a *Agent) Start() error {
-	log.Info("Starting agent")
+	log.Info("starting the trace-agent")
 
 	// Build the pipeline in the opposite way the data is processed
 	a.Writer.Start()
@@ -128,7 +129,7 @@ func (a *Agent) Start() error {
 
 // Stop stops all components
 func (a *Agent) Stop() error {
-	log.Info("Stopping agent")
+	log.Info("stopping the trace-agent")
 
 	a.Receiver.Stop()
 	a.SublayerTagger.Stop()

--- a/agent/listener.go
+++ b/agent/listener.go
@@ -19,7 +19,7 @@ func NewStoppableListener(l net.Listener, exit chan struct{}) (*StoppableListene
 	tcpL, ok := l.(*net.TCPListener)
 
 	if !ok {
-		return nil, errors.New("Cannot wrap listener")
+		return nil, errors.New("cannot wrap listener")
 	}
 
 	sl := &StoppableListener{exit: exit, TCPListener: tcpL}
@@ -38,8 +38,8 @@ func (sl *StoppableListener) Accept() (net.Conn, error) {
 		//Check for the channel being closed
 		select {
 		case <-sl.exit:
-			log.Info("Stopping Listener")
-			return nil, errors.New("Listener stopped")
+			log.Debug("stopping listener")
+			return nil, errors.New("listener stopped")
 		default:
 			//If the channel is still open, continue as normal
 		}

--- a/agent/main.go
+++ b/agent/main.go
@@ -23,7 +23,7 @@ func handleSignal(exit chan struct{}) {
 	for signal := range sigChan {
 		switch signal {
 		case syscall.SIGINT, syscall.SIGTERM:
-			log.Info("Received interruption signal")
+			log.Info("received interruption signal")
 			close(exit)
 		}
 	}
@@ -117,4 +117,5 @@ func main() {
 	go handleSignal(agent.exit)
 
 	agent.Run()
+	log.Info("exiting")
 }

--- a/agent/quantizer.go
+++ b/agent/quantizer.go
@@ -37,7 +37,7 @@ func (q *Quantizer) Start() {
 				}
 				q.out <- trace
 			case <-q.exit:
-				log.Info("Quantizer exiting")
+				log.Debug("stopping quantizer")
 				close(q.out)
 				q.wg.Done()
 				return
@@ -45,5 +45,5 @@ func (q *Quantizer) Start() {
 		}
 	}()
 
-	log.Info("Quantizer started")
+	log.Debug("started quantizer")
 }

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -68,11 +68,11 @@ func (l *HTTPReceiver) Start() {
 	http.HandleFunc("/v0.2/services", httpHandleWithVersion(v02, l.handleServices))
 
 	addr := ":7777"
-	log.Infof("HTTP Listener starting on %s", addr)
+	log.Infof("listening for traces at http://localhost%s/", addr)
 
 	tcpL, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Error("Could not create TCP listener")
+		log.Error("could not create TCP listener")
 		panic(err)
 	}
 
@@ -175,7 +175,7 @@ func (l *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, r *http
 			t = t[:len(t)-1]
 		}
 
-		log.Debugf("received a trace, id:%d len:%d", t[0].TraceID, len(t))
+		log.Debugf("received a trace, id:%d spans:%d", t[0].TraceID, len(t))
 		l.traces <- t
 		ttotal++
 	}

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -41,7 +41,7 @@ func NewSampler(in chan model.Trace, conf *config.AgentConfig) *Sampler {
 // Start runs the Sampler by sending incoming spans to the SamplerEngine and flushing it on demand
 func (s *Sampler) Start() {
 	go s.run()
-	log.Info("Sampler started")
+	log.Debug("started sampler")
 }
 
 func (s *Sampler) run() {
@@ -50,15 +50,14 @@ func (s *Sampler) run() {
 		select {
 		case trace := <-s.in:
 			if len(trace) == 1 && trace[0].IsFlushMarker() {
-				log.Debug("Sampler starts a flush")
 				traces := s.se.Flush()
-				log.Debugf("Sampler flushes %d traces", len(traces))
+				log.Debugf("sampler flushed %d traces", len(traces))
 				s.out <- traces
 			} else {
 				s.se.AddTrace(trace)
 			}
 		case <-s.exit:
-			log.Info("Sampler exiting")
+			log.Debug("stopping sampler")
 			close(s.out)
 			s.wg.Done()
 			return

--- a/agent/sublayers.go
+++ b/agent/sublayers.go
@@ -33,7 +33,7 @@ func NewSublayerTagger(in chan model.Trace) *SublayerTagger {
 // Start starts the tagger
 func (st *SublayerTagger) Start() {
 	go st.run()
-	log.Info("SublayerTagger started")
+	log.Debug("started sublayer tagger")
 }
 
 func (st *SublayerTagger) run() {
@@ -44,7 +44,7 @@ func (st *SublayerTagger) run() {
 		case t := <-st.in:
 			st.out <- tagSublayers(t)
 		case <-st.exit:
-			log.Info("SublayerTagger exiting")
+			log.Debug("stopping sublayer tagger")
 			close(st.out)
 			st.wg.Done()
 			return

--- a/sampler/resource_quantile.go
+++ b/sampler/resource_quantile.go
@@ -96,8 +96,8 @@ func (s *ResourceQuantileSampler) GetSamples(
 	}
 
 	execTime := time.Since(startTime)
-	log.Infof("Sampled %d traces out of %d, %d spans out of %d, in %s",
-		len(result), traces, kSpans, spans, execTime)
+	log.Infof("sampler: selected %d traces (%.2f %%), %d spans (%.2f %%)",
+		len(result), float64(len(result))*100/float64(traces), kSpans, float64(kSpans)*100/float64(spans))
 
 	statsd.Client.Count("trace_agent.sampler.trace.total", int64(traces), nil, 1)
 	statsd.Client.Count("trace_agent.sampler.trace.kept", int64(len(result)), nil, 1)


### PR DESCRIPTION
logging before:

```
2016-06-10 16:28:41 INFO (concentrator.go:137) - Concentrator adds bucket to payload 1465576060000000000
2016-06-10 16:28:41 INFO (resource_quantile.go:100) - Sampled 22 traces out of 26, 291 spans out of 315, in 90.661µs
2016-06-10 16:28:41 INFO (writer.go:67) - Received a payload, initiating a flush
2016-06-10 16:28:41 INFO (writer.go:185) - Payload flushed to the API (time=221.970917ms, size=0)
2016-06-10 16:28:41 INFO (writer.go:132) - Flushed 1/1 payloads
2016-06-10 16:28:51 INFO (concentrator.go:137) - Concentrator adds bucket to payload 1465576070000000000
2016-06-10 16:28:51 INFO (resource_quantile.go:100) - Sampled 16 traces out of 22, 140 spans out of 176, in 67.283µs
2016-06-10 16:28:51 INFO (writer.go:67) - Received a payload, initiating a flush
2016-06-10 16:28:51 INFO (writer.go:185) - Payload flushed to the API (time=43.333496ms, size=0)
2016-06-10 16:28:51 INFO (writer.go:132) - Flushed 1/1 payloads
2016-06-10 16:28:51 INFO (writer.go:216) - flushed 10 services to the API
```

after:

```
2016-06-10 16:34:16 INFO (agent.go:116) - starting the trace-agent
2016-06-10 16:34:16 INFO (receiver.go:71) - listening for traces at http://localhost:7777/
2016-06-10 16:34:26 INFO (resource_quantile.go:100) - sampler: selected 22 traces (84.62 %), 274 spans (91.95 %)
2016-06-10 16:34:26 INFO (writer.go:188) - flushed payload to the API, time:77.81192ms, size:17169
2016-06-10 16:34:36 INFO (resource_quantile.go:100) - sampler: selected 16 traces (94.12 %), 137 spans (95.80 %)
2016-06-10 16:34:36 INFO (writer.go:188) - flushed payload to the API, time:63.924599ms, size:7516
```
