### PR TITLE
do not truncate when logging why a trace could not be normalized

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,7 @@ end
 
 desc "Run Datadog Trace agent"
 task :run do
-  sh "./trace-agent -debug -config ./agent/trace-agent.ini"
+  sh "./trace-agent -config ./agent/trace-agent.ini"
 end
 
 desc "Build deb from current agent source"

--- a/agent/main.go
+++ b/agent/main.go
@@ -39,7 +39,6 @@ func handleSignal(exit chan struct{}) {
 var opts struct {
 	ddConfigFile string
 	configFile   string
-	debug        bool
 	logLevel     string
 	version      bool
 }
@@ -92,7 +91,6 @@ func main() {
 	flag.StringVar(&opts.ddConfigFile, "ddconfig", "/etc/dd-agent/datadog.conf", "Classic agent config file location")
 	// FIXME: merge all APM configuration into dd-agent/datadog.conf and deprecate the below flag
 	flag.StringVar(&opts.configFile, "config", "/etc/datadog/trace-agent.ini", "Trace agent ini config file.")
-	flag.BoolVar(&opts.debug, "debug", false, "Turn on debug mode")
 	flag.BoolVar(&opts.version, "version", false, "Show version information and exit")
 
 	// profiling arguments
@@ -155,14 +153,8 @@ func main() {
 		return
 	}
 
-	// Initialize logging
-	level := agentConf.LogLevel
-	if opts.debug {
-		level = "debug"
-	}
-
-	// replace the default logger
-	err = config.NewLoggerLevelCustom(level, agentConf.LogFilePath)
+	// Initialize logging (replacing the default logger)
+	err = config.NewLoggerLevelCustom(agentConf.LogLevel, agentConf.LogFilePath)
 	if err != nil {
 		panic(fmt.Errorf("error with logger: %v", err))
 	}

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -55,6 +55,7 @@ type HTTPReceiver struct {
 	exit chan struct{}
 
 	maxRequestBodyLength int64
+	debug                bool
 }
 
 // NewHTTPReceiver returns a pointer to a new HTTPReceiver
@@ -69,6 +70,7 @@ func NewHTTPReceiver(conf *config.AgentConfig) *HTTPReceiver {
 		exit:        make(chan struct{}),
 
 		maxRequestBodyLength: maxRequestBodyLength,
+		debug:                strings.ToLower(conf.LogLevel) == "debug",
 	}
 }
 
@@ -201,9 +203,8 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 			atomic.AddInt64(&r.stats.TracesDropped, 1)
 			atomic.AddInt64(&r.stats.SpansDropped, int64(spans))
 
-			// this is a potentially very spammy log message, so extra care
 			errorMsg := fmt.Sprintf("dropping trace reason: %s (debug for more info), %v", err, normTrace)
-			if len(errorMsg) > 150 {
+			if len(errorMsg) > 150 && r.debug {
 				errorMsg = errorMsg[:150] + "..."
 			}
 			r.logger.Errorf(errorMsg)


### PR DESCRIPTION
Also remove the -debug flag as we discussed.