### PR TITLE
[watchdog] ensure agent recovers from and logs its panics in all goroutines

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -157,14 +157,12 @@ func (a *Agent) Process(t model.Trace) {
 	}
 
 	weight := pt.weight() // need to do this now because sampler edits .Metrics map
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		a.Concentrator.Add(pt, weight)
-	}()
-	go func() {
-		defer watchdog.LogOnPanic()
+	})
+	watchdog.Go(func() {
 		a.Sampler.Add(pt)
-	}()
+	})
 }
 
 func (a *Agent) watchdog() {

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -7,10 +7,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	log "github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/statsd"
-	log "github.com/cihub/seelog"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
 // apiError stores a list of errors triggered when sending data to a
@@ -87,7 +89,10 @@ func NewAPIEndpoint(urls, apiKeys []string) *APIEndpoint {
 		urls:    urls,
 		client:  http.DefaultClient,
 	}
-	go a.logStats()
+	go func() {
+		defer watchdog.LogOnPanic()
+		a.logStats()
+	}()
 	return &a
 }
 

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -89,10 +89,9 @@ func NewAPIEndpoint(urls, apiKeys []string) *APIEndpoint {
 		urls:    urls,
 		client:  http.DefaultClient,
 	}
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		a.logStats()
-	}()
+	})
 	return &a
 }
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -213,10 +213,9 @@ func main() {
 	agent := NewAgent(agentConf)
 
 	// Handle stops properly
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		handleSignal(agent.exit)
-	}()
+	})
 
 	log.Infof("trace-agent running on host %s", agentConf.HostName)
 	agent.Run()

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -106,10 +106,9 @@ func (r *HTTPReceiver) Run() {
 		log.Error(err)
 	}
 
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		r.logStats()
-	}()
+	})
 }
 
 // Listen creates a new HTTP server listening on the provided address.
@@ -137,14 +136,12 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 
 	log.Infof("listening for traces at http://%s%s", addr, logExtra)
 
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		stoppableListener.Refresh(r.conf.ConnectionLimit)
-	}()
-	go func() {
-		defer watchdog.LogOnPanic()
+	})
+	watchdog.Go(func() {
 		server.Serve(stoppableListener)
-	}()
+	})
 
 	return nil
 }

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -55,10 +55,9 @@ func NewSampler(conf *config.AgentConfig) *Sampler {
 
 // Run starts sampling traces
 func (s *Sampler) Run() {
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		s.samplerEngine.Run()
-	}()
+	})
 }
 
 // Add samples a trace then keep it until the next flush

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/sampler"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
 // Sampler chooses wich spans to write to the API
@@ -54,7 +55,10 @@ func NewSampler(conf *config.AgentConfig) *Sampler {
 
 // Run starts sampling traces
 func (s *Sampler) Run() {
-	go s.samplerEngine.Run()
+	go func() {
+		defer watchdog.LogOnPanic()
+		s.samplerEngine.Run()
+	}()
 }
 
 // Add samples a trace then keep it until the next flush

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -102,10 +102,9 @@ func (w *Writer) isPayloadBufferingEnabled() bool {
 // Run starts the writer.
 func (w *Writer) Run() {
 	w.exitWG.Add(1)
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		w.main()
-	}()
+	})
 }
 
 // main is the main loop of the writer goroutine. If buffers payloads and

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/statsd"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
 // the amount of time in seconds to wait before resending a payload
@@ -101,7 +102,10 @@ func (w *Writer) isPayloadBufferingEnabled() bool {
 // Run starts the writer.
 func (w *Writer) Run() {
 	w.exitWG.Add(1)
-	go w.main()
+	go func() {
+		defer watchdog.LogOnPanic()
+		w.main()
+	}()
 }
 
 // main is the main loop of the writer goroutine. If buffers payloads and

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -87,10 +87,9 @@ func (s *Sampler) UpdateMaxTPS(maxTPS float64) {
 
 // Run runs and block on the Sampler main loop
 func (s *Sampler) Run() {
-	go func() {
-		defer watchdog.LogOnPanic()
+	watchdog.Go(func() {
 		s.Backend.Run()
-	}()
+	})
 	s.RunAdjustScoring()
 }
 

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
 const (
@@ -86,7 +87,10 @@ func (s *Sampler) UpdateMaxTPS(maxTPS float64) {
 
 // Run runs and block on the Sampler main loop
 func (s *Sampler) Run() {
-	go s.Backend.Run()
+	go func() {
+		defer watchdog.LogOnPanic()
+		s.Backend.Run()
+	}()
 	s.RunAdjustScoring()
 }
 

--- a/watchdog/logonpanic.go
+++ b/watchdog/logonpanic.go
@@ -1,0 +1,22 @@
+package watchdog
+
+import (
+	"fmt"
+	"runtime"
+
+	log "github.com/cihub/seelog"
+)
+
+func LogOnPanic() {
+	if err := recover(); err != nil {
+		// Full print of the trace in the logs
+		buf := make([]byte, 4096)
+		length := runtime.Stack(buf, false)
+		stacktrace := string(buf[:length])
+		msg := fmt.Sprintf("%v: %s\n%s", "Unexpected error", err, stacktrace)
+
+		log.Error(msg)
+		log.Flush()
+		panic(err)
+	}
+}

--- a/watchdog/logonpanic.go
+++ b/watchdog/logonpanic.go
@@ -23,3 +23,11 @@ func LogOnPanic() {
 		panic(err)
 	}
 }
+
+// Go is a helper func that calls LogOnPanic and f in a goroutine.
+func Go(f func()) {
+	go func() {
+		LogOnPanic()
+		f()
+	}()
+}

--- a/watchdog/logonpanic.go
+++ b/watchdog/logonpanic.go
@@ -7,6 +7,9 @@ import (
 	log "github.com/cihub/seelog"
 )
 
+// LogOnPanic catches panics and logs them on the fly. It also flushes
+// the log file, ensuring the message appears. Then it propagates the panic
+// so that the program flow remains unchanged.
 func LogOnPanic() {
 	if err := recover(); err != nil {
 		// Full print of the trace in the logs

--- a/watchdog/logonpanic_test.go
+++ b/watchdog/logonpanic_test.go
@@ -2,6 +2,7 @@ package watchdog
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -28,6 +29,9 @@ func TestLogOnPanicMain(t *testing.T) {
 	defer func() {
 		r := recover()
 		assert.NotNil(r, "panic should bubble up and be trapped here")
+		assert.Contains(fmt.Sprintf("%v", r),
+			"integer divide by zero",
+			"divide by zero panic should be forwarded")
 		msg := testLogBuf.String()
 		assert.Contains(msg,
 			"Unexpected error: runtime error: integer divide by zero",
@@ -51,6 +55,9 @@ func TestLogOnPanicGoroutine(t *testing.T) {
 		defer func() {
 			r := recover()
 			assert.NotNil(r, "panic should bubble up and be trapped here")
+			assert.Contains(fmt.Sprintf("%v", r),
+				"what could possibly go wrong?",
+				"custom panic should be forwarded")
 			msg := testLogBuf.String()
 			assert.Contains(msg,
 				"Unexpected error: what could possibly go wrong?",

--- a/watchdog/logonpanic_test.go
+++ b/watchdog/logonpanic_test.go
@@ -1,0 +1,71 @@
+package watchdog
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	log "github.com/cihub/seelog"
+	"github.com/stretchr/testify/assert"
+)
+
+var testLogBuf bytes.Buffer
+
+func init() {
+	logger, err := log.LoggerFromWriterWithMinLevelAndFormat(&testLogBuf, log.DebugLvl, "%Ns [%Level] %Msg")
+	if err != nil {
+		panic(err)
+	}
+	err = log.ReplaceLogger(logger)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestLogOnPanicMain(t *testing.T) {
+	assert := assert.New(t)
+
+	defer func() {
+		r := recover()
+		assert.NotNil(r, "panic should bubble up and be trapped here")
+		msg := testLogBuf.String()
+		assert.Contains(msg,
+			"Unexpected error: runtime error: integer divide by zero",
+			"divide by zero panic should be reported in log")
+		assert.Contains(msg,
+			"github.com/DataDog/datadog-trace-agent/watchdog.TestLogOnPanicMain",
+			"log should contain a reference to this test func name as it displays the stack trace")
+	}()
+	defer LogOnPanic()
+	zero := 0
+	_ = 1 / zero
+}
+
+func TestLogOnPanicGoroutine(t *testing.T) {
+	assert := assert.New(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer func() {
+			r := recover()
+			assert.NotNil(r, "panic should bubble up and be trapped here")
+			msg := testLogBuf.String()
+			assert.Contains(msg,
+				"Unexpected error: what could possibly go wrong?",
+				"custom panic should be reported in log")
+			assert.Contains(msg,
+				"github.com/DataDog/datadog-trace-agent/watchdog.TestLogOnPanicGoroutine",
+				"log should contain a reference to this test func name as it displays the stack trace")
+			wg.Done()
+		}()
+		defer LogOnPanic()
+		panic("what could possibly go wrong?")
+	}()
+	defer func() {
+		r := recover()
+		assert.Nil(r, "this should trap no error at all, what we demonstrate here is that recover needs to be called on a per-goroutine base")
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/datadog-trace-agent/pull/254 do the same (log and propagate panic) but do it in all goroutines as doing it in main only will only catch a small percentage of possible panics.