### PR TITLE
sql: quantize as aliases.

### DIFF
--- a/quantizer/main.go
+++ b/quantizer/main.go
@@ -2,7 +2,6 @@ package quantizer
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/model"
 )
@@ -25,26 +24,14 @@ type QuantizeFunction func(model.Span) model.Span
 func Quantize(span model.Span) model.Span {
 	switch span.Type {
 	case sqlType:
-		fallthrough
+		return QuantizeSQL(span)
 	case cassandraType:
 		return QuantizeSQL(span)
-
 	case redisType:
 		return QuantizeRedis(span)
-
 	default:
 		return span
 	}
-}
-
-// compactAllSpaces transforms any sequence of space-like characters (including line breaks) into a single standard space
-// Also right trims spaces.
-func compactAllSpaces(text string) string {
-	return compactAllSpacesWithoutRegexp(text)
-}
-
-func compactAllSpacesWithRegexp(text string) string {
-	return strings.Trim(nonUniformSpacesRegexp.ReplaceAllString(text, " "), " ")
 }
 
 func isGenericSpace(char uint8) bool {
@@ -55,7 +42,9 @@ func isWhitespace(char uint8) bool {
 	return char == spaceCode
 }
 
-func compactAllSpacesWithoutRegexp(t string) string {
+// compactAllSpaces transforms any sequence of space-like characters (including line breaks) into a single standard space
+// Also right trims spaces.
+func compactAllSpaces(t string) string {
 	// Algorithm:
 	//  - Iterate over the input string (of length n), char by char (cursor `i`), looking for spaces
 	//  - When a spaces if found:

--- a/quantizer/main_test.go
+++ b/quantizer/main_test.go
@@ -51,21 +51,12 @@ func TestCompactAllSpaces(t *testing.T) {
 	}
 
 	for _, testCase := range resultsToExpect {
-		assert.Equal(testCase.after, compactAllSpacesWithRegexp(testCase.before))
-	}
-	for _, testCase := range resultsToExpect {
-		assert.Equal(testCase.after, compactAllSpacesWithoutRegexp(testCase.before))
+		assert.Equal(testCase.after, compactAllSpaces(testCase.before))
 	}
 }
 
 func BenchmarkCompactAllSpacesWithRegexp(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-		compactAllSpacesWithRegexp("SELECT org_id,metric_key \n		FROM metrics_metadata \n		WHERE org_id = %(org_id)s 	AND 	metric_key = ANY(array[21, 25, 32])")
-	}
-}
-
-func BenchmarkCompactAllSpacesWithoutRegexp(b *testing.B) {
-	for n := 0; n < b.N; n++ {
-		compactAllSpacesWithoutRegexp("SELECT org_id,metric_key \n		FROM metrics_metadata \n		WHERE org_id = %(org_id)s 	AND 	metric_key = ANY(array[21, 25, 32])")
+		compactAllSpaces("SELECT org_id,metric_key \n		FROM metrics_metadata \n		WHERE org_id = %(org_id)s 	AND 	metric_key = ANY(array[21, 25, 32])")
 	}
 }

--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -51,6 +51,8 @@ func (f *ReplaceFilter) Filter(token, lastToken int, buffer []byte) (int, []byte
 		return Filtered, []byte("?")
 	case Limit:
 		return token, buffer
+	case As:
+		return token, []byte("?")
 	}
 
 	switch token {

--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -29,7 +29,18 @@ type DiscardFilter struct{}
 // Filter the given token so that a `nil` slice is returned if the token
 // is in the token filtered list.
 func (f *DiscardFilter) Filter(token, lastToken int, buffer []byte) (int, []byte) {
+	// filters based on previous token
+	switch lastToken {
+	case As:
+		// prevent the next comma from being part of a GroupingFilter
+		return FilteredComma, nil
+	}
+
+	// filters based on the current token; if the next token should be ignored,
+	// return the same token value (not Filtered) and nil
 	switch token {
+	case As:
+		return As, nil
 	case Comment, ';':
 		return Filtered, nil
 	default:
@@ -51,8 +62,6 @@ func (f *ReplaceFilter) Filter(token, lastToken int, buffer []byte) (int, []byte
 		return Filtered, []byte("?")
 	case Limit:
 		return token, buffer
-	case As:
-		return token, []byte("?")
 	}
 
 	switch token {

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -138,7 +138,7 @@ func TestSQLQuantizer(t *testing.T) {
 			"UPDATE user_dash_pref SET json_prefs = ? modified = ? WHERE user_id = ? AND url = ?"},
 		{
 			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
-			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",
+			"SELECT DISTINCT host.id AS ? FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",
 		},
 		{
 			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = %(org_id)s AND metric_key = ANY(array[75])",
@@ -186,7 +186,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT date(created_at) as ordered_date, sum(price) as total_price FROM orders GROUP BY date(created_at) HAVING sum(price) > 100",
-			"SELECT date ( created_at ) as ordered_date, sum ( price ) as total_price FROM orders GROUP BY date ( created_at ) HAVING sum ( price ) > ?",
+			"SELECT date ( created_at ) AS ?, sum ( price ) AS ? FROM orders GROUP BY date ( created_at ) HAVING sum ( price ) > ?",
 		},
 		{
 			"SELECT * FROM articles WHERE id > 10 ORDER BY id asc LIMIT 20",
@@ -222,7 +222,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT server_table.host AS host_id FROM table#.host_tags as server_table WHERE server_table.host_id = 50",
-			"SELECT server_table.host AS host_id FROM table#.host_tags as server_table WHERE server_table.host_id = ?",
+			"SELECT server_table.host AS ? FROM table#.host_tags AS ? WHERE server_table.host_id = ?",
 		},
 		{
 			`INSERT INTO delayed_jobs (attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at) VALUES (0, '2016-12-04 17:09:59', NULL, '--- !ruby/object:Delayed::PerformableMethod\nobject: !ruby/object:Item\n  store:\n  - a simple string\n  - an \'escaped \' string\n  - another \'escaped\' string\n  - 42\n  string: a string with many \\\\\'escapes\\\\\'\nmethod_name: :show_store\nargs: []\n', NULL, NULL, NULL, 0, NULL, '2016-12-04 17:09:59', '2016-12-04 17:09:59')`,
@@ -243,6 +243,10 @@ func TestSQLQuantizer(t *testing.T) {
 		{
 			"SELECT * FROM public.table ( array [ ROW ( array [ 'magic', 'foo',",
 			"SELECT * FROM public.table ( array [ ROW ( array [ ?",
+		},
+		{
+			"SELECT pg_try_advisory_lock (123) AS t46eef3f025cc27feb31ca5a2d668a09a",
+			"SELECT pg_try_advisory_lock ( ? ) AS ?",
 		},
 	}
 

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -138,7 +138,7 @@ func TestSQLQuantizer(t *testing.T) {
 			"UPDATE user_dash_pref SET json_prefs = ? modified = ? WHERE user_id = ? AND url = ?"},
 		{
 			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
-			"SELECT DISTINCT host.id AS ? FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",
+			"SELECT DISTINCT host.id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",
 		},
 		{
 			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = %(org_id)s AND metric_key = ANY(array[75])",
@@ -186,7 +186,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT date(created_at) as ordered_date, sum(price) as total_price FROM orders GROUP BY date(created_at) HAVING sum(price) > 100",
-			"SELECT date ( created_at ) AS ?, sum ( price ) AS ? FROM orders GROUP BY date ( created_at ) HAVING sum ( price ) > ?",
+			"SELECT date ( created_at ), sum ( price ) FROM orders GROUP BY date ( created_at ) HAVING sum ( price ) > ?",
 		},
 		{
 			"SELECT * FROM articles WHERE id > 10 ORDER BY id asc LIMIT 20",
@@ -222,7 +222,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT server_table.host AS host_id FROM table#.host_tags as server_table WHERE server_table.host_id = 50",
-			"SELECT server_table.host AS ? FROM table#.host_tags AS ? WHERE server_table.host_id = ?",
+			"SELECT server_table.host FROM table#.host_tags WHERE server_table.host_id = ?",
 		},
 		{
 			`INSERT INTO delayed_jobs (attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at) VALUES (0, '2016-12-04 17:09:59', NULL, '--- !ruby/object:Delayed::PerformableMethod\nobject: !ruby/object:Item\n  store:\n  - a simple string\n  - an \'escaped \' string\n  - another \'escaped\' string\n  - 42\n  string: a string with many \\\\\'escapes\\\\\'\nmethod_name: :show_store\nargs: []\n', NULL, NULL, NULL, 0, NULL, '2016-12-04 17:09:59', '2016-12-04 17:09:59')`,
@@ -238,7 +238,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"CREATE FUNCTION add(integer, integer) RETURNS integer\n AS 'select $1 + $2;'\n LANGUAGE SQL\n IMMUTABLE\n RETURNS NULL ON NULL INPUT;",
-			"CREATE FUNCTION add ( integer, integer ) RETURNS integer AS ? LANGUAGE SQL IMMUTABLE RETURNS ? ON ? INPUT",
+			"CREATE FUNCTION add ( integer, integer ) RETURNS integer LANGUAGE SQL IMMUTABLE RETURNS ? ON ? INPUT",
 		},
 		{
 			"SELECT * FROM public.table ( array [ ROW ( array [ 'magic', 'foo',",
@@ -246,7 +246,7 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT pg_try_advisory_lock (123) AS t46eef3f025cc27feb31ca5a2d668a09a",
-			"SELECT pg_try_advisory_lock ( ? ) AS ?",
+			"SELECT pg_try_advisory_lock ( ? )",
 		},
 	}
 

--- a/quantizer/tokenizer.go
+++ b/quantizer/tokenizer.go
@@ -37,6 +37,7 @@ const (
 	NE                = 57363
 	Filtered          = 57364
 	As                = 57365
+	FilteredComma     = 57366
 )
 
 // Tokenizer is the struct used to generate SQL

--- a/quantizer/tokenizer.go
+++ b/quantizer/tokenizer.go
@@ -36,6 +36,7 @@ const (
 	GE                = 57362
 	NE                = 57363
 	Filtered          = 57364
+	As                = 57365
 )
 
 // Tokenizer is the struct used to generate SQL
@@ -66,6 +67,7 @@ var keywords = map[string]int{
 	"FALSE":     BooleanLiteral,
 	"SAVEPOINT": Savepoint,
 	"LIMIT":     Limit,
+	"AS":        As,
 }
 
 // Scan scans the tokenizer for the next token and returns


### PR DESCRIPTION
some of them can be unbounded and don't materially change the contents
of the query. here's the direct case:

    SELECT pg_try_advisory_lock ( ? ) AS tabcdef1235

this could also be quantized to ` SELECT pg_try_advisory_lock ( ? )` but i din't do that.