### PR TITLE
[packaging] the build fails if the package is not signed correctly

### DIFF
--- a/packaging/rpm/rpm-sign
+++ b/packaging/rpm/rpm-sign
@@ -10,3 +10,5 @@ spawn rpm --addsign $rpmfile
 expect -exact "Enter pass phrase: "
 send -- "$passphrase\r"
 expect eof
+catch wait result
+exit [lindex $result 3]


### PR DESCRIPTION
`expect` doesn't "proxy" the exit status code from the signing process. This results in wrong builds that cannot be installed by customers.

A note has been added in the https://github.com/DataDog/devops/wiki/Trace-Agent-Build-and-Release#rpm-x86_64 wiki.
