### PR TITLE
[quantizer] sql.query metadata rules for obfuscation

### DIFF
--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -9,7 +9,10 @@ import (
 	"github.com/DataDog/raclette/model"
 )
 
-const sqlVariableReplacement = "?"
+const (
+	sqlVariableReplacement = "?"
+	sqlQueryTag            = "sql.query"
+)
 
 var sqlVariablesRegexp = regexp.MustCompile("('[^']+')|([\\$]*\\b[0-9]+\\b)")
 var sqlLiteralsRegexp = regexp.MustCompile("\\b(?i:true|false|null)\\b")
@@ -20,39 +23,61 @@ var sqlCommentsRegexp = regexp.MustCompile("--[^\n]*")
 // CQL encodes query params with %s
 var cqlListVariablesRegex = regexp.MustCompile(`%s(([,\s]|%s)+%s\s*|)`) // (%s, %s, %s, %s)
 
-// QuantizeSQL generates resource for SQL spans
+// QuantizeSQL generates resource and sql.query meta for SQL spans
 func QuantizeSQL(span model.Span) model.Span {
 	// Trim spaces and ending special chars
 	query := span.Resource
 
-	resource := strings.TrimSpace(query)
-	resource = strings.TrimSuffix(resource, ";")
+	// remove special characters to get a clean query
+	query = strings.TrimSpace(query)
+	query = strings.TrimSuffix(query, ";")
 
-	if resource == "" {
-		span.Resource = resource
+	if query == "" {
+		span.Resource = query
 		return span
 	}
 
 	log.Debugf("Quantize SQL command, generate resource from the query, SpanID: %d", span.SpanID)
-
-	// Remove variables
-	resource = sqlVariablesRegexp.ReplaceAllString(resource, sqlVariableReplacement)
-	resource = sqlLiteralsRegexp.ReplaceAllString(resource, sqlVariableReplacement)
-	resource = sqlalchemyVariablesRegexp.ReplaceAllString(resource, sqlVariableReplacement)
-
-	// Deal with list of variables of arbitrary size
-	resource = sqlListVariablesRegexp.ReplaceAllString(resource, sqlVariableReplacement)
-
-	// Remove comments
-	resource = sqlCommentsRegexp.ReplaceAllString(resource, "")
-
-	// Uniform spacing
-	resource = compactAllSpaces(resource)
-
-	// Replace parenthesized variable lists (%s, %s, %s, %s)
-	resource = cqlListVariablesRegex.ReplaceAllString(resource, sqlVariableReplacement)
-
+	resource := quantize(query)
 	span.Resource = resource
 
+	// set the sql.query tag if and only if it's not already set by users. If a users set
+	// this value, we send that value AS IS to the backend. If the value is not set, we
+	// try to obfuscate users parameters so that sensitive data are not sent in the backend.
+	// TODO: the current implementation is a rough approximation that assumes
+	// obfuscation == quantization. This is not true in real environments because we're
+	// removing data that could be interesting for users.
+	if span.Meta != nil && span.Meta[sqlQueryTag] != "" {
+		return span
+	}
+
+	if span.Meta == nil {
+		span.Meta = make(map[string]string)
+	}
+
+	span.Meta[sqlQueryTag] = resource
+
 	return span
+}
+
+// quantize returns a quantized string for the given query
+func quantize(query string) string {
+	// Remove variables
+	query = sqlVariablesRegexp.ReplaceAllString(query, sqlVariableReplacement)
+	query = sqlLiteralsRegexp.ReplaceAllString(query, sqlVariableReplacement)
+	query = sqlalchemyVariablesRegexp.ReplaceAllString(query, sqlVariableReplacement)
+
+	// Deal with list of variables of arbitrary size
+	query = sqlListVariablesRegexp.ReplaceAllString(query, sqlVariableReplacement)
+
+	// Remove comments
+	query = sqlCommentsRegexp.ReplaceAllString(query, "")
+
+	// Uniform spacing
+	query = compactAllSpaces(query)
+
+	// Replace parenthesized variable lists (%s, %s, %s, %s)
+	query = cqlListVariablesRegex.ReplaceAllString(query, sqlVariableReplacement)
+
+	return query
 }

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -23,6 +23,33 @@ type sqlTestCase struct {
 	expected string
 }
 
+func TestSQLResourceQuery(t *testing.T) {
+	assert := assert.New(t)
+	span := model.Span{
+		Resource: "SELECT * FROM users WHERE id = 42",
+		Type:     "sql",
+		Meta: map[string]string{
+			"sql.query": "SELECT * FROM users WHERE id = 42",
+		},
+	}
+
+	spanQ := Quantize(span)
+	assert.Equal("SELECT * FROM users WHERE id = ?", spanQ.Resource)
+	assert.Equal("SELECT * FROM users WHERE id = 42", spanQ.Meta["sql.query"])
+}
+
+func TestSQLResourceWithoutQuery(t *testing.T) {
+	assert := assert.New(t)
+	span := model.Span{
+		Resource: "SELECT * FROM users WHERE id = 42",
+		Type:     "sql",
+	}
+
+	spanQ := Quantize(span)
+	assert.Equal("SELECT * FROM users WHERE id = ?", spanQ.Resource)
+	assert.Equal("SELECT * FROM users WHERE id = ?", spanQ.Meta["sql.query"])
+}
+
 func TestSQLQuantizer(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
### What it does

The goal of this PR is to open a thread about how we can obfuscate query parameters when the clients (for one reason or another) send these values.

It *tries* to remove sensitive data from the given users' queries. It uses the default ``QuantizeSQL`` version (that seems good enough) but we can enhance the logic (i.e. don't strip comments) if we want (I suggest later?).

Anyway, we should discuss about this.

### Current implementation

* if a ``sql.query`` is provided by user, leave it AS IS
* if a ``sql.query`` is not provided, obfuscate the query using an ``obfuscation`` func
* as a rough approximation, the ``quantize`` func is used to obfuscate the ``sql.query`` starting from the ``resource`` value.

#### What's missing

* ~~housekeeping~~
* ~~maybe remove helpers (used them just to make the code easy to read)~~
* ~~improve the quantizer itself because we're not getting booleans or ``IN (?)`` stuff~~