### PR TITLE
[decoder] big buffers are discarded

### DIFF
--- a/model/client_api.go
+++ b/model/client_api.go
@@ -14,7 +14,7 @@ import (
 // the resize operation is not usually called while reading the response.
 const (
 	minBufferSize = 512
-	maxBufferSize = 10485760
+	maxBufferSize = 1e7
 )
 
 // readAll reads from source until an error or EOF and writes to dest;

--- a/model/client_api_test.go
+++ b/model/client_api_test.go
@@ -197,3 +197,17 @@ func TestPoolBorrowSize(t *testing.T) {
 	check := pool.Borrow("application/msgpack")
 	assert.Equal(check, decoder)
 }
+
+func TestPoolReleaseSizeMax(t *testing.T) {
+	assert := assert.New(t)
+	pool := NewDecoderPool(1)
+	decoder := newMsgpackDecoder()
+
+	// replace the internal buffer with a big one
+	decoder.buf = bytes.NewBuffer(make([]byte, 1, maxBufferSize+1))
+
+	// a decoder is discarded and not reused when the buffer size is too big
+	pool.Release(decoder)
+	anotherDecoder := pool.Borrow("application/msgpack")
+	assert.NotEqual(anotherDecoder, decoder)
+}


### PR DESCRIPTION
### What it does

Prevent to keep really big buffers if clients are sending too much data. Currently we're dropping buffers bigger than 10MB

#### To bear in mind

* if the clients are sending the same huge payload (so the average is bigger than 10MB), the decoder will be created over and over increasing the CPU usage.