### PR TITLE
[quantizer] quantization rules improvements

### DIFF
--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -12,6 +12,7 @@ import (
 const sqlVariableReplacement = "?"
 
 var sqlVariablesRegexp = regexp.MustCompile("('[^']+')|([\\$]*\\b[0-9]+\\b)")
+var sqlLiteralsRegexp = regexp.MustCompile("\\b(?i:true|false|null)\\b")
 var sqlalchemyVariablesRegexp = regexp.MustCompile("%\\(.+?\\)s")
 var sqlListVariablesRegexp = regexp.MustCompile("\\?[\\? ,]+\\?")
 var sqlCommentsRegexp = regexp.MustCompile("--[^\n]*")
@@ -36,6 +37,7 @@ func QuantizeSQL(span model.Span) model.Span {
 
 	// Remove variables
 	resource = sqlVariablesRegexp.ReplaceAllString(resource, sqlVariableReplacement)
+	resource = sqlLiteralsRegexp.ReplaceAllString(resource, sqlVariableReplacement)
 	resource = sqlalchemyVariablesRegexp.ReplaceAllString(resource, sqlVariableReplacement)
 
 	// Deal with list of variables of arbitrary size

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -75,9 +75,8 @@ func TestSQLQuantizer(t *testing.T) {
 			"SELECT articles.* FROM articles WHERE (articles.created_at BETWEEN ? AND ?)",
 		},
 		{
-			// TODO[manu]: this query should be resolved with ?
 			"SELECT articles.* FROM articles WHERE (articles.published != true)",
-			"SELECT articles.* FROM articles WHERE (articles.published != true)",
+			"SELECT articles.* FROM articles WHERE (articles.published != ?)",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE (title = 'guides.rubyonrails.org')",
@@ -100,9 +99,8 @@ func TestSQLQuantizer(t *testing.T) {
 			"SELECT articles.* FROM articles WHERE articles.id IN (?)",
 		},
 		{
-			// TODO[manu]: this query should be resolved with ?
 			"SELECT * FROM clients WHERE (clients.first_name = 'Andy') LIMIT 1 BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES ('2011-08-30 05:22:57', 'Andy', 1, NULL, '2011-08-30 05:22:57') COMMIT",
-			"SELECT * FROM clients WHERE (clients.first_name = ?) LIMIT ? BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES (?, NULL, ?) COMMIT",
+			"SELECT * FROM clients WHERE (clients.first_name = ?) LIMIT ? BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES (?) COMMIT",
 		},
 	}
 


### PR DESCRIPTION
### What it does

Improvements to the current quantizer:
* takes care of ``$1`` values (prior they're changed in ``$?``)
* trims the ``;`` at the end of the query
* *tries* to handle numbers when they have word boundaries (i.e. table names)
* it handles some literals such as ``true``, ``false`` and ``null``
* add some tests with ordinary SQL generated using an ORM. It's meant to extend a little the current case coverage