### PR TITLE
[watchdog] basic funcs returning CPU and Mem usage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -114,7 +114,7 @@ task :lint do
       filename = line.split(':')[0]
       EXCLUDE_LINT.include?(filename)
     end
-    if output.length > 0
+    if !output.empty?
       puts output
       error = true
     end

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ PACKAGES = %w(
   ./quantizer
   ./sampler
   ./statsd
+  ./watchdog
 )
 
 EXCLUDE_LINT = [

--- a/Rakefile
+++ b/Rakefile
@@ -2,22 +2,34 @@ require "./gorake.rb"
 
 desc 'Bootstrap CI environment'
 task :bootstrap do
-  sh 'go get github.com/Masterminds/glide'
-
   tools = {
     'github.com/golang/lint' => {
-      :version => 'b8599f7d71e7fead76b25aeb919c0e2558672f4a',
-      :main_pkg => './golint'
+      version: 'b8599f7d71e7fead76b25aeb919c0e2558672f4a',
+      main_pkg: './golint',
+      check_cmd: 'golint',
+      clean_cmd: "rm -rf #{ENV['GOPATH']}/src/golang.org/x"
     }
   }
 
   tools.each do |pkg, info|
+    if info[:check_cmd]
+      has_cmd = false
+      begin
+        sh "which #{info[:check_cmd]}"
+        has_cmd = true
+      rescue
+        sh info[:clean_cmd] if info[:clean_cmd]
+      end
+      next if has_cmd
+    end
     path = "#{ENV['GOPATH']}/src/#{pkg}"
     FileUtils.rm_rf(path)
 
     sh "go get #{pkg}"
     sh "cd #{path} && git reset --hard #{info[:version]} && go install #{info[:main_pkg]}"
   end
+
+  sh 'go get github.com/Masterminds/glide'
 end
 
 desc 'Restore code workspace to known state from locked versions'

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -73,6 +73,10 @@ func NewAgent(conf *config.AgentConfig) *Agent {
 func (a *Agent) Run() {
 	flushTicker := time.NewTicker(a.conf.BucketInterval)
 	defer flushTicker.Stop()
+
+	// it's really important to use a ticker for this, and with a not too short
+	// interval, for this is our garantee that the process won't start and kill
+	// itself too fast (nightmare loop)
 	watchdogTicker := time.NewTicker(a.conf.WatchdogInterval)
 	defer watchdogTicker.Stop()
 
@@ -167,5 +171,6 @@ func (a *Agent) watchdog() {
 	if int(wi.Net.Connections) > a.conf.MaxConnections {
 		a.die("exceeded max connections (current=%d, max=%d)", wi.Net.Connections, a.conf.MaxConnections)
 	}
+
 	updateWatchdogInfo(wi)
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -72,7 +72,7 @@ func NewAgent(conf *config.AgentConfig) *Agent {
 func (a *Agent) Run() {
 	flushTicker := time.NewTicker(a.conf.BucketInterval)
 	defer flushTicker.Stop()
-	watchdogTicker := time.NewTicker(watchdogInterval)
+	watchdogTicker := time.NewTicker(a.conf.WatchdogInterval)
 	defer watchdogTicker.Stop()
 
 	a.Receiver.Run()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -165,10 +165,10 @@ func (a *Agent) watchdog() {
 	wi.Mem = watchdog.Mem()
 	wi.Net = watchdog.Net()
 
-	if float64(wi.Mem.Alloc) > a.conf.MaxMemory {
+	if float64(wi.Mem.Alloc) > a.conf.MaxMemory && a.conf.MaxMemory > 0 {
 		a.die("exceeded max memory (current=%d, max=%d)", wi.Mem.Alloc, a.conf.MaxMemory)
 	}
-	if int(wi.Net.Connections) > a.conf.MaxConnections {
+	if int(wi.Net.Connections) > a.conf.MaxConnections && a.conf.MaxConnections > 0 {
 		a.die("exceeded max connections (current=%d, max=%d)", wi.Net.Connections, a.conf.MaxConnections)
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -166,7 +166,7 @@ func (a *Agent) watchdog() {
 	wi.Net = watchdog.Net()
 
 	if float64(wi.Mem.Alloc) > a.conf.MaxMemory && a.conf.MaxMemory > 0 {
-		a.die("exceeded max memory (current=%d, max=%d)", wi.Mem.Alloc, a.conf.MaxMemory)
+		a.die("exceeded max memory (current=%d, max=%d)", wi.Mem.Alloc, int64(a.conf.MaxMemory))
 	}
 	if int(wi.Net.Connections) > a.conf.MaxConnections && a.conf.MaxConnections > 0 {
 		a.die("exceeded max connections (current=%d, max=%d)", wi.Net.Connections, a.conf.MaxConnections)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,11 +1,51 @@
 package main
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 )
+
+func TestWatchdog(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	conf := config.NewDefaultAgentConfig()
+	conf.APIKeys = append(conf.APIKeys, "apikey_2")
+	conf.MaxMemory = 1e7
+	conf.WatchdogInterval = time.Millisecond
+	agent := NewAgent(conf)
+
+	defer func() {
+		if r := recover(); r != nil {
+			switch v := r.(type) {
+			case string:
+				if strings.HasPrefix(v, "exceeded max memory") {
+					t.Logf("watchdog worked, trapped the right error: %s", v)
+					return
+				}
+			}
+			t.Fatalf("unexpected error: %v", r)
+		}
+	}()
+
+	// allocating a lot of memory
+	buf := make([]byte, 2*int64(conf.MaxMemory))
+	buf[0] = 1
+	buf[len(buf)-1] = 1
+
+	// after some time, the watchdog should kill this
+	agent.Run()
+
+	// without this. runtime could be smart and free memory before we Run()
+	buf[0] = 2
+	buf[len(buf)-1] = 2
+
+}
 
 func BenchmarkAgentTraceProcessing(b *testing.B) {
 	// Disable debug logs in these tests

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -56,6 +57,11 @@ func TestWatchdog(t *testing.T) {
 	buf := make([]byte, 2*int64(conf.MaxMemory))
 	buf[0] = 1
 	buf[len(buf)-1] = 1
+
+	// override the default die, else our test would stop, use a plain panic() instead
+	agent.die = func(format string, args ...interface{}) {
+		panic(fmt.Sprintf(format, args...))
+	}
 
 	// after some time, the watchdog should kill this
 	agent.Run()

--- a/agent/listener.go
+++ b/agent/listener.go
@@ -67,6 +67,7 @@ func (sl *StoppableListener) Accept() (net.Conn, error) {
 		select {
 		case <-sl.exit:
 			log.Debug("stopping listener")
+			sl.TCPListener.Close()
 			return nil, errors.New("listener stopped")
 		default:
 			//If the channel is still open, continue as normal

--- a/config/agent.go
+++ b/config/agent.go
@@ -172,7 +172,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 
 		MaxMemory:        1e9,
 		MaxConnections:   5000,
-		WatchdogInterval: time.Duration(1) * time.Minute,
+		WatchdogInterval: time.Minute,
 	}
 
 	return ac

--- a/config/agent.go
+++ b/config/agent.go
@@ -56,7 +56,8 @@ type AgentConfig struct {
 	LogFilePath string
 
 	// watchdog
-	MaxMemory float64
+	MaxMemory        float64       // MaxMemory is the threshold above which program panics and exits, to be restarted
+	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
 }
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
@@ -168,7 +169,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 		LogLevel:    "INFO",
 		LogFilePath: "/var/log/datadog/trace-agent.log",
 
-		MaxMemory: 1e9,
+		MaxMemory:        1e9,
+		WatchdogInterval: time.Duration(1) * time.Minute,
 	}
 
 	return ac
@@ -298,6 +300,10 @@ APM_CONF:
 
 	if v, e := conf.GetFloat("trace.watchdog", "max_memory"); e == nil {
 		c.MaxMemory = v
+	}
+
+	if v, e := conf.GetInt("trace.watchdog", "check_delay_seconds"); e == nil {
+		c.WatchdogInterval = time.Duration(v) * time.Second
 	}
 
 ENV_CONF:

--- a/config/agent.go
+++ b/config/agent.go
@@ -54,6 +54,9 @@ type AgentConfig struct {
 	// logging
 	LogLevel    string
 	LogFilePath string
+
+	// watchdog
+	MaxMemory float64
 }
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
@@ -164,6 +167,8 @@ func NewDefaultAgentConfig() *AgentConfig {
 
 		LogLevel:    "INFO",
 		LogFilePath: "/var/log/datadog/trace-agent.log",
+
+		MaxMemory: 1e9,
 	}
 
 	return ac
@@ -289,6 +294,10 @@ APM_CONF:
 
 	if v, e := conf.GetInt("trace.receiver", "timeout"); e == nil {
 		c.ReceiverTimeout = v
+	}
+
+	if v, e := conf.GetFloat("trace.watchdog", "max_memory"); e == nil {
+		c.MaxMemory = v
 	}
 
 ENV_CONF:

--- a/config/agent.go
+++ b/config/agent.go
@@ -56,7 +56,8 @@ type AgentConfig struct {
 	LogFilePath string
 
 	// watchdog
-	MaxMemory        float64       // MaxMemory is the threshold above which program panics and exits, to be restarted
+	MaxMemory        float64       // MaxMemory is the threshold (bytes allocated) above which program panics and exits, to be restarted
+	MaxConnections   int           // MaxConnections is the threshold (opened TCP connections) above which program panics and exits, to be restarted
 	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
 }
 
@@ -170,6 +171,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		LogFilePath: "/var/log/datadog/trace-agent.log",
 
 		MaxMemory:        1e9,
+		MaxConnections:   5000,
 		WatchdogInterval: time.Duration(1) * time.Minute,
 	}
 
@@ -300,6 +302,10 @@ APM_CONF:
 
 	if v, e := conf.GetFloat("trace.watchdog", "max_memory"); e == nil {
 		c.MaxMemory = v
+	}
+
+	if v, e := conf.GetInt("trace.watchdog", "max_connections"); e == nil {
+		c.MaxConnections = v
 	}
 
 	if v, e := conf.GetInt("trace.watchdog", "check_delay_seconds"); e == nil {

--- a/glide.lock
+++ b/glide.lock
@@ -15,6 +15,10 @@ imports:
   version: 362bfb3384d53ae4d5dd745983a4d70b6d23628c
   subpackages:
   - msgp
+- name: github.com/shirou/gopsutil
+  version: 93564b314264efac01934715fad4c355ed6af1c5
+  subpackages:
+  - cpu
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 82b158363973fe2a76243c75d649380286b2dd97e6f263789a3217f0f503316e
-updated: 2017-02-22T16:29:03.841539063+01:00
+hash: 6ee4eb022b387621ddb234375954dc60256fc2df4dcf2099dfb2f55f645756e4
+updated: 2017-02-23T15:00:26.163727755+01:00
 imports:
 - name: github.com/cihub/seelog
   version: d2c6e5aa9fbfdd1c624e140287063c7730654115
@@ -9,16 +9,33 @@ imports:
   - statsd
 - name: github.com/go-ini/ini
   version: 74bdc99692c3408cb103221e38675ce8fda0a718
+- name: github.com/go-ole/go-ole
+  version: de8695c8edbf8236f30d6e1376e20b198a028d42
+  subpackages:
+  - oleutil
+- name: github.com/golang/tools
+  version: 219e654bb7266d3b73c4610ed24c33d12560826a
+  subpackages:
+  - go/gcexportdata
 - name: github.com/philhofer/fwd
   version: 98c11a7a6ec829d672b03833c3d69a7fae1ca972
+- name: github.com/shirou/gopsutil
+  version: 70a1b78fe69202d93d6718fc9e3a4d6f81edfd58
+  subpackages:
+  - cpu
+  - host
+  - internal/common
+  - mem
+  - net
+  - process
+- name: github.com/shirou/w32
+  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
+- name: github.com/StackExchange/wmi
+  version: e542ed97d15e640bdc14b5c12162d59e8fc67324
 - name: github.com/tinylib/msgp
   version: 362bfb3384d53ae4d5dd745983a4d70b6d23628c
   subpackages:
   - msgp
-- name: github.com/shirou/gopsutil
-  version: 93564b314264efac01934715fad4c355ed6af1c5
-  subpackages:
-  - cpu
 testImports:
 - name: github.com/davecgh/go-spew
   version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9

--- a/glide.yaml
+++ b/glide.yaml
@@ -13,6 +13,14 @@ import:
   - msgp
 - package: github.com/go-ini/ini
   version: v1.25.2
+- package: github.com/golang/tools
+  version: 219e654bb7266d3b73c4610ed24c33d12560826a
+  subpackages:
+  - go/gcexportdata
+- package: github.com/shirou/gopsutil
+  version: v2.17.01
+  subpackages:
+  - cpu
 
 testImport:
 - package: github.com/stretchr/testify

--- a/watchdog/info.go
+++ b/watchdog/info.go
@@ -1,10 +1,11 @@
 package watchdog
 
 import (
-	log "github.com/cihub/seelog"
-	"github.com/shirou/gopsutil/cpu"
 	"runtime"
 	"time"
+
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/cpu"
 )
 
 // CPUInfo contains very basic CPU information
@@ -95,12 +96,14 @@ func (pi *ProcessInfo) Mem() MemInfo {
 	return ret
 }
 
-// CPU returns basic CPU info
+// CPU returns basic CPU info.
+// Uses a global shared struct to store information, therefore not thread safe.
 func CPU() CPUInfo {
 	return globalProcessInfo.CPU()
 }
 
 // Mem returns basic memory information
+// Uses a global shared struct to store information, therefore not thread safe.
 func Mem() MemInfo {
 	return globalProcessInfo.Mem()
 }

--- a/watchdog/info.go
+++ b/watchdog/info.go
@@ -12,7 +12,11 @@ import (
 )
 
 const (
-	cacheDelay = time.Second
+	// cacheDelay should be long enough so that we don't poll the info
+	// too often and waste resources doing it, and also long enough
+	// so that it's not jittering (CPU can be volatile).
+	// OTOH it should be short enough to get up-to-date recent info.
+	cacheDelay = 5 * time.Second
 )
 
 // CPUInfo contains basic CPU info

--- a/watchdog/info.go
+++ b/watchdog/info.go
@@ -1,0 +1,106 @@
+package watchdog
+
+import (
+	log "github.com/cihub/seelog"
+	"github.com/shirou/gopsutil/cpu"
+	"runtime"
+	"time"
+)
+
+// CPUInfo contains very basic CPU information
+type CPUInfo struct {
+	// UserAvg is the average of the user CPU usage since last time
+	// it was polled. 0 means "not used at all" and 1 means "1 CPU was
+	// totally full for that period". So it might be greater than 1 if
+	// the process is monopolizing several cores.
+	UserAvg float64
+}
+
+// MemInfo contains very basic memory information
+type MemInfo struct {
+	// Alloc is the number of bytes allocated and not yet freed
+	// as described in runtime.MemStats.Alloc
+	Alloc uint64
+	// AllocPerSec is the average number of bytes allocated, per second,
+	// since last time this function was called.
+	AllocPerSec float64
+}
+
+// ProcessInfo is used to query CPU and Mem info, it keeps data from
+// the previous calls to calculate averages. It is not thread safe.
+type ProcessInfo struct {
+	lastCPUTime time.Time
+	lastCPUUser float64
+	lastCPU     CPUInfo
+
+	lastMemTime       time.Time
+	lastMemTotalAlloc uint64
+	lastMem           MemInfo
+}
+
+// globalProcessInfo is a global default object one can safely use
+// if only one goroutine is polling for CPU() and Mem()
+var globalProcessInfo ProcessInfo
+
+// CPU returns basic CPU info
+func (pi *ProcessInfo) CPU() CPUInfo {
+	now := time.Now()
+	dt := now.Sub(pi.lastCPUTime)
+	if dt <= 0 {
+		return pi.lastCPU // shouldn't happen unless time decreases or back to back calls
+	}
+	ts, err := cpu.Times(false)
+	if err != nil {
+		log.Debugf("unable to get CPU info: %v", err)
+		return pi.lastCPU
+	}
+	if len(ts) != 1 {
+		log.Debugf("inconsistent CPU info len=%d", len(ts))
+		return pi.lastCPU
+	}
+	pi.lastCPUTime = now
+	dua := ts[0].User - pi.lastCPUUser
+	pi.lastCPUUser = ts[0].User
+	if dua <= 0 {
+		pi.lastCPU.UserAvg = 0 // shouldn't happen, but make sure result is always > 0
+	} else {
+		pi.lastCPU.UserAvg = float64(time.Second) * dua / float64(dt)
+		pi.lastCPUUser = ts[0].User
+	}
+
+	return pi.lastCPU
+}
+
+// Mem returns basic memory information
+func (pi *ProcessInfo) Mem() MemInfo {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	ret := MemInfo{Alloc: ms.Alloc, AllocPerSec: pi.lastMem.AllocPerSec}
+
+	now := time.Now()
+	dt := now.Sub(pi.lastMemTime)
+	if dt <= 0 {
+		return pi.lastMem // shouldn't happen unless time decreases or back to back calls
+	}
+	pi.lastMemTime = now
+	dta := int64(ms.TotalAlloc) - int64(pi.lastMemTotalAlloc)
+	pi.lastMemTotalAlloc = ms.TotalAlloc
+	if dta <= 0 {
+		pi.lastMem.AllocPerSec = 0 // shouldn't happen, but make sure result is always > 0
+	} else {
+		pi.lastMem.AllocPerSec = float64(time.Second) * float64(dta) / float64(dt)
+	}
+	ret.AllocPerSec = pi.lastMem.AllocPerSec
+
+	return ret
+}
+
+// CPU returns basic CPU info
+func CPU() CPUInfo {
+	return globalProcessInfo.CPU()
+}
+
+// Mem returns basic memory information
+func Mem() MemInfo {
+	return globalProcessInfo.Mem()
+}

--- a/watchdog/info.go
+++ b/watchdog/info.go
@@ -89,7 +89,6 @@ func init() {
 func NewCurrentInfo() (*CurrentInfo, error) {
 	p, err := process.NewProcess(int32(os.Getpid()))
 	if err != nil {
-		log.Debugf("unable to create Process: %v", err)
 		return nil, err
 	}
 	return &CurrentInfo{

--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -1,0 +1,67 @@
+package watchdog
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testDuration = time.Second
+)
+
+func TestCPULow(t *testing.T) {
+	assert := assert.New(t)
+
+	c := CPU()
+	time.Sleep(testDuration)
+	c = CPU()
+	t.Logf("CPU (sleep): %v", c)
+
+	// checking that CPU is low enough, this is theorically flaky,
+	// but eating 50% of CPU for a time.Sleep is still not likely to happen often
+	assert.Condition(func() bool { return c.UserAvg >= 0.0 }, "cpu avg should be positive")
+	assert.Condition(func() bool { return c.UserAvg <= 0.5 }, "cpu avg should be below 0.5")
+}
+
+func doTestCPUHigh(t *testing.T, n int) {
+	assert := assert.New(t)
+	done := make(chan struct{}, 1)
+	c := CPU()
+	for i := 0; i < n; i++ {
+		go func() {
+			j := 0
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					j++
+				}
+			}
+		}()
+	}
+	time.Sleep(testDuration)
+	c = CPU()
+	for i := 0; i < n; i++ {
+		done <- struct{}{}
+	}
+	t.Logf("CPU (%d goroutines): %v", n, c)
+
+	// Checking that CPU is high enough, a very simple ++ loop should be
+	// enough to stimulate one core and make it over 50%. One of the goals
+	// of this test is to check that values are not wrong by a factor 100, such
+	// as mismatching percentages and [0...1]  values.
+	assert.Condition(func() bool { return c.UserAvg >= 0.5 }, "cpu avg is too low")
+	assert.Condition(func() bool { return c.UserAvg <= float64(n+1) }, "cpu avg is too high")
+}
+
+func TestCPUHigh(t *testing.T) {
+	doTestCPUHigh(t, 1)
+	if testing.Short() {
+		return
+	}
+	doTestCPUHigh(t, 10)
+	doTestCPUHigh(t, 100)
+}

--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -22,6 +22,7 @@ func TestCPULow(t *testing.T) {
 	runtime.GC()
 
 	c := CPU()
+	globalCurrentInfo.cacheDelay = testDuration
 	time.Sleep(testDuration)
 	c = CPU()
 	t.Logf("CPU (sleep): %v", c)
@@ -38,6 +39,7 @@ func doTestCPUHigh(t *testing.T, n int) {
 
 	done := make(chan struct{}, 1)
 	c := CPU()
+	globalCurrentInfo.cacheDelay = testDuration
 	for i := 0; i < n; i++ {
 		go func() {
 			j := 0
@@ -80,6 +82,7 @@ func TestMemLow(t *testing.T) {
 	runtime.GC()
 
 	oldM := Mem()
+	globalCurrentInfo.cacheDelay = testDuration
 	time.Sleep(testDuration)
 	m := Mem()
 	t.Logf("Mem (sleep): %v", m)
@@ -99,6 +102,7 @@ func doTestMemHigh(t *testing.T, n int) {
 	done := make(chan struct{}, 1)
 	data := make(chan []byte, 1)
 	oldM := Mem()
+	globalCurrentInfo.cacheDelay = testDuration
 	go func() {
 		a := make([]byte, n)
 		a[0] = 1

--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -2,6 +2,8 @@ package watchdog
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"runtime"
 	"testing"
@@ -130,7 +132,69 @@ func TestMemHigh(t *testing.T) {
 	doTestMemHigh(t, 1e9)
 }
 
+type testNetHandler struct {
+	t *testing.T
+}
+
+func (h *testNetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	r.Body.Close()
+	h.t.Logf("request")
+}
+
+func newTestNetServer(t *testing.T) *httptest.Server {
+	assert := assert.New(t)
+	server := httptest.NewServer(&testNetHandler{t: t})
+	assert.NotNil(server)
+	t.Logf("server on %v", server.URL)
+	return server
+}
+
+func doTestNetHigh(t *testing.T, n int) {
+	assert := assert.New(t)
+	runtime.GC()
+
+	servers := make([]*httptest.Server, n)
+	for i := range servers {
+		servers[i] = newTestNetServer(t)
+	}
+	time.Sleep(testDuration)
+	info := Net()
+	t.Logf("Net: %v", info)
+	for _, v := range servers {
+		v.Close()
+	}
+
+	// Checking that Net connections number is in a reasonnable range
+	assert.Condition(func() bool { return info.Connections >= int32(n/2) }, fmt.Sprintf("not enough connections %d < %d / 2", info.Connections, n))
+	assert.Condition(func() bool { return info.Connections <= int32(n*3) }, fmt.Sprintf("not enough connections %d > %d * 3", info.Connections, n))
+}
+
+func TestNetHigh(t *testing.T) {
+	doTestNetHigh(t, 10)
+	if testing.Short() {
+		return
+	}
+	doTestNetHigh(t, 100)
+	doTestNetHigh(t, 1000)
+}
+
+func TestNetLow(t *testing.T) {
+	assert := assert.New(t)
+	runtime.GC()
+
+	time.Sleep(testDuration)
+	info := Net()
+	t.Logf("Net: %v", info)
+
+	// Checking that Net connections number is low enough, this is theorically flaky,
+	// unless some other random GoRoutine is running, figures should remain low
+	assert.Condition(func() bool { return int32(info.Connections) <= 10 }, "over 10 connections open when we're doing nothing, way too high")
+}
+
 func BenchmarkCPU(b *testing.B) {
+	CPU()                            // make sure globalCurrentInfo exists
+	globalCurrentInfo.cacheDelay = 0 // disable cache
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -139,10 +203,22 @@ func BenchmarkCPU(b *testing.B) {
 }
 
 func BenchmarkMem(b *testing.B) {
+	Mem()                            // make sure globalCurrentInfo exists
+	globalCurrentInfo.cacheDelay = 0 // disable cache
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		_ = Mem()
+	}
+}
+
+func BenchmarkNet(b *testing.B) {
+	Net()                            // make sure globalCurrentInfo exists
+	globalCurrentInfo.cacheDelay = 0 // disable cache
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = Net()
 	}
 }
 

--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -86,7 +86,7 @@ func TestMemLow(t *testing.T) {
 	// unless some other random GoRoutine is running, figures should remain low
 	assert.Condition(func() bool { return int64(m.Alloc)-int64(oldM.Alloc) <= 1e4 }, "over 10 Kb allocated since last call, way to high for almost no operation")
 	assert.Condition(func() bool { return m.Alloc <= 1e8 }, "over 100 Mb allocated, way to high for almost no operation")
-	assert.Condition(func() bool { return m.AllocPerSec >= 0.5 }, "allocs per sec should be positive")
+	assert.Condition(func() bool { return m.AllocPerSec >= 0.0 }, "allocs per sec should be positive")
 	assert.Condition(func() bool { return m.AllocPerSec <= 1e5 }, "over 100 Kb allocated per sec, way too high for a program doing nothing")
 }
 
@@ -116,7 +116,7 @@ func doTestMemHigh(t *testing.T, n int) {
 	assert.Condition(func() bool { return m.Alloc >= uint64(n) }, "not enough bytes allocated")
 	assert.Condition(func() bool { return int64(m.Alloc)-int64(oldM.Alloc) >= int64(n) }, "not enough bytes allocated since last call")
 	expectedAllocPerSec := float64(n) * float64(time.Second) / (float64(testDuration))
-	assert.Condition(func() bool { return m.AllocPerSec >= 0.5*expectedAllocPerSec }, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
+	assert.Condition(func() bool { return m.AllocPerSec >= 0.1*expectedAllocPerSec }, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
 	assert.Condition(func() bool { return m.AllocPerSec <= 1.5*expectedAllocPerSec }, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
 	<-data
 }

--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -89,10 +89,10 @@ func TestMemLow(t *testing.T) {
 
 	// Checking that Mem is low enough, this is theorically flaky,
 	// unless some other random GoRoutine is running, figures should remain low
-	assert.Condition(func() bool { return int64(m.Alloc)-int64(oldM.Alloc) <= 1e4 }, "over 10 Kb allocated since last call, way to high for almost no operation")
-	assert.Condition(func() bool { return m.Alloc <= 1e8 }, "over 100 Mb allocated, way to high for almost no operation")
-	assert.Condition(func() bool { return m.AllocPerSec >= 0.0 }, "allocs per sec should be positive")
-	assert.Condition(func() bool { return m.AllocPerSec <= 1e5 }, "over 100 Kb allocated per sec, way too high for a program doing nothing")
+	assert.True(int64(m.Alloc)-int64(oldM.Alloc) <= 1e4, "over 10 Kb allocated since last call, way to high for almost no operation")
+	assert.True(m.Alloc <= 1e8, "over 100 Mb allocated, way to high for almost no operation")
+	assert.True(m.AllocPerSec >= 0.0, "allocs per sec should be positive")
+	assert.True(m.AllocPerSec <= 1e5, "over 100 Kb allocated per sec, way too high for a program doing nothing")
 }
 
 func doTestMemHigh(t *testing.T, n int) {
@@ -119,11 +119,11 @@ func doTestMemHigh(t *testing.T, n int) {
 	t.Logf("Mem (%d bytes): %v", n, m)
 
 	// Checking that Mem is high enough
-	assert.Condition(func() bool { return m.Alloc >= uint64(n) }, "not enough bytes allocated")
-	assert.Condition(func() bool { return int64(m.Alloc)-int64(oldM.Alloc) >= int64(n) }, "not enough bytes allocated since last call")
+	assert.True(m.Alloc >= uint64(n), "not enough bytes allocated")
+	assert.True(int64(m.Alloc)-int64(oldM.Alloc) >= int64(n), "not enough bytes allocated since last call")
 	expectedAllocPerSec := float64(n) * float64(time.Second) / (float64(testDuration))
-	assert.Condition(func() bool { return m.AllocPerSec >= 0.1*expectedAllocPerSec }, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
-	assert.Condition(func() bool { return m.AllocPerSec <= 1.5*expectedAllocPerSec }, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
+	assert.True(m.AllocPerSec >= 0.1*expectedAllocPerSec, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
+	assert.True(m.AllocPerSec <= 1.5*expectedAllocPerSec, fmt.Sprintf("not enough bytes allocated per second, expected %f", expectedAllocPerSec))
 	<-data
 }
 
@@ -170,8 +170,8 @@ func doTestNetHigh(t *testing.T, n int) {
 	}
 
 	// Checking that Net connections number is in a reasonnable range
-	assert.Condition(func() bool { return info.Connections >= int32(n/2) }, fmt.Sprintf("not enough connections %d < %d / 2", info.Connections, n))
-	assert.Condition(func() bool { return info.Connections <= int32(n*3) }, fmt.Sprintf("not enough connections %d > %d * 3", info.Connections, n))
+	assert.True(info.Connections >= int32(n/2), fmt.Sprintf("not enough connections %d < %d / 2", info.Connections, n))
+	assert.True(info.Connections <= int32(n*3), fmt.Sprintf("not enough connections %d > %d * 3", info.Connections, n))
 }
 
 func TestNetHigh(t *testing.T) {
@@ -193,7 +193,7 @@ func TestNetLow(t *testing.T) {
 
 	// Checking that Net connections number is low enough, this is theorically flaky,
 	// unless some other random GoRoutine is running, figures should remain low
-	assert.Condition(func() bool { return int32(info.Connections) <= 10 }, "over 10 connections open when we're doing nothing, way too high")
+	assert.True(int32(info.Connections) <= 10, "over 10 connections open when we're doing nothing, way too high")
 }
 
 func BenchmarkCPU(b *testing.B) {


### PR DESCRIPTION
Basic funcs returning:
* CPU usage (value between 0 and number of CPU, 0.3 means 30% of one CPU)
* Mem usage (currently allocated bytes from the point of view of the Go memory manager)
* Byte allocation rate (bytes allocated per second)
* Number of TCP Connections

