### PR TITLE
support 'false' for DD_APM_ENABLED

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -54,6 +54,8 @@ type AgentConfig struct {
 func mergeEnv(c *AgentConfig) {
 	if v := os.Getenv("DD_APM_ENABLED"); v == "true" {
 		c.Enabled = true
+	} else if v == "false" {
+		c.Enabled = false
 	}
 
 	if v := os.Getenv("DD_HOSTNAME"); v != "" {


### PR DESCRIPTION
It should be usable to override the configuration file, both to enable
and disable the trace agent.