### PR TITLE
receiver: set a WriteTimeout, and avoid blocking on a full channel

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -219,7 +219,7 @@ func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *ht
 			select {
 			case r.traces <- normTrace:
 			default:
-			    r.logger.Errorf(fmt.Sprintf("dropping trace reason: rate-limited")
+				r.logger.Errorf("dropping trace reason: rate-limited")
 			}
 		}
 

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -102,7 +102,10 @@ func (r *HTTPReceiver) Run() {
 	if r.conf.ReceiverTimeout > 0 {
 		timeout = r.conf.ReceiverTimeout
 	}
-	server := http.Server{ReadTimeout: time.Second * time.Duration(timeout)}
+	server := http.Server{
+		ReadTimeout:  time.Second * time.Duration(timeout),
+		WriteTimeout: time.Second * time.Duration(timeout),
+	}
 
 	go r.logStats()
 	go sl.Refresh(r.conf.ConnectionLimit)


### PR DESCRIPTION
These changes are in response to a situation where we leaked file descriptors on a high-throughput node,
eventually hitting kernel limits and being unable to accept new traces

It's likely that we were unable to close `request.Body` and release our connection, due to blocking
in the main HTTP loop. To avoid this we:

- set a WriteTimeout on the server, defaulting to 5 seconds, and configurable via `receiver_timeout`
- drop traces on the floor when we can't write them to the outbound `traces` channel