### PR TITLE
docker: install ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Datadog <package@datadoghq.com>
 
 RUN echo "deb http://apt-trace.datad0g.com.s3.amazonaws.com/ stable main" > /etc/apt/sources.list.d/datadog-trace.list \
  && apt-get update \
- && apt-get install --no-install-recommends -y dd-trace-agent \
+ && apt-get install --no-install-recommends -y dd-trace-agent ca-certificates \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
When the tracer tries to push the metrics to https://trace.agent.datadoghq.com/api/v0.1/collector
we are getting an error as follows:

```
error when requesting to endpoint https://trace.agent.datadoghq.com/api/v0.1/collector: Post https://trace.agent.datadoghq.com/api/v0.1/collector?api_key=[key]: x509: failed to load system roots and no roots provided
```

This PR installs the necessary certificates to handle tls connections. 
 