### PR TITLE
[normalizer] only accept strictly positive durations

### DIFF
--- a/model/normalizer.go
+++ b/model/normalizer.go
@@ -102,8 +102,8 @@ func (s *Span) Normalize() error {
 		return fmt.Errorf("span.normalize: more than %v in the future", MaxEndDateOffset)
 	}
 
-	if s.Duration == 0 {
-		return errors.New("span.normalize: spans with zeroed `Duration` are discarded, use annotations")
+	if s.Duration <= 0 {
+		return errors.New("span.normalize: durations need to be strictly positive")
 	}
 
 	// Error - Nothing to do

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -145,6 +145,12 @@ func TestNormalizeEmptyDuration(t *testing.T) {
 	assert.Error(t, s.Normalize())
 }
 
+func TestNormalizeNegativeDuration(t *testing.T) {
+	s := testSpan()
+	s.Duration = -50
+	assert.Error(t, s.Normalize())
+}
+
 func TestNormalizeErrorPassThru(t *testing.T) {
 	s := testSpan()
 	before := s.Error


### PR DESCRIPTION
Also discard the message about annotations because they have not been
implemented (yet).