### PR TITLE
[quantizer] add new HTTP quantizer

### DIFF
--- a/quantizer/http.go
+++ b/quantizer/http.go
@@ -1,0 +1,37 @@
+package quantizer
+
+import (
+	"net/url"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+)
+
+const (
+	httpURLMeta       = "http.url"
+	httpQuantizeError = "agent.parse.error"
+)
+
+// QuantizeHTTP extracts a URL stem for HTTP spans
+func QuantizeHTTP(span model.Span) model.Span {
+	// the URL should be located in the resource
+	rawurl := span.Resource
+
+	if span.Meta == nil {
+		span.Meta = make(map[string]string)
+	}
+	span.Meta[httpURLMeta] = rawurl
+
+	u, err := url.Parse(rawurl)
+	if err != nil || (u.Scheme == "" && u.Host == "") {
+		span.Resource = "Non-parsable URL"
+		span.Meta[httpQuantizeError] = "Problem when parsing URL"
+		return span
+	}
+
+	if span.Meta == nil {
+		span.Meta = make(map[string]string)
+	}
+
+	span.Resource = u.Scheme + "://" + u.Host
+	return span
+}

--- a/quantizer/http_test.go
+++ b/quantizer/http_test.go
@@ -1,0 +1,51 @@
+package quantizer
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTPQuantizer(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			"https://datadog.slack.com/messages/kennel/details/",
+			"https://datadog.slack.com",
+		},
+		{
+			"https://app.datadoghq.com/dash/1337/my-amazing-dashboard?live=true&page=0&is_auto=false&from_ts=1487856590189&to_ts=1487942990189&tile_size=m",
+			"https://app.datadoghq.com",
+		},
+		{
+			"THIS_URL_IS_OBVIOUSLY_BAD",
+			"Non-parsable URL",
+		},
+		{
+			"https://léo.cavaille.net/もの",
+			"https://léo.cavaille.net",
+		},
+		{
+			"http://google.com:8888/a/path?with_params=true",
+			"http://google.com:8888",
+		},
+		{
+			"datadog.com",
+			"Non-parsable URL",
+		},
+	}
+
+	for _, c := range cases {
+		s := fixtures.TestSpan()
+		s.Type = "http"
+		s.Resource = c.input
+
+		s = Quantize(s)
+
+		assert.Equal(t, c.expected, s.Resource)
+		assert.Equal(t, c.input, s.Meta["http.url"])
+	}
+}

--- a/quantizer/main.go
+++ b/quantizer/main.go
@@ -10,6 +10,7 @@ const (
 	sqlType       = "sql"
 	redisType     = "redis"
 	cassandraType = "cassandra"
+	httpType      = "http"
 	tabCode       = uint8(9)
 	newLineCode   = uint8(10)
 	spaceCode     = uint8(32)
@@ -29,6 +30,8 @@ func Quantize(span model.Span) model.Span {
 		return QuantizeSQL(span)
 	case redisType:
 		return QuantizeRedis(span)
+	case httpType:
+		return QuantizeHTTP(span)
 	default:
 		return span
 	}


### PR DESCRIPTION
For all spans that have type set to 'http', we try to extract the "host"
part of the URL and set it as a resource or if we can't fallback to a
placeholder so that we don't spam with zillions of resources.