### PR TITLE
[normalizer] set ParentID to 0 if it's equal to TraceID and SpanID

### DIFF
--- a/model/normalizer.go
+++ b/model/normalizer.go
@@ -78,7 +78,10 @@ func (s *Span) Normalize() error {
 	}
 
 	// ParentID, TraceID and SpanID set in the client could be the same
-	// we should support this format, allowing ParentID == TraceID == SpanID for the root span
+	// Supporting the ParentID == TraceID == SpanID for the root span, is compliant
+	// with the Zipkin implementation. Furthermore, as described in the PR
+	// https://github.com/openzipkin/zipkin/pull/851 the constraint that the
+	// root span's ``trace id = span id`` has been removed
 	if s.ParentID == s.TraceID && s.ParentID == s.SpanID {
 		s.ParentID = 0
 		log.Debugf("span.normalize: `ParentID`, `TraceID` and `SpanID` are the same; `ParentID` set to 0: %s", s.TraceID)

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -217,7 +217,7 @@ func TestNormalizeServiceTag(t *testing.T) {
 	assert.Equal(t, "retargeting_api-staging", s.Service)
 }
 
-func TestNormalizeInequalityRootSpan(t *testing.T) {
+func TestSpecialZipkinRootSpan(t *testing.T) {
 	s := Span(testSpan)
 	s.ParentID = 42
 	s.TraceID = 42


### PR DESCRIPTION
### Quoting [Trello Card](https://trello.com/c/UL1iq1yc/578-alllow-parent-id-span-id-trace-id-for-the-root-span):

> Talked with Aaditya and Manu. That's mostly to be compatible with Zipkin specs (seems to be a special rule to avoid having null `parent_id` ; which we can have).
> Technically, it is fine for us officially support that. But we shouldn't stop both possible format (for the root, `parent_id = 0` or `parent_id = trace_id`).
> Suggestion: in the normalize happening in the Agent (+ also server-side?), if `parent_id == trace_id`, then set `parent_id = 0`.
> 
> This way we have a single way of finding roots.
### What it does

It sets the `span.ParentID = 0`. A test for the special inequality check is provided.
### Questions
- Should I add more tests on this change?
- Should I update the `span.go` model? Maybe providing a kind of `Flag` if the `ParentID` becomes `0` because of the normalize process?
- Do we want to add a kind of `span.IsRoot` field if we detect that? Or it's totally useless in our pipeline?
