### PR TITLE
[build] fixed possible cycle import issue in build (does not show on ci)

### DIFF
--- a/model/client_api_test.go
+++ b/model/client_api_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-trace-agent/config"
+	log "github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
 )
@@ -52,7 +52,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	// neutralize logs for tests
-	config.NewLoggerLevelCustom("critical", "")
+	log.UseLogger(log.Disabled)
 
 	os.Exit(m.Run())
 }

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
+	log "github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	// neutralize logs for tests
-	config.NewLoggerLevelCustom("critical", "")
+	log.UseLogger(log.Disabled)
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
This problem does not show in CircleCI as it checkouts the code in special directories, but running `rake ci` on a standard dev host, with the code in `$GOPATH/src/github.com/DataDog/datadog-trace-agent` the test on `./model` fails, as it imports config, which imports model... Fixed this by disabling the log using log functions directly, and not relying on the helpers in config.