### PR TITLE
[profile] using BestSpeed GZIP compression

### DIFF
--- a/agent/endpoint_test.go
+++ b/agent/endpoint_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/model"
-	// "github.com/stretchr/testify/assert"
 )
 
 func newBenchPayload(traces, spans, stats int) model.AgentPayload {
@@ -33,13 +32,11 @@ func newBenchPayload(traces, spans, stats int) model.AgentPayload {
 
 func BenchmarkEncodeAgentPayload(b *testing.B) {
 	payload := newBenchPayload(10, 1000, 100)
-	var err error
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err = model.EncodeAgentPayload(payload)
-		if err != nil {
+		if _, err := model.EncodeAgentPayload(payload); err != nil {
 			b.Fatalf("error encoding payload: %v", b)
 		}
 	}

--- a/agent/endpoint_test.go
+++ b/agent/endpoint_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/model"
+	// "github.com/stretchr/testify/assert"
+)
+
+func newBenchPayload(traces, spans, stats int) model.AgentPayload {
+	payload := model.AgentPayload{
+		HostName: "test.host",
+		Env:      "test",
+	}
+	for i := 0; i < traces; i++ {
+		var trace model.Trace
+		for j := 0; j < spans/traces; j++ {
+			span := fixtures.TestSpan()
+			span.TraceID += uint64(i * spans)
+			span.ParentID += uint64(i * spans)
+			span.SpanID += uint64(i*spans + j)
+			span.Start += int64(i*spans + j)
+			trace = append(trace, span)
+		}
+		payload.Traces = append(payload.Traces, trace)
+	}
+	for i := 0; i < stats; i++ {
+		payload.Stats = append(payload.Stats, fixtures.TestStatsBucket())
+	}
+	return payload
+}
+
+func BenchmarkEncodeAgentPayload(b *testing.B) {
+	payload := newBenchPayload(10, 1000, 100)
+	var err error
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err = model.EncodeAgentPayload(payload)
+		if err != nil {
+			b.Fatalf("error encoding payload: %v", b)
+		}
+	}
+}

--- a/model/payload.go
+++ b/model/payload.go
@@ -47,7 +47,10 @@ func EncodeAgentPayload(p AgentPayload) ([]byte, error) {
 
 	switch GlobalAgentPayloadVersion {
 	case AgentPayloadV01:
-		gz := gzip.NewWriter(&b)
+		gz, err := gzip.NewWriterLevel(&b, gzip.BestSpeed)
+		if err != nil {
+			return nil, err
+		}
 		err = json.NewEncoder(gz).Encode(p)
 		gz.Close()
 	default:


### PR DESCRIPTION
Using fastest compression saves about 10% CPU cycles but OTOH produces 10% more data. Obviously depends on the data.