### PR TITLE
fix signal handling to avoid closing the exit chan twice

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -22,12 +22,15 @@ import (
 // handleSignal closes a channel to exit cleanly from routines
 func handleSignal(exit chan struct{}) {
 	sigChan := make(chan os.Signal, 10)
-	signal.Notify(sigChan)
-	for signal := range sigChan {
-		switch signal {
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	for signo := range sigChan {
+		switch signo {
 		case syscall.SIGINT, syscall.SIGTERM:
-			log.Info("received interruption signal")
+			log.Infof("received signal %d (%v)", signo, signo)
 			close(exit)
+			return
+		default:
+			log.Warnf("unhandled signal %d (%v)", signo, signo)
 		}
 	}
 }


### PR DESCRIPTION
- It's possible to receive more than one SIGINT/SIGTERM during the
shutdown process. So we return after closing the exit chan to avoid
panicking when closing it a second time.
- Only request notification for SIGINT/SIGTERM since these are the only
ones we handle.