### PR TITLE
[agent] config from environment

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -136,7 +136,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,
 
-		ReceiverHost:    "0.0.0.0",
+		ReceiverHost:    "localhost",
 		ReceiverPort:    7777,
 		ConnectionLimit: 2000,
 


### PR DESCRIPTION
### What it does

Allows users to override the default configuration or the file configuration with environment variables. Actually, provided variables are:
* ``DATADOG_HOSTNAME``
* ``DATADOG_API_KEY``
* ``DATADOG_RECEIVER_HOST``
* ``DATADOG_RECEIVER_PORT``
* ``DATADOG_BIND_HOST``
* ``DATADOG_DOGSTATSD_PORT``

#### What's missing

~~Probably the environment names are not correct.~~