### PR TITLE
[builder] dupe check ensures that the deb is not present in the pool regardless the codename

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -qq -y build-essential debhelper git gnupg rake curl devscripts rubygems ruby-dev zlib1g-dev libxml2-dev
+    apt-get install --no-install-recommends -qq -y build-essential debhelper git gnupg rake curl devscripts rubygems ruby-dev zlib1g-dev libxml2-dev wget
 RUN gem install deb-s3
 
 RUN curl -sL -o /usr/local/bin/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme && \

--- a/packaging/release_deb.sh
+++ b/packaging/release_deb.sh
@@ -27,10 +27,13 @@ fi
 
 
 # make sure we're not uploading a dupe
-if deb-s3 list -b apt-trace.datad0g.com -m main --arch amd64 | grep $TRACE_AGENT_VERSION; then
+set +e
+wget --spider ${APT_BASE_PATH}/dd-trace-agent_${TRACE_AGENT_VERSION}_amd64.deb
+if [ $? -eq 0 ]; then
     echo "Duplicate version detected, exiting"
     exit 1
 fi
+set -e
 
 DEBFILE=`find ../ -type f -name '*.deb'`
 echo $INPUT_GPG_PASSPHRASE | deb-s3 upload --bucket apt-trace.datad0g.com -c $DISTRO -m main --arch amd64 --sign=$SIGN_KEY_ID --gpg_options="--passphrase-fd 0 --no-tty" $DEBFILE --preserve-versions


### PR DESCRIPTION
### What it does

The dupe checker now searches for any ``deb`` files in the entire pool, instead of looking only for the given ``$DISTRO`` codename

#### Testing

You can look at the following jobs (the upload wasn't enabled):

* trying to upload ``0.99.0`` that is not an existing version => [job][1]
* trying to upload ``0.99.153`` that is a ``beta`` [build][2] => [job][3]
* trying to upload ``0.99.154`` that is a ``stable`` [build][4] => [job][5]
* trying to upload ``0.99.157-staging`` that is a ``unstable`` [build][6] => [job][7]

[1]: https://roy.datad0g.com/job/raclette-palazzem-deb/12/console
[2]: https://roy.datad0g.com/job/raclette-prod-deb/53/console
[3]: https://roy.datad0g.com/job/raclette-palazzem-deb/14/console
[4]: https://roy.datad0g.com/job/raclette-prod-deb/54/console
[5]: https://roy.datad0g.com/job/raclette-palazzem-deb/13/console
[6]: https://roy.datad0g.com/job/raclette-staging-deb/155/console
[7]: https://roy.datad0g.com/job/raclette-palazzem-deb/15/console