### PR TITLE
writer: don't discard the client on api errors

### DIFF
--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -31,6 +31,10 @@ func (err *apiError) IsEmpty() bool {
 	return len(err.errs) == 0
 }
 
+func (err *apiError) SetClient(client *http.Client) {
+	err.endpoint.client = client
+}
+
 func (err *apiError) Append(url, apiKey string, e error) {
 	err.errs = append(err.errs, e)
 	err.endpoint.urls = append(err.endpoint.urls, url)
@@ -123,6 +127,11 @@ func (a *APIEndpoint) Write(p model.AgentPayload) (int, error) {
 	atomic.AddInt64(&a.stats.TracesStats, int64(len(p.Stats)))
 
 	endpointErr := newAPIError()
+
+	// if this payload cannot be flushed due to API errors
+	// we need to pass the client along for future submissions
+	// FIXME(aaditya)
+	endpointErr.SetClient(a.client)
 
 	for i := range a.urls {
 		atomic.AddInt64(&a.stats.TracesPayload, 1)

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -70,6 +70,7 @@ func NewWriter(conf *config.AgentConfig) *Writer {
 		if conf.Proxy != nil {
 			// we have some kind of proxy configured.
 			// make sure our http client uses it
+			log.Infof("configuring proxy through host %s", conf.Proxy.Host)
 			endpoint.(*APIEndpoint).SetProxy(conf.Proxy)
 		}
 	} else {


### PR DESCRIPTION
Our payload buffering logic passes along a stateful `APIEndpoint`
when it receives upstream errors. A prior PR ( #251  ) added a `client`
to individual APIEndpoints without propagating this value to the error handler

Thus when an endpoint flush failed, all future flushes would use the
zero value for `APIEndpoint.client` which is `nil`