### PR TITLE
change the redis resource format

### DIFF
--- a/quantizer/redis_test.go
+++ b/quantizer/redis_test.go
@@ -46,10 +46,10 @@ func TestRedisQuantizer(t *testing.T) {
 			"MSET"},
 
 		{"MULTI\nSET k1 v1\nSET k2 v2\nSET k3 v3\nSET k4 v4\nDEL to_del\nEXEC",
-			"MULTI SET* DEL ..."},
+			"MULTI SET SET ..."},
 
 		{"DEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"\nDEL k1\nDEL k2\nHMSET k1 \"a\" 1 \"b\" 2 \"c\" 3\nHMSET k2 \"d\" \"4\" \"e\" \"4\"\nDEL k3\nHMSET k3 \"f\" \"5\"",
-			"DEL* HMSET* DEL ..."},
+			"DEL DEL HMSET ..."},
 
 		{"GET...",
 			"..."},
@@ -58,13 +58,13 @@ func TestRedisQuantizer(t *testing.T) {
 			"GET"},
 
 		{"GET k1\nGET k2\nG...",
-			"GET* ..."},
+			"GET GET ..."},
 
 		{"GET k1\nGET k2\nDEL k3\nGET k...",
-			"GET* DEL GET ..."},
+			"GET GET DEL ..."},
 
 		{"GET k1\nGET k2\nHDEL k3 a\nG...",
-			"GET* HDEL ..."},
+			"GET GET HDEL ..."},
 
 		{"GET k...\nDEL k2\nMS...",
 			"GET DEL ..."},
@@ -73,10 +73,10 @@ func TestRedisQuantizer(t *testing.T) {
 			"GET ..."},
 
 		{"GET k1\nDE...\nGET k2",
-			"GET*"},
+			"GET GET"},
 
 		{"GET k1\nDE...\nGET k2\nHDEL k3 a\nGET k4\nDEL k5",
-			"GET* HDEL GET ..."},
+			"GET GET HDEL ..."},
 	}
 
 	for _, testCase := range queryToExpected {


### PR DESCRIPTION
We remove the '*' mark for duplicate commands in a pipeline.

Before:
BenchmarkTestRedisQuantizer-4  1000000  2228 ns/op  1012 B/op  8 allocs/op

After:
BenchmarkTestRedisQuantizer-4  1000000  2045 ns/op   996 B/op  7 allocs/op