### PR TITLE
[WIP] agent benchmarks

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -9,20 +9,20 @@ import (
 type Span struct {
 	// Mandatory
 	// Service & Name together determine what software we are measuring
-	Service  string `json:"service"`  // the software running (e.g. pylons)
-	Name     string `json:"name"`     // the metric name aka. the thing we're measuring (e.g. pylons.render OR psycopg2.query)
-	Resource string `json:"resource"` // the natural key of what we measure (/index OR SELECT * FROM a WHERE id = ?)
-	TraceID  uint64 `json:"trace_id"` // ID that all spans in the same trace share
-	SpanID   uint64 `json:"span_id"`  // unique ID given to any span
-	Start    int64  `json:"start"`    // nanosecond epoch of span start
-	Duration int64  `json:"duration"` // in nanoseconds
-	Error    int32  `json:"error"`    // error status of the span, 0 == OK
+	Service  string `json:"service" msgpack:"service"`   // the software running (e.g. pylons)
+	Name     string `json:"name" msgpack:"name"`         // the metric name aka. the thing we're measuring (e.g. pylons.render OR psycopg2.query)
+	Resource string `json:"resource" msgpack:"resource"` // the natural key of what we measure (/index OR SELECT * FROM a WHERE id = ?)
+	TraceID  uint64 `json:"trace_id" msgpack:"trace_id"` // ID that all spans in the same trace share
+	SpanID   uint64 `json:"span_id" msgpack:"span_id"`   // unique ID given to any span
+	Start    int64  `json:"start" msgpack:"start"`       // nanosecond epoch of span start
+	Duration int64  `json:"duration" msgpack:"duration"` // in nanoseconds
+	Error    int32  `json:"error" msgpack:"error"`       // error status of the span, 0 == OK
 
 	// Optional
-	Meta     map[string]string  `json:"meta"`      // arbitrary tags/metadata
-	Metrics  map[string]float64 `json:"metrics"`   // arbitrary metrics
-	ParentID uint64             `json:"parent_id"` // span ID of the span in which this one was created
-	Type     string             `json:"type"`      // protocol associated with the span
+	Meta     map[string]string  `json:"meta" msgpack:"meta"`           // arbitrary tags/metadata
+	Metrics  map[string]float64 `json:"metrics"`                       // arbitrary metrics
+	ParentID uint64             `json:"parent_id" msgpack:"parent_id"` // span ID of the span in which this one was created
+	Type     string             `json:"type" msgpack:"type"`           // protocol associated with the span
 }
 
 // String formats a Span struct to be displayed as a string


### PR DESCRIPTION
### What it does

Simple benchmarks for JSON and MsgPack decoding. To run benchmarks simply:
```
go test -run=NONE -bench=. github.com/DataDog/raclette/agent
```

These are the current results:
```
BenchmarkDecoderJSON/JSON_simple_trace-4         	      50	  34475753 ns/op	 8750742 B/op	   73894 allocs/op
BenchmarkDecoderVmihailenco/MessagePack_simple_trace-4       200	   9963308 ns/op	 4252273 B/op	   69345 allocs/op
BenchmarkDecoderUgorji/MessagePack_simple_trace-4            200	   7932522 ns/op	 3822286 B/op	   33046 allocs/op

BenchmarkDecoderJSON/JSON_complex_trace-4        	      10	 110530484 ns/op	30439932 B/op	  250257 allocs/op
BenchmarkDecoderVmihailenco/MessagePack_complex_trace-4       50	  36265177 ns/op	 9491576 B/op	  244986 allocs/op
BenchmarkDecoderUgorji/MessagePack_complex_trace-4            50	  35736153 ns/op	10996871 B/op	   98547 allocs/op
```

You can find more information in the common (client-agent) [documents][1].

[1]: https://docs.google.com/document/d/1_UVE9b6pho37qsXAOfTCKGptOPj-qm8sSTuaEpAUzk0/edit#