### PR TITLE
fix the decoding of float64 values from integers

### DIFF
--- a/model/decoder.go
+++ b/model/decoder.go
@@ -57,10 +57,7 @@ func parseFloat64(dc *msgp.Reader) (float64, error) {
 			return 0, err
 		}
 
-		// if we have an uint64 sent over the wire, this value should be a float64
-		// so we're decoding that value using set bits. This action is compliant
-		// to msgpack specification.
-		return math.Float64frombits(i), nil
+		return float64(i), nil
 	case msgp.Float64Type:
 		f, err := dc.ReadFloat64()
 		if err != nil {

--- a/model/decoder_test.go
+++ b/model/decoder_test.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestParseFloat64(t *testing.T) {
+	assert := assert.New(t)
+
+	data := []byte{
+		0x2a,             // 42
+		0xd1, 0xfb, 0x2e, // -1234
+		0xcd, 0x0a, 0x9b, // 2715
+		0xcb, 0x40, 0x09, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f, // float64(3.14)
+	}
+
+	reader := msgp.NewReader(bytes.NewReader(data))
+
+	var f float64
+	var err error
+
+	f, err = parseFloat64(reader)
+	assert.NoError(err)
+	assert.Equal(42.0, f)
+
+	f, err = parseFloat64(reader)
+	assert.NoError(err)
+	assert.Equal(-1234.0, f)
+
+	f, err = parseFloat64(reader)
+	assert.NoError(err)
+	assert.Equal(2715.0, f)
+
+	f, err = parseFloat64(reader)
+	assert.NoError(err)
+	assert.Equal(3.14, f)
+}


### PR DESCRIPTION
If a client sends an integer value to the agent, it will be encoded as a
msgpack integer. Reading the binary representation of an integer does
not yield the floating value you expect.