### PR TITLE
config: enable agent by default

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -150,6 +150,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		hostname = ""
 	}
 	ac := &AgentConfig{
+		Enabled:                 true,
 		HostName:                hostname,
 		DefaultEnv:              "none",
 		APIEndpoints:            []string{"https://trace.agent.datadoghq.com"},


### PR DESCRIPTION
let this guy run in the absence of instructions not to. `apm_enabled` and `DD_APM_ENABLED` are still respected for overrides