### PR TITLE
[quantizer] remove SQL block comments

### DIFF
--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -18,7 +18,7 @@ var sqlVariablesRegexp = regexp.MustCompile("('[^']+')|([\\$]*\\b[0-9]+\\b)")
 var sqlLiteralsRegexp = regexp.MustCompile("\\b(?i:true|false|null)\\b")
 var sqlalchemyVariablesRegexp = regexp.MustCompile("%\\(.+?\\)s")
 var sqlListVariablesRegexp = regexp.MustCompile("\\?[\\? ,]+\\?")
-var sqlCommentsRegexp = regexp.MustCompile("--[^\n]*")
+var sqlCommentsRegexp = regexp.MustCompile("(--[^\n]*)|(/\\*(.|\n)*?\\*/)")
 
 // CQL encodes query params with %s
 var cqlListVariablesRegex = regexp.MustCompile(`%s(([,\s]|%s)+%s\s*|)`) // (%s, %s, %s, %s)

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -71,6 +71,10 @@ func TestSQLQuantizer(t *testing.T) {
 			"select * from users where id = ?",
 		},
 		{
+			"SELECT * FROM `host` WHERE `id` IN (42, 43) /*comment with parameters,host:localhost,url:controller#home,id:FF005:00CAA*/",
+			"SELECT * FROM `host` WHERE `id` IN (?)",
+		},
+		{
 			"UPDATE user_dash_pref SET json_prefs = %(json_prefs)s, modified = '2015-08-27 22:10:32.492912' WHERE user_id = %(user_id)s AND url = %(url)s",
 			"UPDATE user_dash_pref SET json_prefs = ?, modified = ? WHERE user_id = ? AND url = ?"},
 		{


### PR DESCRIPTION
### What it does

Removes SQL block comments from the resource name. If customers resources have something unique in the comment (such as the ``request_id``) it will mess the resource grouping (causing an overhead everywhere).