### PR TITLE
[writer] prevent services flush if there is a partial match

### DIFF
--- a/model/services.go
+++ b/model/services.go
@@ -13,15 +13,16 @@ type ServicesMetadata map[string]map[string]string
 // Update compares this metadata blob with the one given in the argument
 // if different, update s1 and return true. If equal, return false
 func (s1 ServicesMetadata) Update(s2 ServicesMetadata) bool {
-	if reflect.DeepEqual(s1, s2) {
-		return false
-	}
+	updated := false
 
 	for s, metas := range s2 {
-		s1[s] = metas
+		if !reflect.DeepEqual(s1[s], metas) {
+			s1[s] = metas
+			updated = true
+		}
 	}
 
-	return true
+	return updated
 }
 
 // EncodeServicesPayload will return a slice of bytes representing the

--- a/model/services_test.go
+++ b/model/services_test.go
@@ -1,30 +1,64 @@
 package model
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestServiceMetadataUpdate(t *testing.T) {
+func TestServiceMetadataNotUpdated(t *testing.T) {
+	// metadata should not change
 	metas := make(ServicesMetadata)
 	metas["web-server"] = make(map[string]string)
 	metas["web-server"]["app_type"] = "web"
 	metas["web-server"]["app"] = "pylons"
 
-	// metadata unchanged
 	metas2 := make(ServicesMetadata)
 	metas2["web-server"] = make(map[string]string)
 	metas2["web-server"]["app_type"] = "web"
 	metas2["web-server"]["app"] = "pylons"
 
 	assert.False(t, metas.Update(metas2))
+}
 
-	// metadata app changed
-	metas3 := make(ServicesMetadata)
-	metas3["web-server"] = make(map[string]string)
-	metas3["web-server"]["app_type"] = "web"
-	metas3["web-server"]["app"] = "rails"
+func TestServiceMetadataUpdated(t *testing.T) {
+	// metadata should be updated
+	metas := make(ServicesMetadata)
+	metas["web-server"] = make(map[string]string)
+	metas["web-server"]["app_type"] = "web"
+	metas["web-server"]["app"] = "pylons"
 
-	assert.True(t, metas.Update(metas3))
+	metas2 := make(ServicesMetadata)
+	metas2["web-server"] = make(map[string]string)
+	metas2["web-server"]["app_type"] = "web"
+	metas2["web-server"]["app"] = "rails"
+
+	assert.True(t, metas.Update(metas2))
 	assert.Equal(t, "rails", metas["web-server"]["app"])
+}
+
+func TestServiceMetadataPartial(t *testing.T) {
+	// metadata should be updated
+	metas := make(ServicesMetadata)
+	metas["web-server"] = make(map[string]string)
+	metas["web-server"]["app_type"] = "web"
+	metas["web-server"]["app"] = "pylons"
+	metas["postgres"] = make(map[string]string)
+	metas["postgres"]["app_type"] = "db"
+	metas["postgres"]["app"] = "postgres"
+
+	metas2 := make(ServicesMetadata)
+	metas2["web-server"] = make(map[string]string)
+	metas2["web-server"]["app_type"] = "web"
+	metas2["web-server"]["app"] = "pylons"
+
+	assert.False(t, metas.Update(metas2))
+}
+
+func TestServiceMetadataEmpty(t *testing.T) {
+	// metadata should not be updated
+	metas := make(ServicesMetadata)
+	metas2 := make(ServicesMetadata)
+
+	assert.False(t, metas.Update(metas2))
 }


### PR DESCRIPTION
### What it does

In nodes where services are sent from different applications, the ``DeepEqual`` check for services will fail since buffered service and sent services are deeply equal different (in the sense of Go) even if the `metas` are the same.

The check ensures that a partial deep equality will not flush the service list.

### Impact

It reduces a lot the number of API calls / services encoding in some cases.