### PR TITLE
optionally specify an agent timeout

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -94,7 +94,11 @@ func (r *HTTPReceiver) Run() {
 	sl, err := NewStoppableListener(tcpL, r.exit, r.conf.ConnectionLimit)
 	// some clients might use keep-alive and keep open their connections too long
 	// avoid leaks
-	server := http.Server{ReadTimeout: 5 * time.Second}
+	timeout := 5
+	if r.conf.ReceiverTimeout > 0 {
+		timeout = r.conf.ReceiverTimeout
+	}
+	server := http.Server{ReadTimeout: time.Second * time.Duration(timeout)}
 
 	go r.logStats()
 	go sl.Refresh(r.conf.ConnectionLimit)

--- a/config/agent.go
+++ b/config/agent.go
@@ -39,6 +39,7 @@ type AgentConfig struct {
 	ReceiverHost    string
 	ReceiverPort    int
 	ConnectionLimit int // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	ReceiverTimeout int
 
 	// internal telemetry
 	StatsdHost string
@@ -234,6 +235,10 @@ APM_CONF:
 
 	if v, e := conf.GetInt("trace.receiver", "connection_limit"); e == nil {
 		c.ConnectionLimit = v
+	}
+
+	if v, e := conf.GetInt("trace.receiver", "timeout"); e == nil {
+		c.ReceiverTimeout = v
 	}
 
 ENV_CONF:


### PR DESCRIPTION
makes it easier to run a minute long profile.