### PR TITLE
[tools] add cmd package for external profiling tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 raclette
 trace-agent
+trace-flood
 generator
 *.swp
 python/raclette.egg-info
@@ -11,5 +12,5 @@ stats/stats
 tracegen/tracegen
 agent/agent
 coverage.out
-prof*
+*.prof
 *test

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ PACKAGES = %w(
   ./config
   ./fixtures
   ./model
+  ./cmd/traceflood
   ./quantile
   ./quantizer
   ./sampler
@@ -31,6 +32,11 @@ end
 desc "Install Datadog Trace agent"
 task :install do
   go_build("github.com/DataDog/datadog-trace-agent/agent", :cmd=>"go build -i -o $GOPATH/bin/trace-agent")
+end
+
+desc "Build Datadog Trace tools"
+task :build_tools do
+  go_build("github.com/DataDog/datadog-trace-agent/cmd/traceflood", :cmd => "go build -a -o trace-flood")
 end
 
 desc "Test Datadog Trace agent"

--- a/cmd/traceflood/traceflood.go
+++ b/cmd/traceflood/traceflood.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/ugorji/go/codec"
+)
+
+const (
+	duration           = time.Second
+	defaultHTTPTimeout = time.Second
+)
+
+var mh codec.MsgpackHandle
+
+func main() {
+	// flags
+	randSeed := flag.Int64("seed", 1, "set the `seed` using rand.Seed func")
+	tracesNumber := flag.Int("traces", 1000, "set how many traces should be generated per flush")
+	flag.Parse()
+
+	// initialization
+	rand.Seed(*randSeed)
+	client := &http.Client{
+		Timeout: defaultHTTPTimeout,
+	}
+
+	// infinite loop; it expects a SIGINT/SIGTERM to be stopped
+	for {
+		// generate the trace
+		traces := []model.Trace{}
+		for i := 0; i < *tracesNumber; i++ {
+			traces = append(traces, fixtures.RandomTrace())
+		}
+
+		// flood the agent
+		buffer := &bytes.Buffer{}
+		encoder := codec.NewEncoder(buffer, &mh)
+		err := encoder.Encode(traces)
+		if err != nil {
+			log.Fatal()
+			return
+		}
+
+		// prepare the client and send the payload
+		log.Println("Flooding...")
+		req, _ := http.NewRequest("POST", "http://localhost:7777/v0.3/traces", buffer)
+		req.Header.Set("Content-Type", "application/msgpack")
+		client.Do(req)
+
+		// wait before next execution
+		time.Sleep(duration)
+	}
+}


### PR DESCRIPTION
### What it does

* add the ``cmd`` package for external profiling tools
* ``rake build_tools`` builds the ``trace-flood`` binary
* ``trace-flood`` will start flooding a real ``trace-agent`` executed in ``localhost``

#### Notes

``trace-flood`` uses the ``fixtures`` package. Actually it doesn't create a good random combination of traces but it's a separated task that should only impact how we build fake traces.