### PR TITLE
Make binding to the legacy port optional

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -101,9 +101,11 @@ func (r *HTTPReceiver) Run() {
 		die("%v", err)
 	}
 
-	legacyAddr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, legacyReceiverPort)
-	if err := r.Listen(legacyAddr, " (legacy)"); err != nil {
-		log.Error(err)
+	if r.conf.BindToLegacyPort {
+		legacyAddr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, legacyReceiverPort)
+		if err := r.Listen(legacyAddr, " (legacy)"); err != nil {
+			log.Error(err)
+		}
 	}
 
 	watchdog.Go(func() {

--- a/config/agent.go
+++ b/config/agent.go
@@ -42,10 +42,11 @@ type AgentConfig struct {
 	MaxTPS          float64
 
 	// Receiver
-	ReceiverHost    string
-	ReceiverPort    int
-	ConnectionLimit int // for rate-limiting, how many unique connections to allow in a lease period (30s)
-	ReceiverTimeout int
+	ReceiverHost     string
+	ReceiverPort     int
+	ConnectionLimit  int // for rate-limiting, how many unique connections to allow in a lease period (30s)
+	ReceiverTimeout  int
+	BindToLegacyPort bool // to define whether or not it should bind itself to the legacy port (7777) in addition to the ReceiverPort
 
 	// internal telemetry
 	StatsdHost string
@@ -164,9 +165,10 @@ func NewDefaultAgentConfig() *AgentConfig {
 		ExtraSampleRate: 1.0,
 		MaxTPS:          10,
 
-		ReceiverHost:    "localhost",
-		ReceiverPort:    8126,
-		ConnectionLimit: 2000,
+		ReceiverHost:     "localhost",
+		ReceiverPort:     8126,
+		ConnectionLimit:  2000,
+		BindToLegacyPort: false,
 
 		StatsdHost: "localhost",
 		StatsdPort: 8125,


### PR DESCRIPTION
Binding to the legacy port (in addition to the current one) should be optional, although we can keep the default as `true` to keep the current behavior.