### PR TITLE
[quantizer] remove Debugf from the hot path

### DIFF
--- a/quantizer/main.go
+++ b/quantizer/main.go
@@ -4,8 +4,6 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-trace-agent/model"
 )
 
@@ -42,7 +40,6 @@ func Quantize(span model.Span) model.Span {
 		// redis
 		return QuantizeRedis(span)
 	default:
-		log.Debugf("No quantization for this span, Type: %s", span.Type)
 		return span
 	}
 

--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -196,7 +196,6 @@ func QuantizeSQL(span model.Span) model.Span {
 		return span
 	}
 
-	log.Debugf("Quantize SQL command, generate resource from the query, SpanID: %d", span.SpanID)
 	quantizedString, err := tokenQuantizer.Process(span.Resource)
 
 	if err != nil {


### PR DESCRIPTION
### What it does

Removes the ``Debugf`` call from the ``Quantize`` hot path. In some cases, it takes [2-5]% of profiled execution. We can reintroduce these kind of logs again, when a different logging library is introduced.