### PR TITLE
config: exit 0 if Datadog APM is not enabled explicitly

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -81,7 +81,6 @@ func main() {
 	// command-line arguments
 	flag.StringVar(&opts.ddConfigFile, "ddconfig", "/etc/dd-agent/datadog.conf", "Classic agent config file location")
 	// FIXME: merge all APM configuration into dd-agent/datadog.conf and deprecate the below flag
-	flag.StringVar(&opts.configFile, "config", "/etc/datadog/trace-agent.ini", "Trace agent ini config file.")
 	flag.BoolVar(&opts.debug, "debug", false, "Turn on debug mode")
 	flag.BoolVar(&opts.version, "version", false, "Show version information and exit")
 
@@ -117,6 +116,11 @@ func main() {
 	agentConf, err = config.NewAgentConfig(conf, legacyConf)
 	if err != nil {
 		panic(err)
+	}
+
+	// Exit if tracing is not enabled
+	if !agentConf.Enabled {
+		os.Exit(0)
 	}
 
 	// Initialize logging

--- a/agent/main.go
+++ b/agent/main.go
@@ -121,6 +121,10 @@ func main() {
 
 	// Exit if tracing is not enabled
 	if !agentConf.Enabled {
+		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
+		// If the exit is "too quick", we enter a BACKOFF->FATAL loop even though this is an expected exit
+		// http://supervisord.org/subprocess.html#process-states
+		time.Sleep(5 * time.Second)
 		os.Exit(0)
 	}
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -81,6 +81,7 @@ func main() {
 	// command-line arguments
 	flag.StringVar(&opts.ddConfigFile, "ddconfig", "/etc/dd-agent/datadog.conf", "Classic agent config file location")
 	// FIXME: merge all APM configuration into dd-agent/datadog.conf and deprecate the below flag
+	flag.StringVar(&opts.configFile, "config", "/etc/datadog/trace-agent.ini", "Trace agent ini config file.")
 	flag.BoolVar(&opts.debug, "debug", false, "Turn on debug mode")
 	flag.BoolVar(&opts.version, "version", false, "Show version information and exit")
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -78,8 +78,7 @@ func versionString() string {
 
 const agentDisabledMessage = `trace-agent not enabled.
 Set env var DD_APM_ENABLED=true or add
-[trace.config]
-enabled: true
+apm_enabled: true
 to your datadog.conf file.
 Exiting.`
 

--- a/config/agent.go
+++ b/config/agent.go
@@ -180,7 +180,7 @@ APM_CONF:
 		goto ENV_CONF
 	}
 
-	if v, _ := conf.Get("trace.config", "enabled"); v == "true" {
+	if v, _ := conf.Get("Main", "apm_enabled"); v == "true" {
 		c.Enabled = true
 	}
 

--- a/config/agent.go
+++ b/config/agent.go
@@ -15,6 +15,8 @@ import (
 // behaviors) is one place. It is also a simple structure to share across all
 // the Agent components, with 100% safe and reliable values.
 type AgentConfig struct {
+	Enabled bool
+
 	// Global
 	HostName   string
 	DefaultEnv string // the traces will default to this environment
@@ -50,6 +52,10 @@ type AgentConfig struct {
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
 func mergeEnv(c *AgentConfig) {
+	if v := os.Getenv("DD_APM_ENABLED"); v == "true" {
+		c.Enabled = true
+	}
+
 	if v := os.Getenv("DD_HOSTNAME"); v != "" {
 		c.HostName = v
 	}
@@ -172,6 +178,10 @@ APM_CONF:
 
 	if conf == nil {
 		goto ENV_CONF
+	}
+
+	if v, _ := conf.Get("trace.config", "enabled"); v != "" {
+		c.Enabled = v
 	}
 
 	if v, _ := conf.Get("trace.config", "env"); v != "" {

--- a/config/agent.go
+++ b/config/agent.go
@@ -180,8 +180,8 @@ APM_CONF:
 		goto ENV_CONF
 	}
 
-	if v, _ := conf.Get("trace.config", "enabled"); v != "" {
-		c.Enabled = v
+	if v, _ := conf.Get("trace.config", "enabled"); v == "true" {
+		c.Enabled = true
 	}
 
 	if v, _ := conf.Get("trace.config", "env"); v != "" {


### PR DESCRIPTION
This makes the trace-agent an opt-in process, and is important for hosts
that see an unattended upgrade to datadog-agent@5.11.0 (which will be several)
but don't actually intend to submit to the trace-agent