### PR TITLE
[trace:agent] trying to fix test flakyness

### DIFF
--- a/agent/writer.go
+++ b/agent/writer.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"sync/atomic"
+
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/raclette/config"
@@ -19,6 +21,8 @@ type Writer struct {
 
 	payloadBuffer []model.AgentPayload   // buffered of payloads ready to send
 	serviceBuffer model.ServicesMetadata // services are merged into this map continuously
+
+	payloadBufferLen int32 // used for async debugging, not always exact
 
 	exit chan struct{}
 }
@@ -65,6 +69,7 @@ func (w *Writer) Run() {
 			w.Flush()
 			return
 		}
+		atomic.StoreInt32(&w.payloadBufferLen, int32(len(w.payloadBuffer)))
 	}
 }
 
@@ -82,4 +87,8 @@ func (w *Writer) Flush() {
 	// regardless if the http post was was success or not. We don't want to buffer
 	// data in case of api outage. See also endpoint.Write() comment.
 	w.payloadBuffer = nil
+}
+
+func (w *Writer) getPayloadBufferLen() int32 {
+	return atomic.LoadInt32(&w.payloadBufferLen)
 }

--- a/agent/writer_test.go
+++ b/agent/writer_test.go
@@ -50,6 +50,8 @@ func TestWriterServices(t *testing.T) {
 	conf.APIKeys = []string{"xxxxxxx"}
 
 	w := NewWriter(conf)
+	w.inServices = make(chan model.ServicesMetadata)
+
 	go w.Run()
 
 	// send services
@@ -59,7 +61,6 @@ func TestWriterServices(t *testing.T) {
 		},
 	}
 
-	w.inServices = make(chan model.ServicesMetadata)
 	w.inServices <- services
 
 receivingLoop:
@@ -142,8 +143,8 @@ receivingLoop:
 			t.Fatal("did not receive service data in time")
 		}
 	}
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// we should just have ignored the 400 error on the other backend
-	assert.Len(w.payloadBuffer, 0)
+	assert.Equal(w.getPayloadBufferLen(), 0)
 }


### PR DESCRIPTION
Previous tests were:
1 - flaky
2 - not "-race" proof
With this patch, tests stop fiddling with bucket size while executing,
and some atomic calls have been used to avoid race condtions.