### PR TITLE
[benchmark] Trace Process

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -17,6 +17,6 @@ func BenchmarkAgentTraceProcessing(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		agent.Process(fixtures.RandomTrace())
+		agent.Process(fixtures.RandomTrace(10, 8))
 	}
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/DataDog/datadog-trace-agent/config"
@@ -11,11 +10,6 @@ import (
 func BenchmarkAgentTraceProcessing(b *testing.B) {
 	// Disable debug logs in these tests
 	config.NewLoggerLevelCustom("INFO", "/var/log/datadog/trace-agent.log")
-
-	// TODO the seed must be passed using --seed flag so that executions
-	// are random but can be easily reproduced; using the default Seed(1)
-	// as a placeholder
-	rand.Seed(1)
 
 	conf := config.NewDefaultAgentConfig()
 	conf.APIKeys = append(conf.APIKeys, "")

--- a/agent/bench_test.go
+++ b/agent/bench_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/DataDog/datadog-trace-agent/config"
@@ -8,9 +9,19 @@ import (
 )
 
 func BenchmarkAgentTraceProcessing(b *testing.B) {
+	// Disable debug logs in these tests
+	config.NewLoggerLevelCustom("INFO", "/var/log/datadog/trace-agent.log")
+
+	// TODO the seed must be passed using --seed flag so that executions
+	// are random but can be easily reproduced; using the default Seed(1)
+	// as a placeholder
+	rand.Seed(1)
+
 	conf := config.NewDefaultAgentConfig()
 	conf.APIKeys = append(conf.APIKeys, "")
 	agent := NewAgent(conf)
+	b.ResetTimer()
+	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		agent.Process(fixtures.RandomTrace())
 	}

--- a/agent/bench_test.go
+++ b/agent/bench_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+)
+
+func BenchmarkAgentTraceProcessing(b *testing.B) {
+	conf := config.NewDefaultAgentConfig()
+	conf.APIKeys = append(conf.APIKeys, "")
+	agent := NewAgent(conf)
+	for i := 0; i < b.N; i++ {
+		agent.Process(fixtures.RandomTrace())
+	}
+}

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -1,7 +1,6 @@
 package fixtures
 
 import (
-	"fmt"
 	"math/rand"
 
 	"github.com/DataDog/datadog-trace-agent/model"
@@ -18,8 +17,6 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 	var spans []model.Span
 	numSpans := rand.Intn(100) + 1
 
-	fmt.Printf("prevLevel %d numSpans %d\n", len(prevLevel), numSpans)
-
 	// the spans have to be "nested" in the previous level
 	// choose randomly spans from prev level
 	chosenSpans := rand.Perm(len(prevLevel))
@@ -29,7 +26,6 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 		maxParentSpans = 1
 	}
 	chosenSpans = chosenSpans[:maxParentSpans]
-	fmt.Printf("chosenSpans %v, maxParentSpans %d\n", chosenSpans, maxParentSpans)
 
 	// now choose a random amount of spans per chosen span
 	// total needs to be numSpans
@@ -37,10 +33,11 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 		prev := prevLevel[prevIdx]
 
 		var childSpans int
-		if i == len(chosenSpans)-1 {
+		value := numSpans - (len(chosenSpans) - i)
+		if i == len(chosenSpans)-1 || value < 1 {
 			childSpans = numSpans
 		} else {
-			childSpans = rand.Intn(numSpans - (len(chosenSpans) - i))
+			childSpans = rand.Intn(value)
 		}
 		numSpans -= childSpans
 
@@ -65,7 +62,6 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 			curSpans = append(curSpans, news)
 		}
 
-		fmt.Printf("for span %d, spans: %d\n", prevIdx, len(curSpans))
 		spans = append(spans, curSpans...)
 	}
 
@@ -79,8 +75,10 @@ func RandomTrace() model.Trace {
 	maxDepth := rand.Intn(10)
 
 	for i := 0; i < maxDepth; i++ {
-		prevLevel = genNextLevel(prevLevel)
-		t = append(t, prevLevel...)
+		if len(prevLevel) > 0 {
+			prevLevel = genNextLevel(prevLevel)
+			t = append(t, prevLevel...)
+		}
 	}
 
 	return t

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -6,16 +6,15 @@ import (
 	"github.com/DataDog/datadog-trace-agent/model"
 )
 
-/* tree structure
-   from 1 to 10 levels
+const (
+	maxLevel = 10
+	maxSpans = 100
+)
 
-   always one root
-   each level has at most 100 spans
-*/
-
+/// genNextLevel generates a new level for the trace tree structure
 func genNextLevel(prevLevel []model.Span) []model.Span {
 	var spans []model.Span
-	numSpans := rand.Intn(100) + 1
+	numSpans := rand.Intn(maxSpans) + 1
 
 	// the spans have to be "nested" in the previous level
 	// choose randomly spans from prev level
@@ -68,11 +67,13 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 	return spans
 }
 
+// RandomTrace generates a random trace with a depth from 1 to
+// 10 levels of spans. Each level has at most 100 spans
 func RandomTrace() model.Trace {
 	t := model.Trace{RandomSpan()}
 
 	prevLevel := t
-	maxDepth := rand.Intn(10)
+	maxDepth := rand.Intn(maxLevel)
 
 	for i := 0; i < maxDepth; i++ {
 		if len(prevLevel) > 0 {
@@ -82,14 +83,4 @@ func RandomTrace() model.Trace {
 	}
 
 	return t
-}
-
-func SingleSpanTrace() model.Trace {
-	var t model.Trace
-	t = append(t, RandomSpan())
-	return t
-}
-
-func FuzzTrace() model.Trace {
-	return model.Trace{}
 }

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -1,0 +1,97 @@
+package fixtures
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+)
+
+/* tree structure
+   from 1 to 10 levels
+
+   always one root
+   each level has at most 100 spans
+*/
+
+func genNextLevel(prevLevel []model.Span) []model.Span {
+	var spans []model.Span
+	numSpans := rand.Intn(100) + 1
+
+	fmt.Printf("prevLevel %d numSpans %d\n", len(prevLevel), numSpans)
+
+	// the spans have to be "nested" in the previous level
+	// choose randomly spans from prev level
+	chosenSpans := rand.Perm(len(prevLevel))
+	// cap to a random number > 1
+	maxParentSpans := rand.Intn(len(prevLevel))
+	if maxParentSpans == 0 {
+		maxParentSpans = 1
+	}
+	chosenSpans = chosenSpans[:maxParentSpans]
+	fmt.Printf("chosenSpans %v, maxParentSpans %d\n", chosenSpans, maxParentSpans)
+
+	// now choose a random amount of spans per chosen span
+	// total needs to be numSpans
+	for i, prevIdx := range chosenSpans {
+		prev := prevLevel[prevIdx]
+
+		var childSpans int
+		if i == len(chosenSpans)-1 {
+			childSpans = numSpans
+		} else {
+			childSpans = rand.Intn(numSpans - (len(chosenSpans) - i))
+		}
+		numSpans -= childSpans
+
+		timeLeft := prev.Duration
+
+		// create the spans
+		curSpans := make([]model.Span, 0, childSpans)
+		for j := 0; j < childSpans && timeLeft > 0; j++ {
+			news := RandomSpan()
+			news.TraceID = prev.TraceID
+			news.ParentID = prev.SpanID
+
+			// distribute durations in prev span
+			// random start
+			randStart := rand.Int63n(timeLeft)
+			news.Start = prev.Start + randStart
+			// random duration
+			timeLeft -= randStart
+			news.Duration = rand.Int63n(timeLeft)
+			timeLeft -= news.Duration
+
+			curSpans = append(curSpans, news)
+		}
+
+		fmt.Printf("for span %d, spans: %d\n", prevIdx, len(curSpans))
+		spans = append(spans, curSpans...)
+	}
+
+	return spans
+}
+
+func RandomTrace() model.Trace {
+	t := model.Trace{RandomSpan()}
+
+	prevLevel := t
+	maxDepth := rand.Intn(10)
+
+	for i := 0; i < maxDepth; i++ {
+		prevLevel = genNextLevel(prevLevel)
+		t = append(t, prevLevel...)
+	}
+
+	return t
+}
+
+func SingleSpanTrace() model.Trace {
+	var t model.Trace
+	t = append(t, RandomSpan())
+	return t
+}
+
+func FuzzTrace() model.Trace {
+	return model.Trace{}
+}

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -6,13 +6,9 @@ import (
 	"github.com/DataDog/datadog-trace-agent/model"
 )
 
-const (
-	maxLevel = 10
-	maxSpans = 100
-)
-
-/// genNextLevel generates a new level for the trace tree structure
-func genNextLevel(prevLevel []model.Span) []model.Span {
+// genNextLevel generates a new level for the trace tree structure,
+// having maxSpans as the max number of spans for this level
+func genNextLevel(prevLevel []model.Span, maxSpans int) []model.Span {
 	var spans []model.Span
 	numSpans := rand.Intn(maxSpans) + 1
 
@@ -68,16 +64,16 @@ func genNextLevel(prevLevel []model.Span) []model.Span {
 }
 
 // RandomTrace generates a random trace with a depth from 1 to
-// 10 levels of spans. Each level has at most 100 spans
-func RandomTrace() model.Trace {
+// maxLevels of spans. Each level has at most maxSpans items.
+func RandomTrace(maxLevels, maxSpans int) model.Trace {
 	t := model.Trace{RandomSpan()}
 
 	prevLevel := t
-	maxDepth := rand.Intn(maxLevel)
+	maxDepth := rand.Intn(maxLevels)
 
 	for i := 0; i < maxDepth; i++ {
 		if len(prevLevel) > 0 {
-			prevLevel = genNextLevel(prevLevel)
+			prevLevel = genNextLevel(prevLevel, maxSpans)
 			t = append(t, prevLevel...)
 		}
 	}


### PR DESCRIPTION
### What it does

Adds a benchmark for the ``agent.Process()``. It doesn't cover the full flow (decoding and encoding) but it's an initial good approach to collect performance from a standalone execution.

#### Required for

* a standalone binary that floods a running agent (it will use ``RandomTrace()`` func)
* an agent build that accepts a ``-profile`` flag so that CPU (or memory) profile is extracted
* a simple command that can start the agent, collect profiles and stop the agent