### PR TITLE
[log] using receiver limited logger instead of plain log debug

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -127,15 +127,15 @@ func (a *Agent) Process(t model.Trace) {
 	if len(t) == 0 {
 		// XXX Should never happen since we reject empty traces during
 		// normalization.
-		log.Debugf("skipping received empty trace")
+		a.Receiver.logger.Errorf("skipping received empty trace")
 		return
 	}
 
 	root := t.GetRoot()
 	if root.End() < model.Now()-2*a.conf.BucketInterval.Nanoseconds() {
-		log.Debugf("skipping trace with root too far in past, root:%v", *root)
 		atomic.AddInt64(&a.Receiver.stats.TracesDropped, 1)
 		atomic.AddInt64(&a.Receiver.stats.SpansDropped, int64(len(t)))
+		a.Receiver.logger.Errorf("skipping trace with root too far in past, root:%v", *root)
 		return
 	}
 


### PR DESCRIPTION
When skipping messages, a debug message is of no use in production mode,
as we get no clue on why traces where dropped. Especially when it's for
an obscure reason such as clock skew. This patch uses the receiver logger
object which has a limiter preventing log to be filled with the same error
repeating many times, while still displaying a few of them.