### PR TITLE
fix panic when exiting

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -90,8 +90,9 @@ func (a *Agent) Run() {
 		case <-a.exit:
 			log.Info("exiting")
 			close(a.Receiver.exit)
-			close(a.Writer.exit)
+			a.Writer.Stop()
 			a.Sampler.Stop()
+			return
 		}
 	}
 }


### PR DESCRIPTION
3ee25af22bb2597cd505c2ed389664eb1e9949ed introduced a bug by not exiting the main loop after closing the
exit chan. Therefore the program panics when close is called a second
time.

We also use (*Writer).Stop() since it exists.