### PR TITLE
add ReceiverPort in the agent configuration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -29,7 +29,7 @@ type Agent struct {
 func NewAgent(conf *config.AgentConfig) *Agent {
 	exit := make(chan struct{})
 
-	r := NewHTTPReceiver(conf.ConnectionLimit)
+	r := NewHTTPReceiver(conf)
 	st := NewSublayerTagger(r.traces)
 	q := NewQuantizer(st.out)
 

--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/raclette/config"
 	"github.com/DataDog/raclette/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,8 +16,11 @@ import (
 func TestReceiverTraces(t *testing.T) {
 	assert := assert.New(t)
 
+	// get the default configuration
+	defaultConfig := config.NewDefaultAgentConfig()
+
 	// receiver just here so that we can attach the handler
-	r := NewHTTPReceiver(10)
+	r := NewHTTPReceiver(defaultConfig)
 	server := httptest.NewServer(
 		http.HandlerFunc(httpHandleWithVersion(v02, r.handleTraces)),
 	)

--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -67,5 +67,7 @@ trace_period=5
 # and queues for processing
 ###################################################
 [trace.receiver]
+# the port that the Receiver should listen
+receiver_port=7777
 # how many unique connections to allow during one 30 second lease period
 connection_limit=2000

--- a/config/agent.go
+++ b/config/agent.go
@@ -34,6 +34,7 @@ type AgentConfig struct {
 	TPSMax          float64
 
 	// Receiver
+	ReceiverPort    int
 	ConnectionLimit int // for rate-limiting, how many unique connections to allow in a lease period (30s)
 
 	// internal telemetry
@@ -92,6 +93,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ScoreJitter:     0.1,
 		TPSMax:          100,
 
+		ReceiverPort:    7777,
 		ConnectionLimit: 2000,
 
 		StatsdHost: "localhost",
@@ -153,6 +155,10 @@ func NewAgentConfig(conf *File) (*AgentConfig, error) {
 	}
 	if v, e := conf.GetFloat("trace.sampler", "max_tps"); e == nil {
 		c.TPSMax = v
+	}
+
+	if v, e := conf.GetInt("trace.receiver", "receiver_port"); e == nil {
+		c.ReceiverPort = v
 	}
 
 	if v, e := conf.GetInt("trace.receiver", "connection_limit"); e == nil {


### PR DESCRIPTION
# What it does?

Adds a `ReceiverPort` in the agent configuration. Before this PR, the `HTTPReceiver` expected only a `ConnectionLimit` value, while actually it expects an `AgentConfig` pointer like other components do (i.e. `Concentrator`, `Sampler` and `Writer`)
