### PR TITLE
Adaptive sampling — Step 1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -67,6 +67,7 @@ end
 
 desc "Run Datadog Trace agent"
 task :run do
+  ENV['DD_APM_ENABLED'] = 'true'
   sh "./trace-agent -config ./agent/trace-agent.ini"
 end
 

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -78,10 +78,11 @@ func (s *Sampler) Flush() []model.Trace {
 // TODO: remove (or clean it) in a real released build
 func (s *Sampler) logState() {
 	state := s.samplerEngine.(*sampler.Sampler).GetState()
-	log.Infof("inTPS: %f, outTPS: %f, maxTPS: %f, offset: %f, slope: %f",
-		state.InTPS, state.OutTPS, state.MaxTPS, state.Offset, state.Slope)
+	log.Infof("inTPS: %f, outTPS: %f, maxTPS: %f, offset: %f, slope: %f, cardinality: %d",
+		state.InTPS, state.OutTPS, state.MaxTPS, state.Offset, state.Slope, state.Cardinality)
 	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.offset", state.Offset, nil, 1)
 	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.slope", state.Slope, nil, 1)
+	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.cardinality", float64(state.Cardinality), nil, 1)
 	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.in_tps", state.InTPS, nil, 1)
 	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.out_tps", state.OutTPS, nil, 1)
 	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.max_tps", state.MaxTPS, nil, 1)

--- a/sampler/adjust.go
+++ b/sampler/adjust.go
@@ -1,0 +1,67 @@
+package sampler
+
+import (
+	"math"
+)
+
+// AdjustScoring modifies sampler coefficients to fit better the `maxTPS` condition
+func (s *Sampler) AdjustScoring() {
+	currentTPS := s.Backend.GetSampledScore()
+	totalTPS := s.Backend.GetTotalScore()
+	offset := s.signatureScoreOffset
+	cardinality := float64(s.Backend.GetCardinality())
+
+	newOffset, newSlope := adjustCoefficients(currentTPS, totalTPS, s.maxTPS, offset, cardinality)
+
+	s.SetSignatureCoefficients(newOffset, newSlope)
+}
+
+func adjustCoefficients(currentTPS, totalTPS, maxTPS, offset, cardinality float64) (newOffset, newSlope float64) {
+	// See how far we are from our maxTPS limit and make signature sampler harder/softer accordingly
+	TPSratio := currentTPS / maxTPS
+
+	// Compute how much we should change the offset
+	coefficient := 1.0
+
+	if TPSratio > 1 {
+		// If above, reduce the offset
+		coefficient = 0.8
+		// If we keep 3x too many traces, reduce the offset even more
+		if TPSratio > 3 {
+			coefficient = 0.5
+		}
+	} else if TPSratio < 0.8 {
+		// If below, increase the offset
+		// Don't do it if:
+		//  - we already keep all traces (with a 1% margin because of stats imprecision)
+		//  - offset above maxTPS
+		if currentTPS < 0.99*totalTPS && offset < maxTPS {
+			coefficient = 1.1
+			if TPSratio < 0.5 {
+				coefficient = 1.3
+			}
+		}
+	}
+
+	newOffset = coefficient * offset
+
+	// Safeguard to avoid too small offset (for guaranteed very-low volume sampling)
+	if newOffset < minSignatureScoreOffset {
+		newOffset = minSignatureScoreOffset
+	}
+
+	// Default slope value
+	newSlope = defaultSignatureScoreSlope
+
+	// Compute the slope based on the signature count distribution
+	// TODO: explain this formula
+	if offset < totalTPS {
+		newSlope = math.Pow(10, math.Log10(cardinality*totalTPS/maxTPS)/math.Log10(totalTPS/minSignatureScoreOffset))
+		// That's the max value we should allow. When slope == 10, we basically keep only `offset` traces per signature
+		if newSlope > 10 {
+			newSlope = 10
+		}
+	}
+
+	return newOffset, newSlope
+}

--- a/sampler/adjust_test.go
+++ b/sampler/adjust_test.go
@@ -1,0 +1,32 @@
+package sampler
+
+import (
+	// "fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdjustCoefficients(t *testing.T) {
+	assert := assert.New(t)
+
+	for _, a := range [][5]float64{
+		// currentTPS, totalTPS, maxTPS, offset, cardinality
+		[5]float64{10, 50, 15, 0.5, 200},
+	} {
+		currentTPS, totalTPS, maxTPS, offset, cardinality := a[0], a[1], a[2], a[3], a[4]
+		newOffset, newSlope := adjustCoefficients(currentTPS, totalTPS, maxTPS, offset, cardinality)
+
+		// Whatever the input is, we must always have respect basic bounds
+		assert.True(newOffset >= minSignatureScoreOffset)
+		assert.True(newSlope >= 1)
+		assert.True(newSlope <= 10)
+
+		// Check that we are adjusting in the "good" direction
+		if currentTPS >= maxTPS {
+			assert.True(newOffset <= offset)
+		} else {
+			assert.True(newOffset >= offset)
+		}
+	}
+}

--- a/sampler/backend.go
+++ b/sampler/backend.go
@@ -119,6 +119,15 @@ func (b *Backend) GetUpperSampledScore() float64 {
 	return b.GetSampledScore() * b.decayFactor
 }
 
+// GetCardinality returns the number of different signatures seen recently.
+func (b *Backend) GetCardinality() int64 {
+	b.mu.Lock()
+	cardinality := int64(len(b.scores))
+	b.mu.Unlock()
+
+	return cardinality
+}
+
 // DecayScore applies the decay to the rolling counters
 func (b *Backend) DecayScore() {
 	b.mu.Lock()

--- a/sampler/backend.go
+++ b/sampler/backend.go
@@ -133,7 +133,7 @@ func (b *Backend) DecayScore() {
 	b.mu.Lock()
 	for sig := range b.scores {
 		score := b.scores[sig]
-		if score > 2 {
+		if score > b.decayFactor*minSignatureScoreOffset {
 			b.scores[sig] /= b.decayFactor
 		} else {
 			// When the score is too small, we can optimize by simply dropping the entry

--- a/sampler/backend.go
+++ b/sampler/backend.go
@@ -104,13 +104,19 @@ func (b *Backend) GetSampledScore() float64 {
 	return score
 }
 
-// GetSampledScore returns the global score of all sampled traces.
+// GetTotalScore returns the global score of all sampled traces.
 func (b *Backend) GetTotalScore() float64 {
 	b.mu.Lock()
 	score := b.totalScore / b.countScaleFactor
 	b.mu.Unlock()
 
 	return score
+}
+
+// GetUpperSampledScore returns a certain upper bound of the global count of all sampled traces.
+func (b *Backend) GetUpperSampledScore() float64 {
+	// Overestimate the real score with the high limit of the backend bias.
+	return b.GetSampledScore() * b.decayFactor
 }
 
 // DecayScore applies the decay to the rolling counters

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -134,8 +134,10 @@ func (s *Sampler) AdjustScoring() {
 		}
 	} else if TPSratio < 0.8 {
 		// If below, increase the offset
-		// Don't do it if we already keep all traces or if offset above maxTPS
-		if currentTPS < s.Backend.GetTotalScore() && s.signatureScoreOffset < s.maxTPS {
+		// Don't do it if:
+		//  - we already keep all traces (with a 1% margin because of stats imprecision)
+		//  - offset above maxTPS
+		if currentTPS < 0.99*s.Backend.GetTotalScore() && s.signatureScoreOffset < s.maxTPS {
 			coefficient = 1.1
 			if TPSratio < 0.5 {
 				coefficient = 1.3

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -17,10 +17,7 @@ import (
 	"math"
 	"time"
 
-	log "github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 )
 
 const (
@@ -78,19 +75,6 @@ func NewSampler(extraRate float64, maxTPS float64) *Sampler {
 func (s *Sampler) SetSignatureOffset(offset float64) {
 	s.signatureScoreOffset = offset
 	s.signatureScoreCoefficient = math.Pow(s.signatureScoreSlope, math.Log10(offset))
-}
-
-// logState is a debug logging of the sampler internals, to check its adaptative behavior
-// This is mainly for dev purpose to watch over the adaptative behavior
-// TODO: remove (or clean it) in a real released build
-func (s *Sampler) logState() {
-	log.Infof("inTPS: %f, outTPS: %f, maxTPS: %f, offset: %f, slope: %f",
-		s.Backend.GetTotalScore(), s.Backend.GetSampledScore(), s.maxTPS, s.signatureScoreOffset, s.signatureScoreSlope)
-	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.offset", s.signatureScoreOffset, nil, 1)
-	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.slope", s.signatureScoreSlope, nil, 1)
-	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.in_tps", s.Backend.GetTotalScore(), nil, 1)
-	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.out_tps", s.Backend.GetSampledScore(), nil, 1)
-	statsd.Client.Gauge("datadog.trace_agent.sampler.scoring.max_tps", s.maxTPS, nil, 1)
 }
 
 // UpdateExtraRate updates the extra sample rate
@@ -159,8 +143,6 @@ func (s *Sampler) AdjustScoring() {
 		}
 	}
 	s.SetSignatureOffset(offset * coefficient)
-
-	s.logState()
 }
 
 // Sample counts an incoming trace and tells if it is a sample which has to be kept

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -46,8 +46,8 @@ type Sampler struct {
 	signatureScoreOffset float64
 	// Logarithm slope for the scoring function
 	signatureScoreSlope float64
-	// signatureScoreCoefficient = math.Pow(signatureScoreSlope, math.Log10(scoreSamplingOffset))
-	signatureScoreCoefficient float64
+	// signatureScoreFactor = math.Pow(signatureScoreSlope, math.Log10(scoreSamplingOffset))
+	signatureScoreFactor float64
 
 	exit chan struct{}
 }
@@ -55,26 +55,25 @@ type Sampler struct {
 // NewSampler returns an initialized Sampler
 func NewSampler(extraRate float64, maxTPS float64) *Sampler {
 	decayPeriod := defaultDecayPeriod
-	signatureScoreOffset := initialSignatureScoreOffset
-	signatureScoreSlope := defaultSignatureScoreSlope
 
-	return &Sampler{
+	s := &Sampler{
 		Backend:   NewBackend(decayPeriod),
 		extraRate: extraRate,
 		maxTPS:    maxTPS,
 
-		signatureScoreOffset:      signatureScoreOffset,
-		signatureScoreSlope:       signatureScoreSlope,
-		signatureScoreCoefficient: math.Pow(signatureScoreSlope, math.Log10(signatureScoreOffset)),
-
 		exit: make(chan struct{}),
 	}
+
+	s.SetSignatureCoefficients(initialSignatureScoreOffset, defaultSignatureScoreSlope)
+
+	return s
 }
 
-// SetSignatureOffset updates the offset coefficient of the signature scoring
-func (s *Sampler) SetSignatureOffset(offset float64) {
+// SetSignatureCoefficients updates the internal scoring coefficients used by the signature scoring
+func (s *Sampler) SetSignatureCoefficients(offset float64, slope float64) {
 	s.signatureScoreOffset = offset
-	s.signatureScoreCoefficient = math.Pow(s.signatureScoreSlope, math.Log10(offset))
+	s.signatureScoreSlope = slope
+	s.signatureScoreFactor = math.Pow(slope, math.Log10(offset))
 }
 
 // UpdateExtraRate updates the extra sample rate

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -25,8 +25,8 @@ const (
 	SampleRateMetricKey = "_sample_rate"
 
 	// Sampler parameters not (yet?) configurable
-	defaultDecayPeriod          time.Duration = 30 * time.Second
 	defaultSignatureScoreOffset float64       = 1
+	defaultDecayPeriod          time.Duration = 5 * time.Second
 	defaultSignatureScoreSlope  float64       = 3
 )
 

--- a/sampler/sampler_test.go
+++ b/sampler/sampler_test.go
@@ -89,7 +89,7 @@ func TestMaxTPS(t *testing.T) {
 	tracesPerPeriod := tps * periodSeconds
 	// Set signature score offset high enough not to kick in during the test.
 	s.signatureScoreOffset = 2 * tps
-	s.signatureScoreCoefficient = math.Pow(s.signatureScoreSlope, math.Log10(s.signatureScoreOffset))
+	s.signatureScoreFactor = math.Pow(s.signatureScoreSlope, math.Log10(s.signatureScoreOffset))
 
 	sampledCount := 0
 

--- a/sampler/score.go
+++ b/sampler/score.go
@@ -39,5 +39,5 @@ func (s *Sampler) GetSignatureSampleRate(signature Signature) float64 {
 func (s *Sampler) GetCountScore(signature Signature) float64 {
 	score := s.Backend.GetSignatureScore(signature)
 
-	return s.signatureScoreCoefficient / math.Pow(s.signatureScoreSlope, math.Log10(score))
+	return s.signatureScoreFactor / math.Pow(s.signatureScoreSlope, math.Log10(score))
 }

--- a/sampler/state.go
+++ b/sampler/state.go
@@ -1,7 +1,7 @@
 package sampler
 
-// SamplerState exposes all the main internal settings of the scope sampler
-type SamplerState struct {
+// InternalState exposes all the main internal settings of the scope sampler
+type InternalState struct {
 	Offset float64
 	Slope  float64
 	InTPS  float64
@@ -10,8 +10,8 @@ type SamplerState struct {
 }
 
 // GetState collects and return internal statistics and coefficients for indication purposes
-func (s *Sampler) GetState() SamplerState {
-	return SamplerState{
+func (s *Sampler) GetState() InternalState {
+	return InternalState{
 		s.signatureScoreOffset,
 		s.signatureScoreSlope,
 		s.Backend.GetTotalScore(),

--- a/sampler/state.go
+++ b/sampler/state.go
@@ -2,11 +2,12 @@ package sampler
 
 // InternalState exposes all the main internal settings of the scope sampler
 type InternalState struct {
-	Offset float64
-	Slope  float64
-	InTPS  float64
-	OutTPS float64
-	MaxTPS float64
+	Offset      float64
+	Slope       float64
+	Cardinality int64
+	InTPS       float64
+	OutTPS      float64
+	MaxTPS      float64
 }
 
 // GetState collects and return internal statistics and coefficients for indication purposes
@@ -14,6 +15,7 @@ func (s *Sampler) GetState() InternalState {
 	return InternalState{
 		s.signatureScoreOffset,
 		s.signatureScoreSlope,
+		s.Backend.GetCardinality(),
 		s.Backend.GetTotalScore(),
 		s.Backend.GetSampledScore(),
 		s.maxTPS,

--- a/sampler/state.go
+++ b/sampler/state.go
@@ -1,0 +1,21 @@
+package sampler
+
+// SamplerState exposes all the main internal settings of the scope sampler
+type SamplerState struct {
+	Offset float64
+	Slope  float64
+	InTPS  float64
+	OutTPS float64
+	MaxTPS float64
+}
+
+// GetState collects and return internal statistics and coefficients for indication purposes
+func (s *Sampler) GetState() SamplerState {
+	return SamplerState{
+		s.signatureScoreOffset,
+		s.signatureScoreSlope,
+		s.Backend.GetTotalScore(),
+		s.Backend.GetSampledScore(),
+		s.maxTPS,
+	}
+}


### PR DESCRIPTION
Make sampling smarter with some adaptive scoring.

### Main concept change

The 2 main internal scoring parameters (offset and slope) were constants, and they weren't suitable for all distributions of traces.
Now, they are frequently adjusted to better fit the input and the maxTPS limit.

- `offset` is now computed based on the ratio between the number of Traces Per Second we keep and the maxTPS set by the config. Every 5s, we increase/decrease the offset (to sample more or less)  accordingly.
- `slope` is now a function of the input distribution (the number of different signatures and the total TPS are parameters). 


The implementation/equation is done is such a way that it has some interesting properties/protections. I won't explain in details why here, but I plan on writing a real algorithmic explanation of it at some point.

### Small changes

- Smaller `decayPeriod` (from 30s to 5s). It basically makes the sampler counters shorter-term: more reactive but decay/forget faster (half-life from 3 minutes to 30 seconds). 
- Expose internal parameters in a `InternalState` structure.
- Report all these internal parameters as statsd metrics. Not sure we will keep them forever, but at least for now it is very useful to watch over sampler behavior.



### Next step (future PR)

This brings a scoring sampler <-> maxTPS feedback loop.
The next step will be a maxTPS <-> CPU usage feedback loop.
