### PR TITLE
[perf] move statsd flush out of band in receiver

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -238,5 +238,7 @@ func (l *HTTPReceiver) logStats() {
 		statsd.Client.Count("trace_agent.receiver.trace", traces, nil, 1)
 		statsd.Client.Count("trace_agent.receiver.span_dropped", sdropped, nil, 1)
 		statsd.Client.Count("trace_agent.receiver.trace_dropped", tdropped, nil, 1)
+
+		log.Infof("receiver handled %d spans, dropped %d ; handled %d traces, dropped %d", spans, sdropped, traces, tdropped)
 	}
 }


### PR DESCRIPTION
Syscalls from our internal statsd submissions show up prominently in cpu profiles. this adds a change to move some submissions out of the main request loop and flush them at 10s intervals.:

profile before: `s3cmd get s3://dd-pastebin/talwai/prof_10m.svg`
profile after: `s3cmd get s3://dd-pastebin/talwai/prof_10m_no_statsd.svg` 
