### PR TITLE
[agent] providing a ReceiverHost that defaults to all available interfaces

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -78,8 +78,8 @@ func (l *HTTPReceiver) Run() {
 	http.HandleFunc("/v0.2/traces", httpHandleWithVersion(v02, l.handleTraces))
 	http.HandleFunc("/v0.2/services", httpHandleWithVersion(v02, l.handleServices))
 
-	addr := fmt.Sprintf(":%d", l.conf.ReceiverPort)
-	log.Infof("listening for traces at http://localhost%s/", addr)
+	addr := fmt.Sprintf("%s:%d", l.conf.ReceiverHost, l.conf.ReceiverPort)
+	log.Infof("listening for traces at http://%s/", addr)
 
 	tcpL, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/config/agent.go
+++ b/config/agent.go
@@ -35,6 +35,7 @@ type AgentConfig struct {
 	MaxTPS          float64
 
 	// Receiver
+	ReceiverHost    string
 	ReceiverPort    int
 	ConnectionLimit int // for rate-limiting, how many unique connections to allow in a lease period (30s)
 
@@ -91,6 +92,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,
 
+		ReceiverHost:    "0.0.0.0",
 		ReceiverPort:    7777,
 		ConnectionLimit: 2000,
 


### PR DESCRIPTION
### What it does

Add the ``ReceiverHost`` field so that it's clear to users that the agent will listen to ``0.0.0.0``. It doesn't change the current behavior.