### PR TITLE
[profile] more statsd log

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/profile"
 	"github.com/DataDog/datadog-trace-agent/statsd"
 	log "github.com/cihub/seelog"
 )
@@ -37,6 +39,20 @@ const (
 	// Services: msgpack/JSON, map[string]map[string][string]
 	v03
 )
+
+var receiverTags []string
+
+func init() {
+	if Version != "" {
+		receiverTags = append(receiverTags, "version:"+Version)
+	}
+	if GoVersion != "" {
+		receiverTags = append(receiverTags, "go_version:"+GoVersion)
+	}
+	if GitCommit != "" {
+		receiverTags = append(receiverTags, "git_commit:"+GitCommit)
+	}
+}
 
 func httpHandleWithVersion(v APIVersion, f func(APIVersion, http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -122,6 +138,7 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 
 	var traces []model.Trace
 	contentType := req.Header.Get("Content-Type")
+	contentLength := req.Header.Get("Content-Length")
 
 	switch v {
 	case v01:
@@ -183,6 +200,12 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 	}
 
 	HTTPOK(w)
+
+	atomic.AddInt64(&r.stats.PayloadsReceived, 1)
+	l, err := strconv.Atoi(contentLength)
+	if err == nil {
+		atomic.AddInt64(&r.stats.BytesReceived, int64(l))
+	}
 
 	// normalize data
 	for i := range traces {
@@ -268,6 +291,12 @@ func (r *HTTPReceiver) handleServices(v APIVersion, w http.ResponseWriter, req *
 func (r *HTTPReceiver) logStats() {
 	for range time.Tick(60 * time.Second) {
 		// Load counters and reset them for the next flush
+		payloads := atomic.LoadInt64(&r.stats.PayloadsReceived)
+		r.stats.PayloadsReceived = 0
+
+		bytes := atomic.LoadInt64(&r.stats.BytesReceived)
+		r.stats.BytesReceived = 0
+
 		spans := atomic.LoadInt64(&r.stats.SpansReceived)
 		r.stats.SpansReceived = 0
 
@@ -280,10 +309,20 @@ func (r *HTTPReceiver) logStats() {
 		tdropped := atomic.LoadInt64(&r.stats.TracesDropped)
 		r.stats.TracesDropped = 0
 
-		statsd.Client.Count("trace_agent.receiver.span", spans, nil, 1)
-		statsd.Client.Count("trace_agent.receiver.trace", traces, nil, 1)
-		statsd.Client.Count("trace_agent.receiver.span_dropped", sdropped, nil, 1)
-		statsd.Client.Count("trace_agent.receiver.trace_dropped", tdropped, nil, 1)
+		statsd.Client.Count("trace_agent.receiver.payload", payloads, receiverTags, 1)
+		statsd.Client.Count("trace_agent.receiver.byte", bytes, receiverTags, 1)
+		statsd.Client.Count("trace_agent.receiver.span", spans, receiverTags, 1)
+		statsd.Client.Count("trace_agent.receiver.trace", traces, receiverTags, 1)
+		statsd.Client.Count("trace_agent.receiver.span_dropped", sdropped, receiverTags, 1)
+		statsd.Client.Count("trace_agent.receiver.trace_dropped", tdropped, receiverTags, 1)
+
+		profile.CPUStatsd(profile.IntakeStats{
+			Payloads: payloads,
+			Traces:   traces - tdropped,
+			Spans:    spans - tdropped,
+			Bytes:    bytes,
+		}, receiverTags)
+		profile.MemStatsd(receiverTags)
 
 		log.Infof("receiver handled %d spans, dropped %d ; handled %d traces, dropped %d", spans, sdropped, traces, tdropped)
 		r.logger.Reset()
@@ -291,8 +330,10 @@ func (r *HTTPReceiver) logStats() {
 }
 
 type receiverStats struct {
-	SpansReceived  int64
-	TracesReceived int64
-	SpansDropped   int64
-	TracesDropped  int64
+	PayloadsReceived int64
+	BytesReceived    int64
+	SpansReceived    int64
+	TracesReceived   int64
+	SpansDropped     int64
+	TracesDropped    int64
 }

--- a/profile/cpu.go
+++ b/profile/cpu.go
@@ -1,0 +1,155 @@
+package profile
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-trace-agent/statsd"
+	log "github.com/cihub/seelog"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+/*
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <stdlib.h>
+*/
+import "C"
+
+var ticksPerUsec float64
+
+func init() {
+	if runtime.GOOS == "linux" {
+		// Scale according to the number of ticks per sec. On most implementations
+		// it's 100 but technically, it could be different. The values returned
+		// by /proc/pid/stat should be divided by this to be seconds.
+		ticksPerUsec = float64(C.sysconf(C._SC_CLK_TCK)) / 1e6
+	}
+}
+
+const (
+	utimeIndex  = 13
+	stimeIndex  = 14
+	cutimeIndex = 15
+	cstimeIndex = 16
+	cnswapIndex = 36
+)
+
+// CPUInfo contains basic information about CPU usage.
+type CPUInfo struct {
+	Utime  int64 // Utime is the user time spent by this process
+	Stime  int64 // Stime it the system time spent by this process
+	Cutime int64 // Cutime is the user time spent by children processes
+	Cstime int64 // Cstime is the system time spent by children processes
+}
+
+// IntakeStats contains traces intake statistics.
+type IntakeStats struct {
+	Payloads int64 // Payloads is the total number of traces payloads processed
+	Traces   int64 // Traces is the total number of traces processed
+	Spans    int64 // Spans is the total number of spans processed
+	Bytes    int64 // Bytes is the total number of bytes (raw size of payloads) processed
+}
+
+// GetCPUInfo returns information about this process CPU usage.
+// Only works on systems supporting /proc, tested on Linux only.
+func GetCPUInfo() (*CPUInfo, error) {
+	if runtime.GOOS != "linux" {
+		return nil, fmt.Errorf("os '%s' does not support CPU info", runtime.GOOS)
+	}
+
+	// There are functions in https://golang.org/pkg/os/#ProcessState to get
+	// process info but they all refer to children as here, we want to get
+	// info about this process.
+	path := fmt.Sprintf("/proc/%d/stat", os.Getpid())
+	content, err := ioutil.ReadFile(path)
+	if err != nil && len(content) > 0 {
+		return nil, fmt.Errorf("unable to read CPU info from '%s': %v", path, err)
+	}
+	fields := strings.Split(string(content), " ")
+	if len(fields) <= cnswapIndex {
+		return nil, fmt.Errorf("not enough (%d) fields in '%s': %v", len(fields), string(content), err)
+	}
+	var ci CPUInfo
+	utime, err := strconv.Atoi(fields[utimeIndex])
+	if err != nil {
+		return nil, err
+	}
+	ci.Utime += int64(utime)
+	stime, err := strconv.Atoi(fields[stimeIndex])
+	if err != nil {
+		return nil, err
+	}
+	ci.Stime += int64(stime)
+	cutime, err := strconv.Atoi(fields[cutimeIndex])
+	if err != nil {
+		return nil, err
+	}
+	ci.Cutime += int64(cutime)
+	cstime, err := strconv.Atoi(fields[cstimeIndex])
+	if err != nil {
+		return nil, err
+	}
+	ci.Cstime += int64(cstime)
+	if err != nil {
+		return &ci, nil
+	}
+
+	return &ci, nil
+}
+
+// TotalCPU returns the total number of ticks in a CPUInfo struct.
+func TotalCPU(ci *CPUInfo) int64 {
+	return ci.Utime + ci.Stime + ci.Cutime + ci.Cstime
+}
+
+var lastCPUInfo *CPUInfo
+var lastIntakeStats IntakeStats
+
+// CPUStatsd traces stats on a per-CPU used basis. While raw CPU stats
+// can be obtained easily using standard Datadog tools, what we're searching
+// is "how many CPU cycles does a payload/trace/span/byte costs."
+// It is possible to calculate this later in dashboards, but if we know we're
+// tracking this, let's do it upstream.
+func CPUStatsd(stats IntakeStats, tags []string) {
+	if ticksPerUsec <= 0 {
+		return
+	}
+	ci, err := GetCPUInfo()
+	if err != nil {
+		log.Debugf("unable to get CPUInfo: %v", err)
+	}
+	if lastCPUInfo == nil {
+		lastCPUInfo = ci
+		lastIntakeStats = stats
+		return
+	}
+	ticks := float64(TotalCPU(ci) - TotalCPU(lastCPUInfo))
+	if ticks <= 0 {
+		return
+	}
+	usecs := ticks / ticksPerUsec
+
+	payloads := float64(stats.Payloads - lastIntakeStats.Payloads)
+	if payloads >= 0 {
+		statsd.Client.Gauge("trace_agent.profile.cpu.usec_per_payload", usecs/payloads, tags, 1)
+	}
+	traces := float64(stats.Traces - lastIntakeStats.Traces)
+	if traces >= 0 {
+		statsd.Client.Gauge("trace_agent.profile.cpu.usec_per_trace", usecs/traces, tags, 1)
+	}
+	spans := float64(stats.Spans - lastIntakeStats.Spans)
+	if spans >= 0 {
+		statsd.Client.Gauge("trace_agent.profile.cpu.usec_per_span", usecs/spans, tags, 1)
+	}
+	bytes := float64(stats.Bytes - lastIntakeStats.Bytes)
+	if bytes >= 0 {
+		statsd.Client.Gauge("trace_agent.profile.cpu.usec_per_byte", usecs/bytes, tags, 1)
+	}
+
+	lastCPUInfo = ci
+	lastIntakeStats = stats
+}

--- a/profile/cpu_test.go
+++ b/profile/cpu_test.go
@@ -1,0 +1,47 @@
+package profile
+
+import (
+	"github.com/stretchr/testify/assert"
+	"runtime"
+	"testing"
+)
+
+const (
+	testCycles = 100000000
+)
+
+func TestTotalCPU(t *testing.T) {
+	assert := assert.New(t)
+
+	ci := CPUInfo{Utime: 1, Stime: 2, Cutime: 3, Cstime: 4}
+	assert.Equal(10, TotalCPU(&ci), "bad CPU total")
+}
+
+func TestGetCPUInfo(t *testing.T) {
+	assert := assert.New(t)
+	if runtime.GOOS == "linux" {
+		ci, err := GetCPUInfo()
+		assert.Nil(err, "unable to get CPU Info (note: this only works on UNIX machines supporting /proc/pid/stat")
+		for i := 0; i < testCycles && TotalCPU(ci) == 0; i++ {
+			// normally, the test bootstrap should consume enough CPU cycles,
+			// but just in case, computing random stuff to increase numbers
+			ci, err = GetCPUInfo()
+			assert.Nil(err, "unable to get CPU Info (note: this only works on UNIX machines supporting /proc/pid/stat")
+		}
+		assert.NotEqual(0, TotalCPU(ci), "zero CPU usage found, does not make sense")
+		ci2, err := GetCPUInfo()
+		assert.Nil(err, "unable to get CPU Info (note: this only works on UNIX machines supporting /proc/pid/stat")
+		for i := 0; i < testCycles && TotalCPU(ci) >= TotalCPU(ci2); i++ {
+			// normally, the test bootstrap should consume enough CPU cycles,
+			// but just in case, computing random stuff to increase numbers
+			ci2, err = GetCPUInfo()
+			assert.Nil(err, "unable to get CPU Info (note: this only works on UNIX machines supporting /proc/pid/stat")
+		}
+		assert.Condition(func() bool { return TotalCPU(ci) < TotalCPU(ci2) }, "CPU usage not increasing")
+	} else {
+		// unsupported
+		ci, err := GetCPUInfo()
+		assert.Nil(ci)
+		assert.NotNil(err)
+	}
+}

--- a/profile/mem.go
+++ b/profile/mem.go
@@ -1,0 +1,18 @@
+package profile
+
+import (
+	"github.com/DataDog/datadog-trace-agent/statsd"
+	"runtime"
+)
+
+// MemStatsd writes memory statistics to Datadog data pipeline using Statsd.
+func MemStatsd(tags []string) {
+	var ms runtime.MemStats
+
+	runtime.ReadMemStats(&ms)
+	statsd.Client.Count("trace_agent.profile.mem.total_alloc", int64(ms.TotalAlloc), tags, 1)
+	statsd.Client.Count("trace_agent.profile.mem.sys", int64(ms.Sys), tags, 1)
+	statsd.Client.Count("trace_agent.profile.mem.lookups", int64(ms.Lookups), tags, 1)
+	statsd.Client.Count("trace_agent.profile.mem.mallocs", int64(ms.Mallocs), tags, 1)
+	statsd.Client.Count("trace_agent.profile.mem.frees", int64(ms.Frees), tags, 1)
+}


### PR DESCRIPTION
Reporting more informations using statsd, more precisely:
- tags now report version, go version, and git commit
- report go memory stats
- report cpu usage (parses /proc/pid/stat so not cross-platform)