### PR TITLE
[profile] unpacking "_resource" as resource in tags

### DIFF
--- a/model/meta.go
+++ b/model/meta.go
@@ -1,0 +1,25 @@
+package model
+
+const (
+	refResource = "_resource"
+)
+
+// MetaCompact compacts tags so that if they refer to an existing field, they are not duped
+func (s *Span) MetaCompact() {
+	for k, v := range s.Meta {
+		switch v {
+		case s.Resource:
+			s.Meta[k] = refResource
+		}
+	}
+}
+
+// MetaExpand expands tags so that they are replaced with their original values
+func (s *Span) MetaExpand() {
+	for k, v := range s.Meta {
+		switch v {
+		case refResource:
+			s.Meta[k] = s.Resource
+		}
+	}
+}

--- a/model/meta_test.go
+++ b/model/meta_test.go
@@ -1,0 +1,34 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpanMetaCompactDiff(t *testing.T) {
+	assert := assert.New(t)
+	ts1 := testSpan()
+	ts2 := testSpan()
+	ts1.MetaCompact()
+	assert.Equal(ts1, ts2, "compact modified data which should have remained untouched")
+	ts1.MetaExpand()
+	assert.Equal(ts1, ts2, "compact + expand does not restitute original data")
+}
+
+func TestSpanMetaCompactMatch(t *testing.T) {
+	assert := assert.New(t)
+	ts1 := testSpan()
+	ts1.Meta["foo"] = ts1.Resource
+	ts2 := testSpan()
+	ts2.Meta["foo"] = ts2.Resource
+	ts1.MetaCompact()
+	assert.NotEqual(ts1, ts2, "compact did nothing")
+	assert.Equal("_resource", ts1.Meta["foo"], "compact did not set resource to the right ref")
+	ts1.MetaCompact()
+	assert.Equal("_resource", ts1.Meta["foo"], "compact is not idempotent")
+	ts1.MetaExpand()
+	assert.Equal(ts1, ts2, "compact + expand does not restitute original data")
+	ts1.MetaExpand()
+	assert.Equal(ts1, ts2, "expand is not idempotent")
+}

--- a/model/normalizer.go
+++ b/model/normalizer.go
@@ -98,6 +98,8 @@ func (s *Span) Normalize() error {
 		return errors.New("span.normalize: spans with zeroed `Duration` are discarded, use annotations")
 	}
 
+	s.MetaExpand()
+
 	// Error - Nothing to do
 	// Optional data, Meta & Metrics can be nil
 	// Soft fail on those

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -8,44 +8,44 @@ import (
 )
 
 func TestNormalizeOK(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	assert.Nil(t, s.Normalize())
 }
 
 func TestNormalizeServicePassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Service
 	s.Normalize()
 	assert.Equal(t, before, s.Service)
 }
 
 func TestNormalizeEmptyService(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Service = ""
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeLongService(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Service = strings.Repeat("CAMEMBERT", 100)
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeNamePassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Name
 	s.Normalize()
 	assert.Equal(t, before, s.Name)
 }
 
 func TestNormalizeEmptyName(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Name = ""
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeLongName(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Name = strings.Repeat("CAMEMBERT", 100)
 	assert.NotNil(t, s.Normalize())
 }
@@ -56,7 +56,7 @@ func TestNormalizeName(t *testing.T) {
 		"trace-api.request": "trace_api.request",
 	}
 
-	s := Span(testSpan)
+	s := Span(testSpan())
 	for name, expName := range expNames {
 		s.Name = name
 		assert.Nil(t, s.Normalize())
@@ -65,95 +65,95 @@ func TestNormalizeName(t *testing.T) {
 }
 
 func TestNormalizeResourcePassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Resource
 	s.Normalize()
 	assert.Equal(t, before, s.Resource)
 }
 
 func TestNormalizeEmptyResource(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Resource = ""
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeLongResource(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Resource = strings.Repeat("SELECT ", 5000)
 	assert.Nil(t, s.Normalize())
 	assert.Equal(t, 5000, len(s.Resource))
 }
 
 func TestNormalizeTraceIDPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.TraceID
 	s.Normalize()
 	assert.Equal(t, before, s.TraceID)
 }
 
 func TestNormalizeNoTraceID(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.TraceID = 0
 	s.Normalize()
 	assert.NotEqual(t, 0, s.TraceID)
 }
 
 func TestNormalizeSpanIDPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.SpanID
 	s.Normalize()
 	assert.Equal(t, before, s.SpanID)
 }
 
 func TestNormalizeNoSpanID(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.SpanID = 0
 	s.Normalize()
 	assert.NotEqual(t, 0, s.SpanID)
 }
 
 func TestNormalizeStartPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Start
 	s.Normalize()
 	assert.Equal(t, before, s.Start)
 }
 
 func TestNormalizeStartTooSmall(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Start = 42
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeDurationPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Duration
 	s.Normalize()
 	assert.Equal(t, before, s.Duration)
 }
 
 func TestNormalizeEmptyDuration(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Duration = 0
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeErrorPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Error
 	s.Normalize()
 	assert.Equal(t, before, s.Error)
 }
 
 func TestNormalizeMetricsPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Metrics
 	s.Normalize()
 	assert.Equal(t, before, s.Metrics)
 }
 
 func TestNormalizeMetricsKeyTooLong(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	key := strings.Repeat("TOOLONG", 1000)
 	s.Metrics[key] = 42
 	assert.Nil(t, s.Normalize())
@@ -163,14 +163,14 @@ func TestNormalizeMetricsKeyTooLong(t *testing.T) {
 }
 
 func TestNormalizeMetaPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Meta
 	s.Normalize()
 	assert.Equal(t, before, s.Meta)
 }
 
 func TestNormalizeMetaKeyTooLong(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	key := strings.Repeat("TOOLONG", 1000)
 	s.Meta[key] = "foo"
 	assert.Nil(t, s.Normalize())
@@ -180,7 +180,7 @@ func TestNormalizeMetaKeyTooLong(t *testing.T) {
 }
 
 func TestNormalizeMetaValueTooLong(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	val := strings.Repeat("TOOLONG", 5000)
 	s.Meta["foo"] = val
 	assert.Nil(t, s.Normalize())
@@ -189,36 +189,43 @@ func TestNormalizeMetaValueTooLong(t *testing.T) {
 	}
 }
 
+func TestNormalizeMetaExpand(t *testing.T) {
+	s := Span(testSpan())
+	s.Meta["foo"] = "_resource"
+	assert.Nil(t, s.Normalize())
+	assert.Equal(t, s.Resource, s.Meta["foo"], `Resource and Meta["foo"] should be the same`)
+}
+
 func TestNormalizeParentIDPassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.ParentID
 	s.Normalize()
 	assert.Equal(t, before, s.ParentID)
 }
 
 func TestNormalizeTypePassThru(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	before := s.Type
 	s.Normalize()
 	assert.Equal(t, before, s.Type)
 }
 
 func TestNormalizeTypeTooLong(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Type = strings.Repeat("sql", 1000)
 	s.Normalize()
 	assert.NotNil(t, s.Normalize())
 }
 
 func TestNormalizeServiceTag(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.Service = "retargeting(api-Staging "
 	s.Normalize()
 	assert.Equal(t, "retargeting_api-staging", s.Service)
 }
 
 func TestSpecialZipkinRootSpan(t *testing.T) {
-	s := Span(testSpan)
+	s := Span(testSpan())
 	s.ParentID = 42
 	s.TraceID = 42
 	s.SpanID = 42

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -6,29 +6,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testSpan = Span{
-	Duration: 10000000,
-	Error:    0,
-	Resource: "GET /some/raclette",
-	Service:  "django",
-	Name:     "django.controller",
-	SpanID:   42,
-	Start:    1448466874000000000,
-	TraceID:  424242,
-	Meta: map[string]string{
-		"user": "leo",
-		"pool": "fondue",
-	},
-	Metrics: map[string]float64{
-		"cheese_weight": 100000.0,
-	},
-	ParentID: 1111,
-	Type:     "http",
+func testSpan() Span {
+	return Span{
+		Duration: 10000000,
+		Error:    0,
+		Resource: "GET /some/raclette",
+		Service:  "django",
+		Name:     "django.controller",
+		SpanID:   42,
+		Start:    1448466874000000000,
+		TraceID:  424242,
+		Meta: map[string]string{
+			"user": "leo",
+			"pool": "fondue",
+		},
+		Metrics: map[string]float64{
+			"cheese_weight": 100000.0,
+		},
+		ParentID: 1111,
+		Type:     "http",
+	}
 }
 
 func TestSpanString(t *testing.T) {
 	assert := assert.New(t)
-	assert.NotEqual("", testSpan.String())
+	assert.NotEqual("", testSpan().String())
 }
 
 func TestSpanFlushMarker(t *testing.T) {


### PR DESCRIPTION
In many implementations, resource is sent in the resource field and
as a tag, since agent can decide to treat them differently. Typically,
resource would be quantized, but not the value in the tagset. With
this patch, a client implementation can just send "_resource" instead
of the complete resource value, to save bandwith.