### PR TITLE
[agent] don't report with empty api key

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -81,7 +81,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 	ac := &AgentConfig{
 		HostName:     hostname,
 		APIEndpoints: []string{"https://trace.agent.datadoghq.com"},
-		APIKeys:      []string{""},
+		APIKeys:      []string{},
 		APIEnabled:   true,
 
 		BucketInterval:   time.Duration(10) * time.Second,


### PR DESCRIPTION
Because we default to an empty string in the api key list, this sanity check does not error out when it should: 

https://github.com/DataDog/raclette/blob/49f8813afef0f882f76d929bf2e81af7cc95cac5/config/agent.go#L146-L148