### PR TITLE
config: shell out to dd-agent to retrieve hostname

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -149,3 +149,9 @@ func TestConfigNewIfExists(t *testing.T) {
 	assert.Nil(t, conf)
 	os.Remove(filename)
 }
+
+func TestGetHostname(t *testing.T) {
+	h, err := getHostname()
+	assert.Nil(t, err)
+	assert.NotEqual(t, "", h)
+}


### PR DESCRIPTION
The infrastructure agent implements more refined logic for
inferring hostname of the machine this process is running on
https://github.com/DataDog/dd-agent/blob/7cd0986e137683195f129b2a988dd60ca9ccf0ea/utils/hostname.py#L48

Prior to this change, the trace-agent would identify as a different host
than the infra agent in subtle cases (EC2 / GCE for example). This
created phantom hosts and general inconsistency in the UI

We shell out to the infra agent, via the following command, falling back
to running `os.Hostname()` when it fails

```
PYTHONPATH=/opt/datadog-agent/agent /opt/datadog-agent/embedded/bin/python -c "from utils.hostname import get_hostname; print get_hostname()"
```