### PR TITLE
[pkg] remove dep on systemd in rpm

### DIFF
--- a/packaging/rpm/raclette.spec
+++ b/packaging/rpm/raclette.spec
@@ -9,7 +9,6 @@ License: BSD
 Summary: A tracing agent crafted with <3 from Datadog
 Buildroot: /go/src/github.com/DataDog/raclette
 Packager: Datadog <dev@datadoghq.com>
-%{?systemd_requires}
 BuildRequires: systemd
 
 %description


### PR DESCRIPTION
The `%{?systemd_requires}` macro imposed a dependency on `systemd` even though the agent RPM could run just fine without it. The remaining `systemd_preun` and `systemd_postun` macros should continue to do the right thing without the `Requires:` macro

Relevant reading:
https://fedoraproject.org/wiki/Packaging:Scriptlets#Systemd
https://lists.opensuse.org/opensuse-factory/2015-03/msg00289.html
https://fedorahosted.org/fpc/ticket/600
