### PR TITLE
log errors when loading configuration files

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -120,10 +120,25 @@ func main() {
 	var agentConf *config.AgentConfig
 	var err error
 
-	// tolerate errors in reading the config files. some setups will use only environment variables
-	// which is OK
-	legacyConf, _ := config.New(opts.configFile)
-	conf, _ := config.New(opts.ddConfigFile)
+	// if a configuration file cannot be loaded, log an error but do not
+	// panic since the agent can be configured with environment variables
+	// only.
+	legacyConf, err := config.NewIfExists(opts.configFile)
+	if err != nil {
+		log.Errorf("%s: %v", opts.configFile, err)
+	}
+	if legacyConf != nil {
+		log.Infof("using legacy configuration from %s", opts.configFile)
+	}
+
+	conf, err := config.NewIfExists(opts.ddConfigFile)
+	if err != nil {
+		log.Errorf("%s: %v", opts.ddConfigFile, err)
+	}
+	if conf != nil {
+		log.Infof("using configuration from %s", opts.ddConfigFile)
+	}
+
 	agentConf, err = config.NewAgentConfig(conf, legacyConf)
 	if err != nil {
 		panic(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -130,3 +130,22 @@ func TestDDAgentConfigWithNewOpts(t *testing.T) {
 	assert.Equal([]string{"resource", "error"}, agentConfig.ExtraAggregators)
 	assert.Equal(0.33, agentConfig.ExtraSampleRate)
 }
+
+func TestConfigNewIfExists(t *testing.T) {
+	// The file does not exist: no error returned
+	conf, err := NewIfExists("/does-not-exist")
+	assert.Nil(t, err)
+	assert.Nil(t, conf)
+
+	// The file exists but cannot be read for another reason: an error is
+	// returned.
+	filename := "/tmp/trace-agent-test-config.ini"
+	os.Remove(filename)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0200) // write only
+	assert.Nil(t, err)
+	f.Close()
+	conf, err = NewIfExists(filename)
+	assert.NotNil(t, err)
+	assert.Nil(t, conf)
+	os.Remove(filename)
+}


### PR DESCRIPTION
- Do not wrap the error when loading fails, so that we can test it.
- Log loading errors unless it's an ENOENT error.
- Log the fact that we are using a configuration file.