### PR TITLE
handle errors when sending payloads to endpoints

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -61,7 +61,7 @@ func (a *Agent) Run() {
 	defer flushTicker.Stop()
 
 	a.Receiver.Run()
-	go a.Writer.Run()
+	a.Writer.Run()
 
 	for {
 		select {

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -11,12 +11,48 @@ import (
 	log "github.com/cihub/seelog"
 )
 
+// apiError stores a list of errors triggered when sending data to a
+// list of endpoints. The endpoints member contains an api key and url for
+// each error.
+type apiError struct {
+	errs     []error // the errors, one for each endpoint
+	endpoint APIEndpoint
+}
+
+func newAPIError() *apiError {
+	return &apiError{}
+}
+
+func (err *apiError) IsEmpty() bool {
+	return len(err.errs) == 0
+}
+
+func (err *apiError) Append(url, apiKey string, e error) {
+	err.errs = append(err.errs, e)
+	err.endpoint.urls = append(err.endpoint.urls, url)
+	err.endpoint.apiKeys = append(err.endpoint.apiKeys, apiKey)
+}
+
+func (err *apiError) Error() string {
+	var buf bytes.Buffer
+
+	for i, e := range err.errs {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+
+		fmt.Fprintf(&buf, "%s: %v", err.endpoint.urls[i], e)
+	}
+
+	return buf.String()
+}
+
 // AgentEndpoint is an interface where we write the data
 // that comes out of the agent
 type AgentEndpoint interface {
 	// Write sends an agent payload which carries all the
 	// pre-processed stats/traces
-	Write(b model.AgentPayload)
+	Write(b model.AgentPayload) (int, error)
 	// WriteServices sends updates about the services metadata
 	WriteServices(s model.ServicesMetadata)
 }
@@ -49,17 +85,16 @@ func NewAPIEndpoint(urls, apiKeys []string) APIEndpoint {
 }
 
 // Write writes the bucket to the API collector endpoint.
-// Currently, the errors are just logged and we fail silently, keeping
-// writing till we have tried everything. This is because currently the
-// choice is to just drop the data we cannot write on the floor.
-// FIXME?
-func (a APIEndpoint) Write(p model.AgentPayload) {
+func (a APIEndpoint) Write(p model.AgentPayload) (int, error) {
 	data, err := model.EncodeAgentPayload(p)
 	if err != nil {
 		log.Errorf("encoding issue: %v", err)
-		return
+		return 0, err
 	}
-	statsd.Client.Count("trace_agent.writer.payload_bytes", int64(len(data)), nil, 1)
+	payloadSize := len(data)
+	statsd.Client.Count("trace_agent.writer.payload_bytes", int64(payloadSize), nil, 1)
+
+	endpointErr := newAPIError()
 
 	for i := range a.urls {
 		startFlush := time.Now()
@@ -68,6 +103,9 @@ func (a APIEndpoint) Write(p model.AgentPayload) {
 		req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 		if err != nil {
 			log.Errorf("could not create request for endpoint %s: %v", url, err)
+			// If the request cannot be created, there is no point
+			// in trying again later, it will always yield the
+			// same result.
 			continue
 		}
 
@@ -79,12 +117,21 @@ func (a APIEndpoint) Write(p model.AgentPayload) {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			log.Errorf("error when requesting to endpoint %s: %v", url, err)
+			endpointErr.Append(a.urls[i], a.apiKeys[i], err)
 			continue
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode/100 != 2 {
-			log.Errorf("request to %s responded with %s", url, resp.Status)
+			err := fmt.Errorf("request to %s responded with %s", url, resp.Status)
+			log.Error(err)
+
+			// Only retry for 5xx (server) errors; for 4xx errors,
+			// something is wrong with the request and there is
+			// usually no point in trying again.
+			if resp.StatusCode/100 == 5 {
+				endpointErr.Append(a.urls[i], a.apiKeys[i], err)
+			}
 			continue
 		}
 
@@ -100,6 +147,13 @@ func (a APIEndpoint) Write(p model.AgentPayload) {
 		}
 		statsd.Client.Gauge("trace_agent.writer.flush_duration", flushTime.Seconds(), tags, 1)
 	}
+
+	if endpointErr.IsEmpty() {
+		// The payload was sent to all endpoints without any error
+		return payloadSize, nil
+	}
+
+	return payloadSize, endpointErr
 }
 
 // WriteServices writes services to the services endpoint
@@ -146,8 +200,9 @@ func (a APIEndpoint) WriteServices(s model.ServicesMetadata) {
 type NullEndpoint struct{}
 
 // Write just logs and bails
-func (ne NullEndpoint) Write(p model.AgentPayload) {
+func (ne NullEndpoint) Write(p model.AgentPayload) (int, error) {
 	log.Debug("null endpoint: dropping payload, %d traces, %d stats buckets", p.Traces, p.Stats)
+	return 0, nil
 }
 
 // WriteServices just logs and stops

--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -27,6 +27,9 @@ api_key=apikey_2
 # default to true, disable if you want dry-run mode
 # enabled=false
 
+# the maximum size of the payload buffer in bytes
+# buffering is disabled if this setting is set to 0
+payload_buffer_max_size=16777216
 
 ###################################################
 # Agent concentrator - stats aggregation

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -93,12 +93,17 @@ func (w *Writer) isPayloadBufferingEnabled() bool {
 	return w.conf.APIPayloadBufferMaxSize > 0
 }
 
-// Run starts the writer and starts writing what comes through the
-// input channel.
-// NOTE: this currently happens sequentially, but it would not be too
-// hard to mutex and parallelize. Not sure it's needed though.
+// Run starts the writer.
 func (w *Writer) Run() {
 	w.exitWG.Add(1)
+	go w.main()
+}
+
+// main is the main loop of the writer goroutine. If buffers payloads and
+// services read from input chans and flushes them when necessary.
+// NOTE: this currently happens sequentially, but it would not be too
+// hard to mutex and parallelize. Not sure it's needed though.
+func (w *Writer) main() {
 	defer w.exitWG.Done()
 
 	flushTicker := time.NewTicker(time.Second)

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -2,12 +2,43 @@ package main
 
 import (
 	"sync"
+	"time"
 
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
 )
+
+// the amount of time in seconds to wait before resending a payload
+const payloadResendDelay = 5 * time.Second
+
+// the amount of time in seconds a payload can stay buffered before being dropped
+const payloadMaxAge = 10 * time.Minute
+
+// writerPayload wraps a model.AgentPayload and keeps track of a list of
+// endpoints the payload must be sent to.
+type writerPayload struct {
+	payload      model.AgentPayload // the payload itself
+	size         int                // the size of the serialized payload or 0 if it has not been serialized yet
+	endpoint     AgentEndpoint      // the endpoints the payload must be sent to
+	creationDate time.Time          // the creation date of the payload
+	nextFlush    time.Time          // The earliest moment we can flush
+}
+
+func newWriterPayload(p model.AgentPayload, endpoint AgentEndpoint) *writerPayload {
+	return &writerPayload{
+		payload:      p,
+		endpoint:     endpoint,
+		creationDate: time.Now(),
+	}
+}
+
+func (p *writerPayload) write() error {
+	size, err := p.endpoint.Write(p.payload)
+	p.size = size
+	return err
+}
 
 // Writer is the last chain of trace-agent which takes the
 // pre-processed data from channels and tentatively output them
@@ -19,11 +50,13 @@ type Writer struct {
 	inPayloads chan model.AgentPayload     // main payloads for processed traces/stats
 	inServices chan model.ServicesMetadata // secondary services metadata
 
-	payloadBuffer []model.AgentPayload   // buffered of payloads ready to send
+	payloadBuffer []*writerPayload       // buffer of payloads ready to send
 	serviceBuffer model.ServicesMetadata // services are merged into this map continuously
 
 	exit   chan struct{}
 	exitWG *sync.WaitGroup
+
+	conf *config.AgentConfig
 }
 
 // NewWriter returns a new Writer
@@ -43,12 +76,20 @@ func NewWriter(conf *config.AgentConfig) *Writer {
 		// small buffer to not block in case we're flushing
 		inPayloads: make(chan model.AgentPayload, 1),
 
-		payloadBuffer: make([]model.AgentPayload, 0, 5),
+		payloadBuffer: make([]*writerPayload, 0, 5),
 		serviceBuffer: make(model.ServicesMetadata),
 
 		exit:   make(chan struct{}),
 		exitWG: &sync.WaitGroup{},
+
+		conf: conf,
 	}
+}
+
+// isPayloadBufferingEnabled returns true if payload buffering is enabled or
+// false if it is not.
+func (w *Writer) isPayloadBufferingEnabled() bool {
+	return w.conf.APIPayloadBufferMaxSize > 0
 }
 
 // Run starts the writer and starts writing what comes through the
@@ -59,13 +100,19 @@ func (w *Writer) Run() {
 	w.exitWG.Add(1)
 	defer w.exitWG.Done()
 
+	flushTicker := time.NewTicker(time.Second)
+	defer flushTicker.Stop()
+
 	for {
 		select {
 		case p := <-w.inPayloads:
 			if p.IsEmpty() {
 				continue
 			}
-			w.payloadBuffer = append(w.payloadBuffer, p)
+			w.payloadBuffer = append(w.payloadBuffer,
+				newWriterPayload(p, w.endpoint))
+			w.Flush()
+		case <-flushTicker.C:
 			w.Flush()
 		case sm := <-w.inServices:
 			updated := w.serviceBuffer.Update(sm)
@@ -94,11 +141,60 @@ func (w *Writer) FlushServices() {
 // Flush actually writes the data in the API
 func (w *Writer) Flush() {
 	// TODO[leo]: batch payloads in same API key
-	for _, p := range w.payloadBuffer {
-		w.endpoint.Write(p)
-	}
-	// regardless if the http post was was success or not. We don't want to buffer
-	// data in case of api outage. See also endpoint.Write() comment.
-	w.payloadBuffer = nil
-}
 
+	var payloads []*writerPayload
+	now := time.Now()
+	bufSize := 0
+
+	bufferPayload := func(p *writerPayload) {
+		payloads = append(payloads, p)
+		bufSize += p.size
+	}
+
+	for _, p := range w.payloadBuffer {
+		if w.isPayloadBufferingEnabled() && p.nextFlush.After(now) {
+			// We already tried to flush recently, so there's no
+			// point in trying again right now.
+			bufferPayload(p)
+			continue
+		}
+
+		err := p.write()
+
+		if err == nil || !w.isPayloadBufferingEnabled() {
+			continue
+		}
+
+		if terr, ok := err.(*apiError); ok {
+			// We could not send the payload and this is an API
+			// endpoint error, so we can try again later.
+
+			if now.Sub(p.creationDate) > payloadMaxAge {
+				// The payload is too old, let's drop it
+				continue
+			}
+
+			p.nextFlush = now.Add(payloadResendDelay)
+
+			// Keep this payload in the buffer to try again later,
+			// but only with the endpoints that failed.
+			p.endpoint = terr.endpoint
+			bufferPayload(p)
+		}
+	}
+
+	// Drop payloads to respect the buffer size limit if necessary.
+	nbDrops := 0
+	for n := 0; n < len(payloads) && bufSize > w.conf.APIPayloadBufferMaxSize; n++ {
+		bufSize -= payloads[n].size
+		nbDrops++
+	}
+
+	if nbDrops > 0 {
+		log.Infof("dropping %d payloads (payload buffer full)", nbDrops)
+
+		payloads = payloads[nbDrops:]
+	}
+
+	w.payloadBuffer = payloads
+}

--- a/agent/writer_test.go
+++ b/agent/writer_test.go
@@ -143,8 +143,9 @@ receivingLoop:
 			t.Fatal("did not receive service data in time")
 		}
 	}
-	time.Sleep(100 * time.Millisecond)
+
+	w.Stop()
 
 	// we should just have ignored the 400 error on the other backend
-	assert.Equal(w.getPayloadBufferLen(), 0)
+	assert.Equal(0, len(w.payloadBuffer))
 }

--- a/config/agent.go
+++ b/config/agent.go
@@ -20,9 +20,10 @@ type AgentConfig struct {
 	DefaultEnv string // the traces will default to this environment
 
 	// API
-	APIEndpoints []string
-	APIKeys      []string
-	APIEnabled   bool
+	APIEndpoints            []string
+	APIKeys                 []string
+	APIEnabled              bool
+	APIPayloadBufferMaxSize int
 
 	// Concentrator
 	BucketInterval   time.Duration // the size of our pre-aggregation per bucket
@@ -97,11 +98,12 @@ func NewDefaultAgentConfig() *AgentConfig {
 		hostname = ""
 	}
 	ac := &AgentConfig{
-		HostName:     hostname,
-		DefaultEnv:   "none",
-		APIEndpoints: []string{"https://trace.agent.datadoghq.com"},
-		APIKeys:      []string{},
-		APIEnabled:   true,
+		HostName:                hostname,
+		DefaultEnv:              "none",
+		APIEndpoints:            []string{"https://trace.agent.datadoghq.com"},
+		APIKeys:                 []string{},
+		APIEnabled:              true,
+		APIPayloadBufferMaxSize: 16 * 1024 * 1024,
 
 		BucketInterval:   time.Duration(10) * time.Second,
 		ExtraAggregators: []string{},
@@ -198,6 +200,10 @@ APM_CONF:
 			vals[i] = strings.TrimSpace(vals[i])
 		}
 		c.APIEndpoints = vals
+	}
+
+	if v, e := conf.GetInt("trace.api", "payload_buffer_max_size"); e == nil {
+		c.APIPayloadBufferMaxSize = v
 	}
 
 	if v, e := conf.GetInt("trace.concentrator", "bucket_size_seconds"); e == nil {


### PR DESCRIPTION
The goal of these commits is to avoid losing payloads when the API is unavailable. A longer description is available in the last commit.