### PR TITLE
[ci] run go test -bench on Circle CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ agent/agent
 coverage.out
 prof*
 *test
+gobench

--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,16 @@ task :test do
   PACKAGES.each { |pkg| go_test(pkg) }
 end
 
+desc "Bench Datadog Trace agent"
+task :bench do
+  sh "install -d ./gobench"
+  rev = `git rev-parse --short HEAD`.strip
+  PACKAGES.each { |pkg|
+    name = pkg.gsub(/[\.\/]/, '')
+    go_bench(pkg, "./gobench/trace-agent-#{rev}-#{name}-gobench.txt")
+  }
+end
+
 desc "Run Datadog Trace agent"
 task :run do
   sh "./trace-agent -debug -config ./agent/trace-agent.ini"
@@ -79,9 +89,8 @@ task :fmt do
   PACKAGES.each { |pkg| go_fmt(pkg) }
 end
 
-# FIXME: add :test in the list
 desc "Datadog Trace agent CI script (fmt, vet, etc)"
-task :ci => [:fmt, :vet, :lint, :test, :build]
+task :ci => [:fmt, :vet, :lint, :test, :build, :bench]
 
 task :err do
   sh "errcheck github.com/DataDog/datadog-trace-agent"

--- a/circle.yml
+++ b/circle.yml
@@ -22,3 +22,7 @@ dependencies:
 test:
   override:
     - rake ci
+
+general:
+  artifacts:
+    - gobench

--- a/gorake.rb
+++ b/gorake.rb
@@ -52,6 +52,10 @@ def go_test(path)
   sh "go test #{path}"
 end
 
+def go_bench(path, output)
+  sh "go test -run=NONE -bench . -benchtime=3s #{path} > #{output}"
+end
+
 # return the dependencies of all the packages who start with the root path
 def go_pkg_deps(pkgs, root_path)
   deps = []
@@ -74,4 +78,3 @@ def go_fmt(path)
     fail
   end
 end
-


### PR DESCRIPTION
Simply run our aleady written go benchmarks and store the artifacts on CircleCI