### PR TITLE
model/tags: fix resource tag bug

### DIFF
--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -157,7 +157,7 @@ func BenchmarkGetAggregateString(b *testing.B) {
 	sb := NewStatsBucket(0, 1e9, time.Millisecond)
 	for i := 0; i < b.N; i++ {
 		for _, s := range testSpans {
-			getAggregateString(s, aggr, &sb.keyBuf)
+			getAggregateGrain(s, aggr, &sb.keyBuf)
 		}
 	}
 	b.ReportAllocs()


### PR DESCRIPTION
We didn't handle properly resources with commas in them becaus the way we went from string -> `TagSet` when initializing counts was incorrect. This fixes it the dumb way by just creating a TagSet up front (cheap to pass around since it's a slice), and passing it  along with its string representation (which was introduced [here](http://github.com/DataDog/raclette/pull/79) to improve memory usage
