### PR TITLE
[agent:dockerfile] added trace-agent.ini in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN echo "deb http://apt-trace.datad0g.com.s3.amazonaws.com/ stable main" > /etc
 
 EXPOSE 7777/tcp
 
+COPY ./agent/trace-agent.ini /etc/datadog/trace-agent.ini
+
 ENTRYPOINT ["/opt/datadog-agent/bin/trace-agent"]


### PR DESCRIPTION
Without /etc/datadog/trace-agent.ini, daemon would die with the error:

----8<-----------------------------------------------
panic: APIEndpoint should be initialized with same number of url/api keys

goroutine 1 [running]:
panic(0x7dc100, 0xc4200e4ba0)
	/root/.gimme/versions/go1.7.1.linux.amd64/src/runtime/panic.go:500 +0x1a1
main.NewAPIEndpoint(0xc42013e390, 0x1, 0x1, 0xa6fd70, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/DataDog/raclette/agent/endpoint.go:38 +0x141
main.NewWriter(0xc4201560c0, 0xc4201560c0)
	/go/src/github.com/DataDog/raclette/agent/writer.go:31 +0x7d
main.NewAgent(0xc4201560c0, 0x1e4be31c)
	/go/src/github.com/DataDog/raclette/agent/agent.go:42 +0x37e
main.main()
	/go/src/github.com/DataDog/raclette/agent/main.go:114 +0x290
----8<-----------------------------------------------