### PR TITLE
add an env variable to control the inclusion of build vars in -version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,8 @@ desc "Build Datadog Trace agent"
 task :build do
   go_build("github.com/DataDog/datadog-trace-agent/agent", {
     :cmd => "go build -a -o trace-agent",
-    :race => ENV['GO_RACE'] == 'true'
+    :race => ENV['GO_RACE'] == 'true',
+    :add_build_vars => ENV['TRACE_AGENT_ADD_BUILD_VARS'] != 'false'
   })
 end
 


### PR DESCRIPTION
We need to be able to build the agent without build variables (commit,
branch, etc.) in omnibus.