### PR TITLE
weight spans using their sample rate

### DIFF
--- a/agent/concentrator.go
+++ b/agent/concentrator.go
@@ -45,11 +45,16 @@ func (c *Concentrator) Add(t processedTrace) {
 			c.buckets[btime] = b
 		}
 
+		weight := 1.0
+		if t.Root != nil {
+			weight = t.Root.Weight()
+		}
+
 		if t.Root != nil && s.SpanID == t.Root.SpanID && t.Sublayers != nil {
 			// handle sublayers
-			b.HandleSpan(s, t.Env, c.aggregators, &t.Sublayers)
+			b.HandleSpan(s, t.Env, c.aggregators, weight, &t.Sublayers)
 		} else {
-			b.HandleSpan(s, t.Env, c.aggregators, nil)
+			b.HandleSpan(s, t.Env, c.aggregators, weight, nil)
 		}
 	}
 

--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -22,8 +22,9 @@ func BenchmarkHandleSpanRandom(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		trace := fixtures.RandomTrace(10, 8)
+		root := trace.GetRoot()
 		for _, span := range trace {
-			sb.HandleSpan(span, defaultEnv, aggr, nil)
+			sb.HandleSpan(span, defaultEnv, aggr, root.Weight(), nil)
 		}
 	}
 }

--- a/fixtures/stats.go
+++ b/fixtures/stats.go
@@ -12,7 +12,7 @@ const defaultEnv = "none"
 // TestStatsBucket returns a fixed stats bucket to be used in unit tests
 func TestStatsBucket() model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
-	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, nil)
+	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, 1.0, nil)
 	sb := srb.Export()
 
 	// marshalling then unmarshalling data to:
@@ -36,7 +36,7 @@ func TestStatsBucket() model.StatsBucket {
 func StatsBucketWithSpans(s []model.Span) model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
 	for _, s := range s {
-		srb.HandleSpan(s, defaultEnv, defaultAggregators, nil)
+		srb.HandleSpan(s, defaultEnv, defaultAggregators, 1.0, nil)
 	}
 	return srb.Export()
 }

--- a/model/span.go
+++ b/model/span.go
@@ -5,6 +5,11 @@ import (
 	"math/rand"
 )
 
+const (
+	// SpanSampleRateMetricKey is the metric key holding the sample rate
+	SpanSampleRateMetricKey = "_sample_rate"
+)
+
 // Span is the common struct we use to represent a dapper-like span
 type Span struct {
 	// Mandatory
@@ -58,4 +63,15 @@ func NewFlushMarker() Span {
 // End returns the end time of the span.
 func (s *Span) End() int64 {
 	return s.Start + s.Duration
+}
+
+// Weight returns the weight of the span as defined for sampling, i.e. the
+// inverse of the sampling rate.
+func (s *Span) Weight() float64 {
+	sampleRate, ok := s.Metrics[SpanSampleRateMetricKey]
+	if !ok || sampleRate <= 0.0 || sampleRate > 1.0 {
+		return 1.0
+	}
+
+	return 1.0 / sampleRate
 }

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -38,3 +38,25 @@ func TestSpanFlushMarker(t *testing.T) {
 	s := NewFlushMarker()
 	assert.True(s.IsFlushMarker())
 }
+
+func TestSpanWeight(t *testing.T) {
+	assert := assert.New(t)
+
+	span := testSpan()
+	assert.Equal(1.0, span.Weight())
+
+	span.Metrics[SpanSampleRateMetricKey] = -1.0
+	assert.Equal(1.0, span.Weight())
+
+	span.Metrics[SpanSampleRateMetricKey] = 0.0
+	assert.Equal(1.0, span.Weight())
+
+	span.Metrics[SpanSampleRateMetricKey] = 0.25
+	assert.Equal(4.0, span.Weight())
+
+	span.Metrics[SpanSampleRateMetricKey] = 1.0
+	assert.Equal(1.0, span.Weight())
+
+	span.Metrics[SpanSampleRateMetricKey] = 1.5
+	assert.Equal(1.0, span.Weight())
+}

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -21,9 +21,6 @@ import (
 )
 
 const (
-	// SampleRateMetricKey is the metric key holding the sample rate
-	SampleRateMetricKey = "_sample_rate"
-
 	// Sampler parameters not (yet?) configurable
 	defaultDecayPeriod          time.Duration = 30 * time.Second
 	defaultSignatureScoreOffset float64       = 1
@@ -154,7 +151,7 @@ func ApplySampleRate(root *model.Span, sampleRate float64) bool {
 
 // GetTraceAppliedSampleRate gets the sample rate the sample rate applied earlier in the pipeline.
 func GetTraceAppliedSampleRate(root *model.Span) float64 {
-	if rate, ok := root.Metrics[SampleRateMetricKey]; ok {
+	if rate, ok := root.Metrics[model.SpanSampleRateMetricKey]; ok {
 		return rate
 	}
 
@@ -166,8 +163,5 @@ func SetTraceAppliedSampleRate(root *model.Span, sampleRate float64) {
 	if root.Metrics == nil {
 		root.Metrics = make(map[string]float64)
 	}
-	if _, ok := root.Metrics[SampleRateMetricKey]; !ok {
-		root.Metrics[SampleRateMetricKey] = 1.0
-	}
-	root.Metrics[SampleRateMetricKey] = sampleRate
+	root.Metrics[model.SpanSampleRateMetricKey] = sampleRate
 }


### PR DESCRIPTION
The root span of a trace can contain a _sample_rate value if the client
sampled spans. When this is the case, we scale stats (hit and error
counts, and durations) by a factor, or weight, equal to `1.0 /
_sample_rate`.

This also means that we have to use floating point values to accumulate
values for `StatsRawBucket`.