### PR TITLE
fix http response statuses

### DIFF
--- a/agent/receiver_responses.go
+++ b/agent/receiver_responses.go
@@ -11,21 +11,21 @@ import (
 func HTTPFormatError(tags []string, w http.ResponseWriter) {
 	tags = append(tags, "error:format-error")
 	statsd.Client.Count("datadog.trace_agent.receiver.error", 1, tags, 1)
-	http.Error(w, "format-error", 415)
+	http.Error(w, "format-error", http.StatusUnsupportedMediaType)
 }
 
 // HTTPDecodingError is used for errors happening in decoding
 func HTTPDecodingError(tags []string, w http.ResponseWriter) {
 	tags = append(tags, "error:decoding-error")
 	statsd.Client.Count("datadog.trace_agent.receiver.error", 1, tags, 1)
-	http.Error(w, "decoding-error", 500)
+	http.Error(w, "decoding-error", http.StatusBadRequest)
 }
 
 // HTTPEndpointNotSupported is for payloads getting sent to a wrong endpoint
 func HTTPEndpointNotSupported(tags []string, w http.ResponseWriter) {
 	tags = append(tags, "error:unsupported-endpoint")
 	statsd.Client.Count("datadog.trace_agent.receiver.error", 1, tags, 1)
-	http.Error(w, "unsupported-endpoint", 500)
+	http.Error(w, "unsupported-endpoint", http.StatusInternalServerError)
 }
 
 // HTTPOK is a dumb response for when things are a OK


### PR DESCRIPTION
- Use status code constants.
- Return a 400 error (bad request) instead of a 500 (internal server
  error) for decoding errors.