### PR TITLE
[optimization] improving pipeline entrypoint performance

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -129,7 +129,7 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 		dec := model.DecoderFromContentType(contentType)
 		err := dec.Decode(req.Body, &spans)
 		if err != nil {
-			//r.logger.Errorf(model.HumanReadableJSONError(bodyBuffer, err))
+			r.logger.Errorf(model.HumanReadableJSONError(dec.BufferReader(), err))
 			HTTPDecodingError(handlerTags, w)
 			return
 		}
@@ -145,7 +145,7 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 		dec := model.DecoderFromContentType(contentType)
 		err := dec.Decode(req.Body, &traces)
 		if err != nil {
-			//r.logger.Errorf(model.HumanReadableJSONError(bodyBuffer, err))
+			r.logger.Errorf(model.HumanReadableJSONError(dec.BufferReader(), err))
 			HTTPDecodingError(handlerTags, w)
 			return
 		}
@@ -155,7 +155,7 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 		err := dec.Decode(req.Body, &traces)
 		if err != nil {
 			if strings.Contains(contentType, "json") {
-				//r.logger.Errorf(model.HumanReadableJSONError(bodyBuffer, err))
+				r.logger.Errorf(model.HumanReadableJSONError(dec.BufferReader(), err))
 			} else {
 				r.logger.Errorf("error when decoding msgpack traces")
 			}
@@ -224,7 +224,7 @@ func (r *HTTPReceiver) handleServices(v APIVersion, w http.ResponseWriter, req *
 		dec := model.DecoderFromContentType(contentType)
 		err := dec.Decode(req.Body, &servicesMeta)
 		if err != nil {
-			//r.logger.Errorf(model.HumanReadableJSONError(bodyBuffer, err))
+			r.logger.Errorf(model.HumanReadableJSONError(dec.BufferReader(), err))
 			HTTPDecodingError(handlerTags, w)
 			return
 		}
@@ -234,7 +234,7 @@ func (r *HTTPReceiver) handleServices(v APIVersion, w http.ResponseWriter, req *
 		err := dec.Decode(req.Body, &servicesMeta)
 		if err != nil {
 			if strings.Contains(contentType, "json") {
-				//r.logger.Errorf(model.HumanReadableJSONError(bodyBuffer, err))
+				r.logger.Errorf(model.HumanReadableJSONError(dec.BufferReader(), err))
 			} else {
 				r.logger.Errorf("error when decoding msgpack traces")
 			}

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -25,7 +25,7 @@ const (
 
 // Pool of decoders to prevent continuous allocations
 // TODO[manu]: don't make it global even if it's thread-safe (uses channels)
-var decoderPool *model.DecoderPool = model.NewDecoderPool(decoderSize)
+var decoderPool = model.NewDecoderPool(decoderSize)
 
 const (
 	// v01 DEPRECATED, FIXME[1.x]

--- a/agent/receiver_responses.go
+++ b/agent/receiver_responses.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/DataDog/datadog-trace-agent/statsd"
@@ -30,5 +31,5 @@ func HTTPEndpointNotSupported(tags []string, w http.ResponseWriter) {
 // HTTPOK is a dumb response for when things are a OK
 func HTTPOK(w http.ResponseWriter) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK\n"))
+	io.WriteString(w, "OK\n")
 }

--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -7,45 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/ugorji/go/codec"
 )
-
-// getTestSpan returns a Span with different fields set
-func getTestSpan() model.Span {
-	return model.Span{
-		TraceID:  42,
-		SpanID:   52,
-		ParentID: 42,
-		Type:     "web",
-		Service:  "fennel_IS amazing!",
-		Name:     "something &&<@# that should be a metric!",
-		Resource: "NOT touched because it is going to be hashed",
-		Start:    time.Now().UnixNano(),
-		Duration: time.Second.Nanoseconds(),
-		Meta:     map[string]string{"http.host": "192.168.0.1"},
-		Metrics:  map[string]float64{"http.monitor": 41.99},
-	}
-}
-
-// getTestTrace returns a []Trace that is composed by ``traceN`` number
-// of traces, each one composed by ``size`` number of spans.
-func getTestTrace(traceN, size int) []model.Trace {
-	traces := []model.Trace{}
-
-	for i := 0; i < traceN; i++ {
-		trace := model.Trace{}
-		for j := 0; j < size; j++ {
-			trace = append(trace, getTestSpan())
-		}
-		traces = append(traces, trace)
-	}
-	return traces
-}
 
 func TestLegacyReceiver(t *testing.T) {
 	// testing traces without content-type in agent endpoints, it should use JSON decoding
@@ -58,8 +26,8 @@ func TestLegacyReceiver(t *testing.T) {
 		contentType string
 		traces      model.Trace
 	}{
-		{"v01 with empty content-type", NewHTTPReceiver(config), v01, "", model.Trace{getTestSpan()}},
-		{"v01 with application/json", NewHTTPReceiver(config), v01, "application/json", model.Trace{getTestSpan()}},
+		{"v01 with empty content-type", NewHTTPReceiver(config), v01, "", model.Trace{fixtures.GetTestSpan()}},
+		{"v01 with application/json", NewHTTPReceiver(config), v01, "application/json", model.Trace{fixtures.GetTestSpan()}},
 	}
 
 	for _, tc := range testCases {
@@ -114,12 +82,12 @@ func TestReceiverJSONDecoder(t *testing.T) {
 		contentType string
 		traces      []model.Trace
 	}{
-		{"v02 with empty content-type", NewHTTPReceiver(config), v02, "", getTestTrace(1, 1)},
-		{"v03 with empty content-type", NewHTTPReceiver(config), v03, "", getTestTrace(1, 1)},
-		{"v02 with application/json", NewHTTPReceiver(config), v02, "application/json", getTestTrace(1, 1)},
-		{"v03 with application/json", NewHTTPReceiver(config), v03, "application/json", getTestTrace(1, 1)},
-		{"v02 with text/json", NewHTTPReceiver(config), v02, "text/json", getTestTrace(1, 1)},
-		{"v03 with text/json", NewHTTPReceiver(config), v03, "text/json", getTestTrace(1, 1)},
+		{"v02 with empty content-type", NewHTTPReceiver(config), v02, "", fixtures.GetTestTrace(1, 1)},
+		{"v03 with empty content-type", NewHTTPReceiver(config), v03, "", fixtures.GetTestTrace(1, 1)},
+		{"v02 with application/json", NewHTTPReceiver(config), v02, "application/json", fixtures.GetTestTrace(1, 1)},
+		{"v03 with application/json", NewHTTPReceiver(config), v03, "application/json", fixtures.GetTestTrace(1, 1)},
+		{"v02 with text/json", NewHTTPReceiver(config), v02, "text/json", fixtures.GetTestTrace(1, 1)},
+		{"v03 with text/json", NewHTTPReceiver(config), v03, "text/json", fixtures.GetTestTrace(1, 1)},
 	}
 
 	for _, tc := range testCases {
@@ -176,9 +144,9 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 		contentType string
 		traces      []model.Trace
 	}{
-		{"v01 with application/msgpack", NewHTTPReceiver(config), v01, "application/msgpack", getTestTrace(1, 1)},
-		{"v02 with application/msgpack", NewHTTPReceiver(config), v02, "application/msgpack", getTestTrace(1, 1)},
-		{"v03 with application/msgpack", NewHTTPReceiver(config), v03, "application/msgpack", getTestTrace(1, 1)},
+		{"v01 with application/msgpack", NewHTTPReceiver(config), v01, "application/msgpack", fixtures.GetTestTrace(1, 1)},
+		{"v02 with application/msgpack", NewHTTPReceiver(config), v02, "application/msgpack", fixtures.GetTestTrace(1, 1)},
+		{"v03 with application/msgpack", NewHTTPReceiver(config), v03, "application/msgpack", fixtures.GetTestTrace(1, 1)},
 	}
 
 	for _, tc := range testCases {
@@ -380,7 +348,7 @@ func TestReceiverServiceMsgpackDecoder(t *testing.T) {
 
 func BenchmarkDecoderJSON(b *testing.B) {
 	assert := assert.New(b)
-	traces := getTestTrace(150, 66)
+	traces := fixtures.GetTestTrace(150, 66)
 
 	// json payload
 	payload, err := json.Marshal(traces)
@@ -398,7 +366,7 @@ func BenchmarkDecoderJSON(b *testing.B) {
 
 func BenchmarkDecoderMsgpack(b *testing.B) {
 	assert := assert.New(b)
-	traces := getTestTrace(150, 66)
+	traces := fixtures.GetTestTrace(150, 66)
 
 	// msgpack payload
 	var payload []byte

--- a/fixtures/span.go
+++ b/fixtures/span.go
@@ -262,6 +262,23 @@ func RandomSpan() model.Span {
 	}
 }
 
+// GetTestSpan returns a Span with different fields set
+func GetTestSpan() model.Span {
+	return model.Span{
+		TraceID:  42,
+		SpanID:   52,
+		ParentID: 42,
+		Type:     "web",
+		Service:  "fennel_IS amazing!",
+		Name:     "something &&<@# that should be a metric!",
+		Resource: "NOT touched because it is going to be hashed",
+		Start:    time.Now().UnixNano(),
+		Duration: time.Second.Nanoseconds(),
+		Meta:     map[string]string{"http.host": "192.168.0.1"},
+		Metrics:  map[string]float64{"http.monitor": 41.99},
+	}
+}
+
 // TestSpan returns a fix span with hardcoded info, useful for reproducible tests
 func TestSpan() model.Span {
 	return model.Span{

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -80,3 +80,18 @@ func RandomTrace(maxLevels, maxSpans int) model.Trace {
 
 	return t
 }
+
+// GetTestTrace returns a []Trace that is composed by ``traceN`` number
+// of traces, each one composed by ``size`` number of spans.
+func GetTestTrace(traceN, size int) []model.Trace {
+	traces := []model.Trace{}
+
+	for i := 0; i < traceN; i++ {
+		trace := model.Trace{}
+		for j := 0; j < size; j++ {
+			trace = append(trace, GetTestSpan())
+		}
+		traces = append(traces, trace)
+	}
+	return traces
+}

--- a/model/client_api.go
+++ b/model/client_api.go
@@ -38,18 +38,21 @@ func readAll(source io.Reader, dest *bytes.Buffer) (err error) {
 type ClientDecoder interface {
 	Decode(body io.Reader, v interface{}) error
 	BufferReader() *bytes.Reader
+	ContentType() string
 }
 
 type jsonDecoder struct {
-	decoder *json.Decoder
-	buf     *bytes.Buffer
-	slice   []byte
+	decoder     *json.Decoder
+	buf         *bytes.Buffer
+	slice       []byte
+	contentType string
 }
 
 type msgpackDecoder struct {
-	decoder *codec.Decoder
-	buf     *bytes.Buffer
-	slice   []byte
+	decoder     *codec.Decoder
+	buf         *bytes.Buffer
+	slice       []byte
+	contentType string
 }
 
 func newJSONDecoder() *jsonDecoder {
@@ -57,9 +60,10 @@ func newJSONDecoder() *jsonDecoder {
 	// to be expanded or reallocated
 	buf := bytes.NewBuffer(make([]byte, 0, minBufferSize))
 	return &jsonDecoder{
-		buf:     buf,
-		slice:   buf.Bytes(),
-		decoder: json.NewDecoder(buf),
+		buf:         buf,
+		slice:       buf.Bytes(),
+		decoder:     json.NewDecoder(buf),
+		contentType: "application/json",
 	}
 }
 
@@ -78,14 +82,19 @@ func (d *jsonDecoder) BufferReader() *bytes.Reader {
 	return bytes.NewReader(d.slice)
 }
 
+func (d *jsonDecoder) ContentType() string {
+	return d.contentType
+}
+
 func newMsgpackDecoder() *msgpackDecoder {
 	// sets the size of the buffer so that it usually doesn't need
 	// to be expanded or reallocated
 	buf := bytes.NewBuffer(make([]byte, 0, minBufferSize))
 	return &msgpackDecoder{
-		buf:     buf,
-		slice:   buf.Bytes(),
-		decoder: codec.NewDecoder(buf, &codec.MsgpackHandle{}),
+		buf:         buf,
+		slice:       buf.Bytes(),
+		decoder:     codec.NewDecoder(buf, &codec.MsgpackHandle{}),
+		contentType: "application/msgpack",
 	}
 }
 
@@ -102,6 +111,70 @@ func (d *msgpackDecoder) Decode(body io.Reader, v interface{}) error {
 
 func (d *msgpackDecoder) BufferReader() *bytes.Reader {
 	return bytes.NewReader(d.slice)
+}
+
+func (d *msgpackDecoder) ContentType() string {
+	return d.contentType
+}
+
+// DecoderPool is a pool meant to share buffers required to decode traces.
+// It naively tries to cap the number of active encoders, but doesn't enforce
+// the limit. To use a pool, you should Borrow() for a decoder and then
+// Return() that decoder to the pool. Decoders in that pool should honor
+// the ClientDecoder interface.
+// For compatibility, the pool owns both JSON and Msgpack decoders so that
+// we don't need multiple pools. Borrowing a decoder, means asking a decoder
+// for the given content type
+type DecoderPool struct {
+	json    chan ClientDecoder
+	msgpack chan ClientDecoder
+}
+
+func NewDecoderPool(size int) *DecoderPool {
+	return &DecoderPool{
+		json:    make(chan ClientDecoder, size),
+		msgpack: make(chan ClientDecoder, size),
+	}
+}
+
+func (p *DecoderPool) Borrow(contentType string) ClientDecoder {
+	// select the right Decoder based on the given content-type header
+	var decoder ClientDecoder
+
+	switch contentType {
+	case "application/msgpack":
+		select {
+		case decoder = <-p.msgpack:
+		default:
+			decoder = newMsgpackDecoder()
+		}
+	default:
+		// if the client doesn't use a specific decoder, fallback to JSON
+		select {
+		case decoder = <-p.json:
+		default:
+			decoder = newJSONDecoder()
+		}
+	}
+
+	return decoder
+}
+
+func (p *DecoderPool) Release(dec ClientDecoder) {
+	switch dec.ContentType() {
+	case "application/msgpack":
+		select {
+		case p.msgpack <- dec:
+		default:
+			// discard
+		}
+	default:
+		select {
+		case p.json <- dec:
+		default:
+			// discard
+		}
+	}
 }
 
 // DecoderFromContentType returns a ClientDecoder depending on the contentType value

--- a/model/client_api.go
+++ b/model/client_api.go
@@ -1,26 +1,105 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 
 	"github.com/ugorji/go/codec"
 )
 
+// average size of a buffer
+const minBufferSize = 512
+
+// readAll reads from source until an error or EOF and writes to dest;
+// if the dest buffer contains data, it is truncated
+func readAll(source io.Reader, dest *bytes.Buffer) (err error) {
+	// If the buffer overflows, we will get bytes.ErrTooLarge.
+	// Return that as an error. Any other panic remains.
+	defer func() {
+		e := recover()
+		if e == nil {
+			return
+		}
+		if panicErr, ok := e.(error); ok && panicErr == bytes.ErrTooLarge {
+			err = panicErr
+		} else {
+			panic(e)
+		}
+	}()
+
+	// empty the buffer and copy the source into it
+	dest.Reset()
+	_, err = dest.ReadFrom(source)
+	return err
+}
+
 // ClientDecoder is the common interface that all decoders should honor
 type ClientDecoder interface {
-	Decode(v interface{}) error
+	Decode(body io.Reader, v interface{}) error
+}
+
+type jsonDecoder struct {
+	decoder *json.Decoder
+	buf     *bytes.Buffer
+}
+
+type msgpackDecoder struct {
+	decoder *codec.Decoder
+	buf     *bytes.Buffer
+}
+
+func newJSONDecoder() *jsonDecoder {
+	// sets the size of the buffer so that it usually doesn't need
+	// to be expanded or reallocated
+	buf := bytes.NewBuffer(make([]byte, 0, minBufferSize))
+	return &jsonDecoder{
+		buf:     buf,
+		decoder: json.NewDecoder(buf),
+	}
+}
+
+func (d *jsonDecoder) Decode(body io.Reader, v interface{}) error {
+	// read the response into the buffer
+	err := readAll(body, d.buf)
+	if err != nil {
+		return err
+	}
+
+	// decode the payload to the given interface
+	return d.decoder.Decode(v)
+}
+
+func newMsgpackDecoder() *msgpackDecoder {
+	// sets the size of the buffer so that it usually doesn't need
+	// to be expanded or reallocated
+	buf := bytes.NewBuffer(make([]byte, 0, minBufferSize))
+	return &msgpackDecoder{
+		buf:     buf,
+		decoder: codec.NewDecoder(buf, &codec.MsgpackHandle{}),
+	}
+}
+
+func (d *msgpackDecoder) Decode(body io.Reader, v interface{}) error {
+	// read the response into the buffer
+	err := readAll(body, d.buf)
+	if err != nil {
+		return err
+	}
+
+	// decode the payload to the given interface
+	return d.decoder.Decode(v)
 }
 
 // DecoderFromContentType returns a ClientDecoder depending on the contentType value
 // orig. coming from a request header
-func DecoderFromContentType(contentType string, bodyBuffer io.Reader) ClientDecoder {
+func DecoderFromContentType(contentType string) ClientDecoder {
 	// select the right Decoder based on the given content-type header
 	switch contentType {
 	case "application/msgpack":
-		return codec.NewDecoder(bodyBuffer, &codec.MsgpackHandle{})
+		return newMsgpackDecoder()
 	default:
 		// if the client doesn't use a specific decoder, fallback to JSON
-		return json.NewDecoder(bodyBuffer)
+		return newJSONDecoder()
 	}
 }

--- a/model/client_api_test.go
+++ b/model/client_api_test.go
@@ -1,0 +1,126 @@
+package model
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/ugorji/go/codec"
+)
+
+// getTestTrace returns a Trace with a single Span
+func getTestTrace() []Trace {
+	return []Trace{
+		Trace{
+			Span{
+				TraceID:  42,
+				SpanID:   52,
+				ParentID: 42,
+				Type:     "web",
+				Service:  "fennel_IS amazing!",
+				Name:     "something &&<@# that should be a metric!",
+				Resource: "NOT touched because it is going to be hashed",
+				Start:    time.Now().UnixNano(),
+				Duration: time.Second.Nanoseconds(),
+				Meta:     map[string]string{"http.host": "192.168.0.1"},
+				Metrics:  map[string]float64{"http.monitor": 41.99},
+			},
+		},
+	}
+}
+
+func getJSONPayload() io.Reader {
+	data, _ := json.Marshal(getTestTrace())
+	return bytes.NewReader(data)
+}
+
+func getMsgpackPayload() io.Reader {
+	var data []byte
+	enc := codec.NewEncoderBytes(&data, &codec.MsgpackHandle{})
+	enc.Encode(getTestTrace())
+	return bytes.NewReader(data)
+}
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	// neutralize logs for tests
+	config.NewLoggerLevelCustom("critical", "")
+
+	os.Exit(m.Run())
+}
+
+func TestDecoders(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		payload io.Reader
+		decoder ClientDecoder
+	}{
+		{payload: getJSONPayload(), decoder: newJSONDecoder()},
+		{payload: getMsgpackPayload(), decoder: newMsgpackDecoder()},
+	}
+
+	for _, tc := range testCases {
+		var traces []Trace
+		err := tc.decoder.Decode(tc.payload, &traces)
+
+		assert.Nil(err)
+		assert.Len(traces, 1)
+		trace := traces[0]
+		assert.Len(trace, 1)
+		span := trace[0]
+		assert.Equal(uint64(42), span.TraceID)
+		assert.Equal(uint64(52), span.SpanID)
+		assert.Equal("fennel_IS amazing!", span.Service)
+		assert.Equal("something &&<@# that should be a metric!", span.Name)
+		assert.Equal("NOT touched because it is going to be hashed", span.Resource)
+		assert.Equal("192.168.0.1", span.Meta["http.host"])
+		assert.Equal(41.99, span.Metrics["http.monitor"])
+	}
+}
+
+func TestDecodersReusable(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		firstPayload  io.Reader
+		secondPayload io.Reader
+		decoder       ClientDecoder
+	}{
+		{firstPayload: getJSONPayload(), secondPayload: getJSONPayload(), decoder: newJSONDecoder()},
+		{firstPayload: getMsgpackPayload(), secondPayload: getMsgpackPayload(), decoder: newMsgpackDecoder()},
+	}
+
+	for _, tc := range testCases {
+		// first decoding
+		var firstTraces []Trace
+		err := tc.decoder.Decode(tc.firstPayload, &firstTraces)
+		assert.Nil(err)
+
+		// second decoding
+		var secondTraces []Trace
+		err = tc.decoder.Decode(tc.secondPayload, &secondTraces)
+		assert.Nil(err)
+
+		assert.Len(secondTraces, 1)
+		trace := secondTraces[0]
+		assert.Len(trace, 1)
+		span := trace[0]
+		assert.Equal(uint64(42), span.TraceID)
+		assert.Equal(uint64(52), span.SpanID)
+		assert.Equal("fennel_IS amazing!", span.Service)
+		assert.Equal("something &&<@# that should be a metric!", span.Name)
+		assert.Equal("NOT touched because it is going to be hashed", span.Resource)
+		assert.Equal("192.168.0.1", span.Meta["http.host"])
+		assert.Equal(41.99, span.Metrics["http.monitor"])
+
+		// the two data structures should be different because of the timestamps
+		assert.False(reflect.DeepEqual(firstTraces, secondTraces))
+	}
+}


### PR DESCRIPTION
### What it does

* improves the ``ClientDecoder`` interface to make decoders implementations reusable
* implements the ``jsonDecoder`` and ``msgpackDecoder`` structs to keep references to the internal buffers and decoders; in this way decoders are reusable multiple times
* ``readAll`` re-implementation that overwrites the given buffer without any kind of allocations (the built-in version allocates a new resizable ``Buffer`` and returns a slice descriptor for each request)
* when a decoder is created with the internal ``Buffer``, the buffer has ``minBufferSize`` size. This improves a lot performances because during each request the buffer is resized many times to contain the ``req.Body``
* the request handler hot path, doesn't make useless allocations when a request is handled without errors.

#### Performance impact
The benchmark includes the trace handling for a single trace with a single span, so the performance gain is linear with the number of traces. Furthermore, because we're not allocating anything (obviously with the exception of the ``[]Trace`` and the built-in server objects), we're reducing the number of GC.

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkHandleTraces-4     13198         9723          -26.33%

benchmark                   old allocs     new allocs     delta
BenchmarkHandleTraces-4     33             23             -30.30%

benchmark                   old bytes     new bytes     delta
BenchmarkHandleTraces-4     6530          1408          -78.44%
```