### PR TITLE
config: allow disabling agent

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -243,8 +243,8 @@ APM_CONF:
 		goto ENV_CONF
 	}
 
-	if v, _ := conf.Get("Main", "apm_enabled"); v == "true" {
-		c.Enabled = true
+	if v, _ := conf.Get("Main", "apm_enabled"); v == "no" || v == "false" {
+		c.Enabled = false
 	}
 
 	if v, _ := conf.Get("trace.config", "env"); v != "" {

--- a/config/agent.go
+++ b/config/agent.go
@@ -243,7 +243,7 @@ APM_CONF:
 		goto ENV_CONF
 	}
 
-	if v, _ := conf.Get("Main", "apm_enabled"); v == "no" || v == "false" {
+	if v := strings.ToLower(conf.GetDefault("Main", "apm_enabled", "")); v == "no" || v == "false" {
 		c.Enabled = false
 	}
 


### PR DESCRIPTION
When `apm_enabled` is set to a falsy value the agent should pick it up
and exit.