### PR TITLE
[decoder] graceful accept uint64 values if they're sent as int64 for ids

### DIFF
--- a/model/span_gen.go
+++ b/model/span_gen.go
@@ -57,7 +57,7 @@ func (z *Span) DecodeMsg(dc *msgp.Reader) (err error) {
 				break
 			}
 
-			z.TraceID, err = dc.ReadUint64()
+			z.TraceID, err = parseUint64(dc)
 			if err != nil {
 				return
 			}
@@ -67,7 +67,7 @@ func (z *Span) DecodeMsg(dc *msgp.Reader) (err error) {
 				break
 			}
 
-			z.SpanID, err = dc.ReadUint64()
+			z.SpanID, err = parseUint64(dc)
 			if err != nil {
 				return
 			}
@@ -171,7 +171,7 @@ func (z *Span) DecodeMsg(dc *msgp.Reader) (err error) {
 				break
 			}
 
-			z.ParentID, err = dc.ReadUint64()
+			z.ParentID, err = parseUint64(dc)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
### What it does

In JRuby interpreter, unsigned int are sent as ``int`` type (Java related type system). This patch will handle IDs so that they're cast from ``int`` to ``uint``.