### PR TITLE
config: respect proxy_* settings in agent

### DIFF
--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sync/atomic"
 	"time"
 
@@ -94,20 +93,11 @@ func NewAPIEndpoint(urls, apiKeys []string) *APIEndpoint {
 
 // SetProxy updates the http client used by APIEndpoint to report via the given proxy
 func (a *APIEndpoint) SetProxy(settings *config.ProxySettings) {
-	// construct user:pass@host:port
-	var userpass string
-	if settings.User != "" {
-		if settings.Password != "" {
-			userpass = fmt.Sprintf("%s:%s@", settings.User, settings.Password)
-		}
-	}
-
-	proxyPath, err := url.Parse(fmt.Sprintf("%s%s:%s", userpass, settings.Host, settings.Port))
+	proxyPath, err := settings.URL()
 	if err != nil {
 		log.Errorf("failed to configure proxy: %v", err)
 		return
 	}
-
 	a.client = &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyURL(proxyPath),

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -92,6 +92,7 @@ func NewAPIEndpoint(urls, apiKeys []string) *APIEndpoint {
 	return &a
 }
 
+// SetProxy updates the http client used by APIEndpoint to report via the given proxy
 func (a *APIEndpoint) SetProxy(settings *config.ProxySettings) {
 	// construct user:pass@host:port
 	var userpass string

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -66,6 +66,11 @@ func NewWriter(conf *config.AgentConfig) *Writer {
 
 	if conf.APIEnabled {
 		endpoint = NewAPIEndpoint(conf.APIEndpoints, conf.APIKeys)
+		if conf.Proxy != nil {
+			// we have some kind of proxy configured.
+			// make sure our http client uses it
+			endpoint.(*APIEndpoint).SetProxy(conf.Proxy)
+		}
 	} else {
 		log.Info("API interface is disabled, flushing to /dev/null instead")
 		endpoint = NullEndpoint{}

--- a/config/agent.go
+++ b/config/agent.go
@@ -59,6 +59,9 @@ type AgentConfig struct {
 	MaxMemory        float64       // MaxMemory is the threshold (bytes allocated) above which program panics and exits, to be restarted
 	MaxConnections   int           // MaxConnections is the threshold (opened TCP connections) above which program panics and exits, to be restarted
 	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
+
+	// http/s proxying
+	Proxy *ProxySettings
 }
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
@@ -221,6 +224,10 @@ func NewAgentConfig(conf *File, legacyConf *File) (*AgentConfig, error) {
 		}
 		if v := m.Key("log_level").MustString(""); v != "" {
 			c.LogLevel = v
+		}
+
+		if p := getProxySettings(m); p.Host != "" {
+			c.Proxy = p
 		}
 	}
 

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"github.com/go-ini/ini"
+)
+
+const DefaultProxyPort = 3128
+
+type ProxySettings struct {
+	User     string
+	Password string
+	Host     string
+	Port     int
+}
+
+func getProxySettings(m *ini.Section) *ProxySettings {
+	p := ProxySettings{Port: DefaultProxyPort}
+
+	if v := m.Key("proxy_host").MustString(""); v != "" {
+		p.Host = v
+	}
+	if v := m.Key("proxy_port").MustInt(-1); v != -1 {
+		p.Port = v
+	}
+	if v := m.Key("proxy_user").MustString(""); v != "" {
+		p.User = v
+	}
+	if v := m.Key("proxy_password").MustString(""); v != "" {
+		p.Password = v
+	}
+
+	return &p
+}

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -48,12 +48,21 @@ func getProxySettings(m *ini.Section) *ProxySettings {
 // URL turns ProxySettings into an idiomatic URL struct
 func (p *ProxySettings) URL() (*url.URL, error) {
 	// construct scheme://user:pass@host:port
-	var userpass string
+	var userpass *url.Userinfo
 	if p.User != "" {
 		if p.Password != "" {
-			userpass = fmt.Sprintf("%s:%s@", p.User, p.Password)
+			userpass = url.UserPassword(p.User, p.Password)
+		} else {
+			userpass = url.User(p.User)
 		}
 	}
 
-	return url.Parse(fmt.Sprintf("%s://%s%s:%v", p.Scheme, userpass, p.Host, p.Port))
+	var path string
+	if userpass != nil {
+		path = fmt.Sprintf("%s://%s@%s:%v", p.Scheme, userpass.String(), p.Host, p.Port)
+	} else {
+		path = fmt.Sprintf("%s://%s:%v", p.Scheme, p.Host, p.Port)
+	}
+
+	return url.Parse(path)
 }

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-ini/ini"
 )
 
+// mirror default behavior of the infra agent
 const DefaultProxyPort = 3128
 
 type ProxySettings struct {

--- a/config/proxy.go
+++ b/config/proxy.go
@@ -5,8 +5,9 @@ import (
 )
 
 // mirror default behavior of the infra agent
-const DefaultProxyPort = 3128
+const defaultProxyPort = 3128
 
+// ProxySettings contains configuration for http/https proxying
 type ProxySettings struct {
 	User     string
 	Password string
@@ -15,7 +16,7 @@ type ProxySettings struct {
 }
 
 func getProxySettings(m *ini.Section) *ProxySettings {
-	p := ProxySettings{Port: DefaultProxyPort}
+	p := ProxySettings{Port: defaultProxyPort}
 
 	if v := m.Key("proxy_host").MustString(""); v != "" {
 		p.Host = v

--- a/config/proxy_test.go
+++ b/config/proxy_test.go
@@ -42,6 +42,35 @@ func TestGetProxySettings(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("https://myhost:3128", s.String())
 
+	// generic user name
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+
+	assert.Equal("https://aaditya@myhost:3129", s.String())
+
+	// special char in user name <3
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = myhost",
+		"proxy_port = 3129",
+		"proxy_user = léo",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+
+	// user is url-encoded and decodes to original string
+	assert.Equal("http://l%C3%A9o@myhost:3129", s.String())
+	assert.Equal("léo", s.User.Username())
+
+	// generic  user-pass
 	f, _ = ini.Load([]byte(strings.Join([]string{
 		"[Main]",
 		"proxy_host = myhost",
@@ -54,6 +83,7 @@ func TestGetProxySettings(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("http://aaditya:password_12@myhost:3129", s.String())
 
+	// user-pass with schemed host
 	f, _ = ini.Load([]byte(strings.Join([]string{
 		"[Main]",
 		"proxy_host = https://myhost",
@@ -65,4 +95,22 @@ func TestGetProxySettings(t *testing.T) {
 	s, err = getURL(f)
 	assert.Nil(err)
 	assert.Equal("https://aaditya:password_12@myhost:3129", s.String())
+
+	// special characters in password
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = /:!?&=@éÔγλῶσσα",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+
+	// password is url-encoded and decodes to the original string
+	assert.Equal("https://aaditya:%2F%3A%21%3F&=%40%C3%A9%C3%94%CE%B3%CE%BB%E1%BF%B6%CF%83%CF%83%CE%B1@myhost:3129", s.String())
+
+	pass, _ := s.User.Password()
+	assert.Equal("/:!?&=@éÔγλῶσσα", pass)
 }

--- a/config/proxy_test.go
+++ b/config/proxy_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+
+	"github.com/go-ini/ini"
+)
+
+func getURL(f *ini.File) (*url.URL, error) {
+	conf := File{
+		f,
+		"some/path",
+	}
+	m, _ := conf.GetSection("Main")
+	p := getProxySettings(m)
+	return p.URL()
+}
+
+func TestGetProxySettings(t *testing.T) {
+	assert := assert.New(t)
+
+	f, _ := ini.Load([]byte("[Main]\n\nproxy_host = myhost"))
+
+	s, err := getURL(f)
+	assert.Nil(err)
+	assert.Equal("http://myhost:3128", s.String())
+
+	f, _ = ini.Load([]byte("[Main]\n\nproxy_host = http://myhost"))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+	assert.Equal("http://myhost:3128", s.String())
+
+	f, _ = ini.Load([]byte("[Main]\n\nproxy_host = https://myhost"))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+	assert.Equal("https://myhost:3128", s.String())
+
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = password_12",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+	assert.Equal("http://aaditya:password_12@myhost:3129", s.String())
+
+	f, _ = ini.Load([]byte(strings.Join([]string{
+		"[Main]",
+		"proxy_host = https://myhost",
+		"proxy_port = 3129",
+		"proxy_user = aaditya",
+		"proxy_password = password_12",
+	}, "\n")))
+
+	s, err = getURL(f)
+	assert.Nil(err)
+	assert.Equal("https://aaditya:password_12@myhost:3129", s.String())
+}


### PR DESCRIPTION
when [proxy
settings](https://github.com/DataDog/dd-agent/blob/master/datadog.conf.example#L7-L10) are defined in datadog.conf
update the default client in the writer to submit to a proxy.

fixes #245