### PR TITLE
[trace] refactoring, removed usage of deprecated method

### DIFF
--- a/fixtures/stats.go
+++ b/fixtures/stats.go
@@ -138,7 +138,7 @@ var TestDistroValues = []int64{
 
 // TestDistribution returns a distribution with pre-defined values
 func TestDistribution() model.Distribution {
-	tgs := model.NewTagsFromString("service:X,name:Y,host:Z")
+	tgs := model.NewTagSetFromString("service:X,name:Y,host:Z")
 	d := model.NewDistribution("duration", "duration|service:X,name:Y,host:Z", tgs)
 	for i, v := range TestDistroValues {
 		d.Add(float64(v), uint64(i))

--- a/model/tags.go
+++ b/model/tags.go
@@ -49,12 +49,6 @@ func NewTagSetFromString(raw string) TagSet {
 	return tags
 }
 
-// NewTagsFromString is deprecated
-func NewTagsFromString(r string) TagSet {
-	// FIXME[matt] kill me
-	return NewTagSetFromString(r)
-}
-
 // TagKey returns a unique key from the string given and the tagset, useful to index stuff on tagsets
 func (t TagSet) TagKey(m string) string {
 	tagStrings := make([]string, len(t))

--- a/model/tags_test.go
+++ b/model/tags_test.go
@@ -23,27 +23,27 @@ func TestGroup(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
-	t1 := NewTagsFromString("a:2,a:1,a:3")
-	t2 := NewTagsFromString("a:1,a:2,a:3")
+	t1 := NewTagSetFromString("a:2,a:1,a:3")
+	t2 := NewTagSetFromString("a:1,a:2,a:3")
 	sort.Sort(t1)
 	assert.Equal(t, t1, t2)
 }
 
 func TestTagMerge(t *testing.T) {
-	t1 := NewTagsFromString("a:1,a:2")
-	t2 := NewTagsFromString("a:2,a:3")
+	t1 := NewTagSetFromString("a:1,a:2")
+	t2 := NewTagSetFromString("a:2,a:3")
 	t3 := MergeTagSets(t1, t2)
-	assert.Equal(t, t3, NewTagsFromString("a:1,a:2,a:3"))
+	assert.Equal(t, t3, NewTagSetFromString("a:1,a:2,a:3"))
 
-	t1 = NewTagsFromString("a:1")
-	t2 = NewTagsFromString("a:2")
+	t1 = NewTagSetFromString("a:1")
+	t2 = NewTagSetFromString("a:2")
 	t3 = MergeTagSets(t1, t2)
-	assert.Equal(t, t3, NewTagsFromString("a:1,a:2"))
+	assert.Equal(t, t3, NewTagSetFromString("a:1,a:2"))
 
-	t1 = NewTagsFromString("a:2,a:1")
-	t2 = NewTagsFromString("a:6,a:2")
+	t1 = NewTagSetFromString("a:2,a:1")
+	t2 = NewTagSetFromString("a:6,a:2")
 	t3 = MergeTagSets(t1, t2)
-	assert.Equal(t, t3, NewTagsFromString("a:1,a:2,a:6"))
+	assert.Equal(t, t3, NewTagSetFromString("a:1,a:2,a:6"))
 
 }
 


### PR DESCRIPTION
raclette.NewTagsFromString -> raclette.NewTagSetFromString
