### PR TITLE
introduce a new resource syntax for pipelined redis commands

### DIFF
--- a/quantizer/redis.go
+++ b/quantizer/redis.go
@@ -16,11 +16,21 @@ var redisCompoundCommandSet = map[string]bool{
 func QuantizeRedis(span model.Span) model.Span {
 	query := compactWhitespaces(span.Resource)
 
-	rawLines := strings.Split(query, "\n")
-	lines := make([]string, 0, len(rawLines))
-	for _, rawLine := range rawLines {
+	lines := []string{}
+	for len(query) > 0 {
+		var rawLine string
+
+		idx := strings.IndexByte(query, '\n')
+		if idx == -1 {
+			rawLine = query
+			query = ""
+		} else {
+			rawLine = query[:idx]
+			query = query[idx+1:]
+		}
+
 		if line := strings.Trim(rawLine, " "); len(line) > 0 {
-			lines = append(lines, line)
+			lines = append(lines, string(line))
 		}
 	}
 

--- a/quantizer/redis.go
+++ b/quantizer/redis.go
@@ -1,6 +1,8 @@
 package quantizer
 
 import (
+	"bytes"
+	"sort"
 	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/model"
@@ -12,38 +14,57 @@ var redisCompoundCommandSet = map[string]bool{
 
 // QuantizeRedis generates resource for Redis spans
 func QuantizeRedis(span model.Span) model.Span {
-	query := span.Resource
+	query := compactWhitespaces(span.Resource)
 
-	resource := ""
-	previousCommand := ""
-	previousDuplicate := false
-
-	query = compactWhitespaces(query)
-	lines := strings.Split(query, "\n")
-
-	for _, q := range lines {
-		q = strings.Trim(q, " ")
-		if len(q) > 0 {
-			args := strings.SplitN(q, " ", 3)
-			command := strings.ToUpper(args[0])
-			if redisCompoundCommandSet[command] {
-				command += " " + strings.ToUpper(args[1])
-			}
-
-			if command == previousCommand {
-				if !previousDuplicate {
-					resource += "*"
-					previousDuplicate = true
-				}
-			} else {
-				resource += " " + command
-				previousCommand = command
-				previousDuplicate = false
-			}
+	rawLines := strings.Split(query, "\n")
+	lines := make([]string, 0, len(rawLines))
+	for _, rawLine := range rawLines {
+		if line := strings.Trim(rawLine, " "); len(line) > 0 {
+			lines = append(lines, line)
 		}
 	}
 
-	span.Resource = strings.Trim(resource, " ")
+	readLine := func(line string) string {
+		args := strings.SplitN(line, " ", 3)
+		command := strings.ToUpper(args[0])
+
+		if redisCompoundCommandSet[command] {
+			command += " " + strings.ToUpper(args[1])
+		}
+
+		return command
+	}
+
+	var resource bytes.Buffer
+
+	switch len(lines) {
+	case 1:
+		// Single command
+		resource.WriteString(readLine(lines[0]))
+
+	default:
+		// Pipeline
+		commandMap := make(map[string]struct{})
+
+		for _, line := range lines {
+			commandMap[readLine(line)] = struct{}{}
+		}
+
+		commands := make([]string, 0, len(commandMap))
+		for command := range commandMap {
+			commands = append(commands, command)
+		}
+		sort.Strings(commands)
+
+		resource.WriteString("PIPELINE [")
+		for _, command := range commands {
+			resource.WriteByte(' ')
+			resource.WriteString(command)
+		}
+		resource.WriteString(" ]")
+	}
+
+	span.Resource = strings.Trim(resource.String(), " ")
 
 	return span
 }

--- a/quantizer/redis_test.go
+++ b/quantizer/redis_test.go
@@ -37,13 +37,16 @@ func TestRedisQuantizer(t *testing.T) {
 			"CONFIG SET"},
 
 		{"SET toto tata \n \n  EXPIRE toto 15  ",
-			"SET EXPIRE"},
+			"PIPELINE [ EXPIRE SET ]"},
 
 		{"MSET toto tata toto tata toto tata \n ",
 			"MSET"},
 
 		{"MULTI\nSET k1 v1\nSET k2 v2\nSET k3 v3\nSET k4 v4\nDEL to_del\nEXEC",
-			"MULTI SET* DEL EXEC"},
+			"PIPELINE [ DEL EXEC MULTI SET ]"},
+
+		{"DEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"",
+			"PIPELINE [ DEL HMSET ]"},
 	}
 
 	for _, testCase := range queryToExpected {

--- a/quantizer/redis_test.go
+++ b/quantizer/redis_test.go
@@ -51,3 +51,12 @@ func TestRedisQuantizer(t *testing.T) {
 	}
 
 }
+
+func BenchmarkTestRedisQuantizer(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		span := RedisSpan(`DEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"`)
+		_ = QuantizeRedis(span)
+	}
+}

--- a/quantizer/redis_test.go
+++ b/quantizer/redis_test.go
@@ -33,6 +33,9 @@ func TestRedisQuantizer(t *testing.T) {
 		{"SET le_key le_value",
 			"SET"},
 
+		{"\n\n  \nSET foo bar  \n  \n\n  ",
+			"SET"},
+
 		{"CONFIG SET parameter value",
 			"CONFIG SET"},
 


### PR DESCRIPTION
When there are more than one command, the syntax is now:

        PIPELINE [ <commands> ]

Where <commands> is a deduplicated and sorted list of commands.

This new format will significantly reduce the cardinality of the
resource set for application which use a lot of pipelined commands.