### PR TITLE
[toplevelname] identifying top-level name spans

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -148,6 +148,8 @@ func (a *Agent) Process(t model.Trace) {
 	rate *= a.Receiver.preSampler.Rate()
 	sampler.SetTraceAppliedSampleRate(root, rate)
 
+	t.ComputeTopLevel()
+
 	sublayers := model.ComputeSublayers(&t)
 	model.SetSublayersOnSpan(root, sublayers)
 

--- a/model/span.go
+++ b/model/span.go
@@ -28,6 +28,7 @@ type Span struct {
 	Metrics  map[string]float64 `json:"metrics" msg:"metrics"`     // arbitrary metrics
 	ParentID uint64             `json:"parent_id" msg:"parent_id"` // span ID of the span in which this one was created
 	Type     string             `json:"type" msg:"type"`           // protocol associated with the span
+	TopLevel bool               `json:"top_level" msg:"top_level"` // true if a "local root" considering its service
 }
 
 // String formats a Span struct to be displayed as a string

--- a/model/span.go
+++ b/model/span.go
@@ -28,7 +28,6 @@ type Span struct {
 	Metrics  map[string]float64 `json:"metrics" msg:"metrics"`     // arbitrary metrics
 	ParentID uint64             `json:"parent_id" msg:"parent_id"` // span ID of the span in which this one was created
 	Type     string             `json:"type" msg:"type"`           // protocol associated with the span
-	TopLevel bool               `json:"top_level" msg:"top_level"` // true if a "local root" considering its service
 }
 
 // String formats a Span struct to be displayed as a string

--- a/model/stats.go
+++ b/model/stats.go
@@ -28,8 +28,7 @@ type Count struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time" (was Name)
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	SubName      bool `json:"sub_name"`      // true for sub-name (non top-level) stats
-	ForceMetrics bool `json:"force_metrics"` // true if stats should be computed no matter what
+	TopLevel int `json:"top_level"` // number of top-level spans contributing to this count
 
 	Value float64 `json:"value"` // accumulated values
 }
@@ -41,8 +40,7 @@ type Distribution struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time"
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	SubName      bool `json:"sub_name"`      // true for sub-name (non top-level) stats
-	ForceMetrics bool `json:"force_metrics"` // true if stats should be computed no matter what
+	TopLevel int `json:"top_level"` // number of top-level spans contributing to this count
 
 	Summary *quantile.SliceSummary `json:"summary"` // actual representation of data
 }

--- a/model/stats.go
+++ b/model/stats.go
@@ -53,12 +53,11 @@ func GrainKey(name, measure, aggr string) string {
 // NewCount returns a new Count for a metric and a given tag set
 func NewCount(m, ckey, name string, tgs TagSet) Count {
 	return Count{
-		Key:       ckey,
-		Name:      name,
-		Measure:   m,
-		TagSet:    tgs,  // note: by doing this, tgs is a ref shared by all objects created with the same arg
-		SkipStats: true, // consider it a sub-name until we saw a span marked as top-level
-		Value:     0.0,
+		Key:     ckey,
+		Name:    name,
+		Measure: m,
+		TagSet:  tgs, // note: by doing this, tgs is a ref shared by all objects created with the same arg
+		Value:   0.0,
 	}
 }
 
@@ -82,12 +81,11 @@ func (c Count) Merge(c2 Count) Count {
 // NewDistribution returns a new Distribution for a metric and a given tag set
 func NewDistribution(m, ckey, name string, tgs TagSet) Distribution {
 	return Distribution{
-		Key:       ckey,
-		Name:      name,
-		Measure:   m,
-		TagSet:    tgs,  // note: by doing this, tgs is a ref shared by all objects created with the same arg
-		SkipStats: true, // consider it a sub-name until we saw a span marked as top-level
-		Summary:   quantile.NewSliceSummary(),
+		Key:     ckey,
+		Name:    name,
+		Measure: m,
+		TagSet:  tgs, // note: by doing this, tgs is a ref shared by all objects created with the same arg
+		Summary: quantile.NewSliceSummary(),
 	}
 }
 

--- a/model/stats.go
+++ b/model/stats.go
@@ -28,8 +28,10 @@ type Count struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time" (was Name)
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	SkipStats bool    `json:"skip_stats"` // true if stats can be skipped at some point
-	Value     float64 `json:"value"`      // accumulated values
+	SubName      bool `json:"sub_name"`      // true for sub-name (non top-level) stats
+	ForceMetrics bool `json:"force_metrics"` // true if stats should be computed no matter what
+
+	Value float64 `json:"value"` // accumulated values
 }
 
 // Distribution represents a true image of the spectrum of values, allowing arbitrary quantile queries
@@ -39,8 +41,10 @@ type Distribution struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time"
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	SkipStats bool                   `json:"skip_stats"` // true if stats can be skipped at some point
-	Summary   *quantile.SliceSummary `json:"summary"`    // actual representation of data
+	SubName      bool `json:"sub_name"`      // true for sub-name (non top-level) stats
+	ForceMetrics bool `json:"force_metrics"` // true if stats should be computed no matter what
+
+	Summary *quantile.SliceSummary `json:"summary"` // actual representation of data
 }
 
 // GrainKey generates the key used to aggregate counts and distributions

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -97,6 +97,7 @@ func TestStatsBucketDefault(t *testing.T) {
 			assert.Fail("Unexpected count %s", ckey)
 		}
 		assert.Equal(val, c.Value, "Count %s wrong value", ckey)
+		assert.False(c.SkipStats, "stats should be done by default")
 	}
 
 	expectedDistributions := map[string]int{
@@ -113,12 +114,13 @@ func TestStatsBucketDefault(t *testing.T) {
 		t.Logf("%v: %v", k, v.Summary.Entries)
 	}
 	assert.Len(sb.Distributions, len(expectedDistributions), "Missing distributions!")
-	for dkey, c := range sb.Distributions {
+	for dkey, d := range sb.Distributions {
 		val, ok := expectedDistributions[dkey]
 		if !ok {
 			assert.Fail("Unexpected distribution %s", dkey)
 		}
-		assert.Equal(val, len(c.Summary.Entries), "Distribution %s wrong value", dkey)
+		assert.Equal(val, len(d.Summary.Entries), "Distribution %s wrong value", dkey)
+		assert.False(d.SkipStats, "stats should be done by default")
 	}
 }
 

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -97,7 +97,8 @@ func TestStatsBucketDefault(t *testing.T) {
 			assert.Fail("Unexpected count %s", ckey)
 		}
 		assert.Equal(val, c.Value, "Count %s wrong value", ckey)
-		assert.False(c.SkipStats, "stats should be done by default")
+		assert.False(c.SubName, "stats should be considered top-level by default")
+		assert.False(c.ForceMetrics, "metrics should not be enforced by default")
 	}
 
 	expectedDistributions := map[string]int{
@@ -120,7 +121,8 @@ func TestStatsBucketDefault(t *testing.T) {
 			assert.Fail("Unexpected distribution %s", dkey)
 		}
 		assert.Equal(val, len(d.Summary.Entries), "Distribution %s wrong value", dkey)
-		assert.False(d.SkipStats, "stats should be done by default")
+		assert.False(d.SubName, "stats should be considered top-level by default")
+		assert.False(d.ForceMetrics, "metrics should not be enforced by default")
 	}
 }
 

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -15,7 +15,7 @@ import (
 const defaultEnv = "default"
 
 func testSpans() []Span {
-	return []Span{
+	spans := []Span{
 		Span{Service: "A", Name: "A.foo", Resource: "α", Duration: 1},
 		Span{Service: "A", Name: "A.foo", Resource: "β", Duration: 2, Error: 1},
 		Span{Service: "B", Name: "B.foo", Resource: "γ", Duration: 3},
@@ -25,6 +25,11 @@ func testSpans() []Span {
 		Span{Service: "C", Name: "sql.query", Resource: "δ", Duration: 7},
 		Span{Service: "C", Name: "sql.query", Resource: "δ", Duration: 8},
 	}
+	for i, span := range spans {
+		span.setTopLevel(true)
+		spans[i] = span
+	}
+	return spans
 }
 
 func testTrace() Trace {

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -140,13 +140,20 @@ func TestStatsBucketDefault(t *testing.T) {
 	}
 
 	expectedDistributions := map[string]expectedDistribution{
-		"A.foo|duration|env:default,resource:α,service:A":     expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 1, G: 1, Delta: 0}}, topLevel: 1},
-		"A.foo|duration|env:default,resource:β,service:A":     expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 2, G: 1, Delta: 0}}, topLevel: 1},
-		"B.foo|duration|env:default,resource:γ,service:B":     expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 1},
-		"B.foo|duration|env:default,resource:ε,service:B":     expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 4, G: 1, Delta: 0}}, topLevel: 1},
-		"B.foo|duration|env:default,resource:ζ,service:B":     expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 1},
-		"sql.query|duration|env:default,resource:ζ,service:B": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 6, G: 1, Delta: 0}}, topLevel: 1},
-		"sql.query|duration|env:default,resource:δ,service:C": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 7, G: 1, Delta: 0}, quantile.Entry{V: 8, G: 1, Delta: 0}}, topLevel: 2},
+		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 1, G: 1, Delta: 0}}, topLevel: 1},
+		"A.foo|duration|env:default,resource:β,service:A": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 2, G: 1, Delta: 0}}, topLevel: 1},
+		"B.foo|duration|env:default,resource:γ,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 1},
+		"B.foo|duration|env:default,resource:ε,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 4, G: 1, Delta: 0}}, topLevel: 1},
+		"B.foo|duration|env:default,resource:ζ,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 1},
+		"sql.query|duration|env:default,resource:ζ,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 6, G: 1, Delta: 0}}, topLevel: 1},
+		"sql.query|duration|env:default,resource:δ,service:C": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 7, G: 1, Delta: 0}, quantile.Entry{V: 8, G: 1, Delta: 0}}, topLevel: 2},
 	}
 
 	for k, v := range sb.Distributions {
@@ -175,28 +182,28 @@ func TestStatsBucketExtraAggregators(t *testing.T) {
 	}
 	sb := srb.Export()
 
-	expectedCounts := map[string]float64{
-		"A.foo|duration|env:default,resource:α,service:A":                 1,
-		"A.foo|duration|env:default,resource:β,service:A":                 2,
-		"B.foo|duration|env:default,resource:γ,service:B":                 3,
-		"B.foo|duration|env:default,resource:ε,service:B":                 4,
-		"sql.query|duration|env:default,resource:δ,service:C":             15,
-		"A.foo|errors|env:default,resource:α,service:A":                   0,
-		"A.foo|errors|env:default,resource:β,service:A":                   1,
-		"B.foo|errors|env:default,resource:γ,service:B":                   0,
-		"B.foo|errors|env:default,resource:ε,service:B":                   1,
-		"sql.query|errors|env:default,resource:δ,service:C":               0,
-		"A.foo|hits|env:default,resource:α,service:A":                     1,
-		"A.foo|hits|env:default,resource:β,service:A":                     1,
-		"B.foo|hits|env:default,resource:γ,service:B":                     1,
-		"B.foo|hits|env:default,resource:ε,service:B":                     1,
-		"sql.query|hits|env:default,resource:δ,service:C":                 2,
-		"sql.query|errors|env:default,resource:ζ,service:B,version:1.4":   0,
-		"sql.query|hits|env:default,resource:ζ,service:B,version:1.4":     1,
-		"sql.query|duration|env:default,resource:ζ,service:B,version:1.4": 6,
-		"B.foo|errors|env:default,resource:ζ,service:B,version:1.3":       0,
-		"B.foo|duration|env:default,resource:ζ,service:B,version:1.3":     5,
-		"B.foo|hits|env:default,resource:ζ,service:B,version:1.3":         1,
+	expectedCounts := map[string]expectedCount{
+		"A.foo|duration|env:default,resource:α,service:A":                 expectedCount{value: 1, topLevel: 1},
+		"A.foo|duration|env:default,resource:β,service:A":                 expectedCount{value: 2, topLevel: 1},
+		"B.foo|duration|env:default,resource:γ,service:B":                 expectedCount{value: 3, topLevel: 1},
+		"B.foo|duration|env:default,resource:ε,service:B":                 expectedCount{value: 4, topLevel: 1},
+		"sql.query|duration|env:default,resource:δ,service:C":             expectedCount{value: 15, topLevel: 2},
+		"A.foo|errors|env:default,resource:α,service:A":                   expectedCount{value: 0, topLevel: 1},
+		"A.foo|errors|env:default,resource:β,service:A":                   expectedCount{value: 1, topLevel: 1},
+		"B.foo|errors|env:default,resource:γ,service:B":                   expectedCount{value: 0, topLevel: 1},
+		"B.foo|errors|env:default,resource:ε,service:B":                   expectedCount{value: 1, topLevel: 1},
+		"sql.query|errors|env:default,resource:δ,service:C":               expectedCount{value: 0, topLevel: 2},
+		"A.foo|hits|env:default,resource:α,service:A":                     expectedCount{value: 1, topLevel: 1},
+		"A.foo|hits|env:default,resource:β,service:A":                     expectedCount{value: 1, topLevel: 1},
+		"B.foo|hits|env:default,resource:γ,service:B":                     expectedCount{value: 1, topLevel: 1},
+		"B.foo|hits|env:default,resource:ε,service:B":                     expectedCount{value: 1, topLevel: 1},
+		"sql.query|hits|env:default,resource:δ,service:C":                 expectedCount{value: 2, topLevel: 2},
+		"sql.query|errors|env:default,resource:ζ,service:B,version:1.4":   expectedCount{value: 0, topLevel: 1},
+		"sql.query|hits|env:default,resource:ζ,service:B,version:1.4":     expectedCount{value: 1, topLevel: 1},
+		"sql.query|duration|env:default,resource:ζ,service:B,version:1.4": expectedCount{value: 6, topLevel: 1},
+		"B.foo|errors|env:default,resource:ζ,service:B,version:1.3":       expectedCount{value: 0, topLevel: 1},
+		"B.foo|duration|env:default,resource:ζ,service:B,version:1.3":     expectedCount{value: 5, topLevel: 1},
+		"B.foo|hits|env:default,resource:ζ,service:B,version:1.3":         expectedCount{value: 1, topLevel: 1},
 	}
 
 	assert.Len(sb.Counts, len(expectedCounts), "Missing counts!")
@@ -205,7 +212,8 @@ func TestStatsBucketExtraAggregators(t *testing.T) {
 		if !ok {
 			assert.Fail("Unexpected count %s", ckey)
 		}
-		assert.Equal(val, c.Value, "Count %s wrong value", ckey)
+		assert.Equal(val.value, c.Value, "Count %s wrong value", ckey)
+		assert.Equal(val.topLevel, c.TopLevel, "Count %s wrong topLevel", ckey)
 		keyFields := strings.Split(ckey, "|")
 		tags := NewTagSetFromString(keyFields[2])
 		assert.Equal(tags, c.TagSet, "bad tagset for count %s", ckey)
@@ -320,10 +328,14 @@ func TestStatsBucketSublayers(t *testing.T) {
 	}
 
 	expectedDistributions := map[string]expectedDistribution{
-		"A.foo|duration|env:default,resource:α,service:A":                                        expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 1},
-		"B.bar|duration|env:default,resource:α,service:B":                                        expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 1},
-		"sql.query|duration|env:default,resource:SELECT value FROM table,service:C":              expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 1},
-		"sql.query|duration|env:default,resource:SELECT ololololo... value FROM table,service:C": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 1},
+		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 1},
+		"B.bar|duration|env:default,resource:α,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 1},
+		"sql.query|duration|env:default,resource:SELECT value FROM table,service:C": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 1},
+		"sql.query|duration|env:default,resource:SELECT ololololo... value FROM table,service:C": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 1},
 	}
 
 	assert.Len(sb.Distributions, len(expectedDistributions), "Missing distributions!")
@@ -405,11 +417,15 @@ func TestStatsBucketSublayersTopLevel(t *testing.T) {
 	}
 
 	expectedDistributions := map[string]expectedDistribution{
-		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 1},
-		"B.bar|duration|env:default,resource:α,service:B": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 1},
+		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 1},
+		"B.bar|duration|env:default,resource:α,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 1},
 		// [TODO] the ultimate target is to *NOT* compute & store the counts below, which have topLevel == 0
-		"B.bar.1|duration|env:default,resource:α,service:B": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 0},
-		"B.bar.2|duration|env:default,resource:α,service:B": expectedDistribution{entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 0},
+		"B.bar.1|duration|env:default,resource:α,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 0},
+		"B.bar.2|duration|env:default,resource:α,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 0},
 	}
 
 	assert.Len(sb.Distributions, len(expectedDistributions), "Missing distributions!")

--- a/model/statsraw.go
+++ b/model/statsraw.go
@@ -201,9 +201,6 @@ func (sb *StatsRawBucket) HandleSpan(s Span, env string, aggregators []string, w
 }
 
 func (sb *StatsRawBucket) add(s Span, weight float64, aggr string, tags TagSet) {
-	// [TODO:christian] the day we want to skip stats on non top-level spans
-	// totally, do it here.
-
 	var gs groupedStats
 	var ok bool
 

--- a/model/statsraw.go
+++ b/model/statsraw.go
@@ -190,6 +190,11 @@ func (sb *StatsRawBucket) HandleSpan(s Span, env string, aggregators []string, w
 }
 
 func (sb *StatsRawBucket) add(s Span, weight float64, aggr string, tags TagSet) {
+	// if this is not a top-level name -> don't keep track of any stats
+	if _, ok := s.Meta[topLevelTag]; !ok {
+		return
+	}
+
 	var gs groupedStats
 	var ok bool
 

--- a/model/statsraw.go
+++ b/model/statsraw.go
@@ -11,8 +11,11 @@ import (
 // is that the final data, the one with send after a call to Export(), is correct.
 
 type groupedStats struct {
-	tags                 TagSet
-	keepStats            bool
+	tags TagSet
+
+	topLevel     bool
+	forceMetrics bool
+
 	hits                 float64
 	errors               float64
 	duration             float64
@@ -20,9 +23,12 @@ type groupedStats struct {
 }
 
 type sublayerStats struct {
-	tags      TagSet
-	keepStats bool
-	value     int64
+	tags TagSet
+
+	topLevel     bool
+	forceMetrics bool
+
+	value int64
 }
 
 func newGroupedStats(tags TagSet) groupedStats {
@@ -85,49 +91,54 @@ func (sb *StatsRawBucket) Export() StatsBucket {
 	for k, v := range sb.data {
 		hitsKey := GrainKey(k.name, HITS, k.aggr)
 		ret.Counts[hitsKey] = Count{
-			Key:       hitsKey,
-			Name:      k.name,
-			Measure:   HITS,
-			TagSet:    v.tags,
-			SkipStats: !v.keepStats,
-			Value:     float64(v.hits),
+			Key:          hitsKey,
+			Name:         k.name,
+			Measure:      HITS,
+			TagSet:       v.tags,
+			SubName:      !v.topLevel,
+			ForceMetrics: v.forceMetrics,
+			Value:        float64(v.hits),
 		}
 		errorsKey := GrainKey(k.name, ERRORS, k.aggr)
 		ret.Counts[errorsKey] = Count{
-			Key:       errorsKey,
-			Name:      k.name,
-			Measure:   ERRORS,
-			TagSet:    v.tags,
-			SkipStats: !v.keepStats,
-			Value:     float64(v.errors),
+			Key:          errorsKey,
+			Name:         k.name,
+			Measure:      ERRORS,
+			TagSet:       v.tags,
+			SubName:      !v.topLevel,
+			ForceMetrics: v.forceMetrics,
+			Value:        float64(v.errors),
 		}
 		durationKey := GrainKey(k.name, DURATION, k.aggr)
 		ret.Counts[durationKey] = Count{
-			Key:       durationKey,
-			Name:      k.name,
-			Measure:   DURATION,
-			TagSet:    v.tags,
-			SkipStats: !v.keepStats,
-			Value:     float64(v.duration),
+			Key:          durationKey,
+			Name:         k.name,
+			Measure:      DURATION,
+			TagSet:       v.tags,
+			SubName:      !v.topLevel,
+			ForceMetrics: v.forceMetrics,
+			Value:        float64(v.duration),
 		}
 		ret.Distributions[durationKey] = Distribution{
-			Key:       durationKey,
-			Name:      k.name,
-			Measure:   DURATION,
-			TagSet:    v.tags,
-			SkipStats: !v.keepStats,
-			Summary:   v.durationDistribution,
+			Key:          durationKey,
+			Name:         k.name,
+			Measure:      DURATION,
+			TagSet:       v.tags,
+			SubName:      !v.topLevel,
+			ForceMetrics: v.forceMetrics,
+			Summary:      v.durationDistribution,
 		}
 	}
 	for k, v := range sb.sublayerData {
 		key := GrainKey(k.name, k.measure, k.aggr)
 		ret.Counts[key] = Count{
-			Key:       key,
-			Name:      k.name,
-			Measure:   k.measure,
-			TagSet:    v.tags,
-			SkipStats: !v.keepStats,
-			Value:     float64(v.value),
+			Key:          key,
+			Name:         k.name,
+			Measure:      k.measure,
+			TagSet:       v.tags,
+			SubName:      !v.topLevel,
+			ForceMetrics: v.forceMetrics,
+			Value:        float64(v.value),
 		}
 	}
 	return ret
@@ -200,7 +211,7 @@ func (sb *StatsRawBucket) add(s Span, weight float64, aggr string, tags TagSet) 
 	// [TODO:christian] the day we want to skip stats on non top-level spans
 	// totally, do it with something like:
 	// // if this is not a top-level name -> don't keep track of any stats
-	// if _, ok := s.Meta[keepStatsTag]; !ok {
+	// if !s.TopLevel() && !s.ForceMetrics() {
 	//     return
 	// }
 
@@ -212,9 +223,13 @@ func (sb *StatsRawBucket) add(s Span, weight float64, aggr string, tags TagSet) 
 		gs = newGroupedStats(tags)
 	}
 
-	// keep stats if at least one span requires it
-	if !s.SkipStats() {
-		gs.keepStats = true
+	// if at least one span is marked, taint the whole stat
+	if s.TopLevel() {
+		gs.topLevel = true
+	}
+	// if at least one span is marked as forced, taint the whole stat
+	if s.ForceMetrics() {
+		gs.forceMetrics = true
 	}
 
 	gs.hits += weight
@@ -250,9 +265,13 @@ func (sb *StatsRawBucket) addSublayer(s Span, aggr string, tags TagSet, sub Subl
 		ss = newSublayerStats(subTags)
 	}
 
-	// keep stats if at least one span requires it
-	if !s.SkipStats() {
-		ss.keepStats = true
+	// if at least one span is marked, taint the whole stat
+	if s.TopLevel() {
+		ss.topLevel = true
+	}
+	// if at least one span is marked as forced, taint the whole stat
+	if s.ForceMetrics() {
+		ss.forceMetrics = true
 	}
 
 	ss.value += int64(sub.Value)

--- a/model/top_level.go
+++ b/model/top_level.go
@@ -1,0 +1,37 @@
+package model
+
+// ComputeTopLevel updates all the spans TopLevel field.
+//
+// A span is considered top-level if:
+// - it's a root span
+// - its parent is unknown (other part of the code, distributed trace)
+// - its parent belongs to another service (in that case it's a "local root"
+//   being the highest ancestor of other spans belonging to this service and
+//   attached to it).
+func (t Trace) ComputeTopLevel() {
+	// build a lookup map
+	spanIDToIdx := make(map[uint64]int, len(t))
+	for i, v := range t {
+		spanIDToIdx[v.SpanID] = i
+	}
+
+	// iterate on each span and mark them as top-level if relevant
+	for i, span := range t {
+		if span.ParentID == 0 {
+			// Root Span -> top-level
+			t[i].TopLevel = true
+			continue
+		}
+		parentIdx, ok := spanIDToIdx[span.ParentID]
+		if !ok {
+			// Unknown parent -> top-level
+			t[i].TopLevel = true
+			continue
+		}
+		if t[parentIdx].Service != span.Service {
+			// Parent and self have different services -> top-level
+			t[i].TopLevel = true
+			continue
+		}
+	}
+}

--- a/model/top_level.go
+++ b/model/top_level.go
@@ -60,13 +60,10 @@ func (s *Span) setTopLevel(topLevel bool) {
 
 // TopLevel returns true if span is top-level.
 func (s *Span) TopLevel() bool {
-	return !(s.Meta[subNameTag] == trueTagValue)
+	return s.Meta[subNameTag] != trueTagValue
 }
 
-// SkipStats returns true if statistics should not be computed for this span.
-func (s *Span) SkipStats() bool {
-	if s.Meta[TraceMetricsTagKey] == trueTagValue {
-		return false
-	}
-	return !s.TopLevel()
+// ForceMetrics returns true if statistics computation should be forced for this span.
+func (s *Span) ForceMetrics() bool {
+	return s.Meta[TraceMetricsTagKey] == trueTagValue
 }

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -149,3 +149,15 @@ func TestTopLevelGetSetMeta(t *testing.T) {
 	span.setTopLevel(true)
 	assert.True(span.TopLevel(), "top-level again")
 }
+
+func TestForceMetrics(t *testing.T) {
+	assert := assert.New(t)
+
+	span := Span{}
+
+	assert.False(span.ForceMetrics(), "by default, metrics are not enforced for sub name spans")
+	span.Meta = map[string]string{"datadog.trace_metrics": "true"}
+	assert.True(span.ForceMetrics(), "metrics should be enforced because tag is present")
+	span.Meta = map[string]string{"env": "dev"}
+	assert.False(span.ForceMetrics(), "there's a tag, but metrics should not be enforced anyway")
+}

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTopLevel(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{
+		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
+		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
+		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
+		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
+	}
+
+	tr.ComputeTopLevel()
+
+	assert.True(tr[0].TopLevel, "root span should be top-level")
+	assert.False(tr[1].TopLevel, "main service, and not a root span, not top-level")
+	assert.True(tr[2].TopLevel, "only 1 span for this service, should be top-level")
+	assert.True(tr[3].TopLevel, "only 1 span for this service, should be top-level")
+	assert.False(tr[4].TopLevel, "yet another sup span, not top-level")
+}

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTopLevel(t *testing.T) {
+func TestTopLevelTypical(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
@@ -24,4 +24,86 @@ func TestTopLevel(t *testing.T) {
 	assert.Equal("true", tr[2].Meta["_top_level"], "only 1 span for this service, should be top-level")
 	assert.Equal("true", tr[3].Meta["_top_level"], "only 1 span for this service, should be top-level")
 	assert.Nil(tr[4].Meta, "yet another sup span, not top-level")
+}
+
+func TestTopLevelSingle(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{
+		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+	}
+
+	tr.ComputeTopLevel()
+
+	assert.Equal("true", tr[0].Meta["_top_level"], "root span should be top-level")
+}
+
+func TestTopLevelEmpty(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{}
+
+	tr.ComputeTopLevel()
+
+	assert.Equal(0, len(tr), "trace should still be empty")
+}
+
+func TestTopLevelOneService(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{
+		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: "web"},
+	}
+
+	tr.ComputeTopLevel()
+
+	assert.Nil(tr[0].Meta, "just a sub-span, not top-level")
+	assert.Nil(tr[1].Meta, "just a sub-span, not top-level")
+	assert.Equal("true", tr[2].Meta["_top_level"], "root span should be top-level")
+	assert.Nil(tr[3].Meta, "just a sub-span, not top-level")
+	assert.Nil(tr[4].Meta, "just a sub-span, not top-level")
+}
+
+func TestTopLevelLocalRoot(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{
+		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
+		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
+		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
+		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
+		Span{TraceID: 1, SpanID: 6, ParentID: 4, Service: "redis", Type: "redis"},
+		Span{TraceID: 1, SpanID: 7, ParentID: 4, Service: "redis", Type: "redis"},
+	}
+
+	tr.ComputeTopLevel()
+
+	assert.Equal("true", tr[0].Meta["_top_level"], "root span should be top-level")
+	assert.Nil(tr[1].Meta, "main service, and not a root span, not top-level")
+	assert.Equal("true", tr[2].Meta["_top_level"], "only 1 span for this service, should be top-level")
+	assert.Equal("true", tr[3].Meta["_top_level"], "top-level but not root")
+	assert.Nil(tr[4].Meta, "yet another sup span, not top-level")
+	assert.Nil(tr[5].Meta, "yet another sup span, not top-level")
+	assert.Nil(tr[6].Meta, "yet another sup span, not top-level")
+}
+
+func TestTopLevelWithTag(t *testing.T) {
+	assert := assert.New(t)
+
+	tr := Trace{
+		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web", Meta: map[string]string{"env": "prod"}},
+		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web", Meta: map[string]string{"env": "prod"}},
+	}
+
+	tr.ComputeTopLevel()
+
+	assert.Equal("true", tr[0].Meta["_top_level"], "root span should be top-level")
+	assert.Equal("prod", tr[0].Meta["env"], "env tag should still be here")
+	assert.Equal("", tr[1].Meta["_top_level"], "not a top-level span")
+	assert.Equal("prod", tr[1].Meta["env"], "env tag should still be here")
 }

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -19,9 +19,9 @@ func TestTopLevel(t *testing.T) {
 
 	tr.ComputeTopLevel()
 
-	assert.True(tr[0].TopLevel, "root span should be top-level")
-	assert.False(tr[1].TopLevel, "main service, and not a root span, not top-level")
-	assert.True(tr[2].TopLevel, "only 1 span for this service, should be top-level")
-	assert.True(tr[3].TopLevel, "only 1 span for this service, should be top-level")
-	assert.False(tr[4].TopLevel, "yet another sup span, not top-level")
+	assert.Equal("true", tr[0].Meta["_top_level"], "root span should be top-level")
+	assert.Nil(tr[1].Meta, "main service, and not a root span, not top-level")
+	assert.Equal("true", tr[2].Meta["_top_level"], "only 1 span for this service, should be top-level")
+	assert.Equal("true", tr[3].Meta["_top_level"], "only 1 span for this service, should be top-level")
+	assert.Nil(tr[4].Meta, "yet another sup span, not top-level")
 }

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -115,19 +115,19 @@ func TestTopLevelGetSetBlackBox(t *testing.T) {
 
 	span := Span{}
 
-	assert.True(span.TopLevel(), "by default, all spans are considered top-level")
-	span.setTopLevel(false)
-	assert.False(span.TopLevel(), "marked as non top-level (AKA subname)")
+	assert.False(span.TopLevel(), "by default, all spans are considered non top-level")
 	span.setTopLevel(true)
-	assert.True(span.TopLevel(), "top-level again")
+	assert.True(span.TopLevel(), "marked as top-level")
+	span.setTopLevel(false)
+	assert.False(span.TopLevel(), "no more top-level")
 
 	span.Meta = map[string]string{"env": "staging"}
 
-	assert.True(span.TopLevel(), "by default, all spans are considered top-level")
-	span.setTopLevel(false)
-	assert.False(span.TopLevel(), "marked as non top-level (AKA subname)")
+	assert.False(span.TopLevel(), "by default, all spans are considered non top-level")
 	span.setTopLevel(true)
-	assert.True(span.TopLevel(), "top-level again")
+	assert.True(span.TopLevel(), "marked as top-level")
+	span.setTopLevel(false)
+	assert.False(span.TopLevel(), "no more top-level")
 }
 
 func TestTopLevelGetSetMeta(t *testing.T) {
@@ -135,19 +135,23 @@ func TestTopLevelGetSetMeta(t *testing.T) {
 
 	span := Span{}
 
-	span.setTopLevel(false)
-	assert.Equal("true", span.Meta["_sub_name"], "should have a _sub_name:true flag")
+	assert.Nil(span.Meta, "no meta at all")
 	span.setTopLevel(true)
+	assert.Equal("true", span.Meta["_top_level"], "should have a _top_level:true flag")
+	span.setTopLevel(false)
 	assert.Nil(span.Meta, "no meta at all")
 
 	span.Meta = map[string]string{"env": "staging"}
 
-	span.setTopLevel(false)
-	assert.Equal("true", span.Meta["_sub_name"], "should have a _sub_name:true flag")
-	assert.Equal("staging", span.Meta["env"], "former tags should still be here")
-	assert.False(span.TopLevel(), "marked as non top-level (AKA subname)")
+	assert.False(span.TopLevel(), "still non top-level")
 	span.setTopLevel(true)
-	assert.True(span.TopLevel(), "top-level again")
+	assert.Equal("true", span.Meta["_top_level"], "should have a _top_level:true flag")
+	assert.Equal("staging", span.Meta["env"], "former tags should still be here")
+	assert.True(span.TopLevel(), "marked as top-level")
+	span.setTopLevel(false)
+	assert.False(span.TopLevel(), "non top-level any more")
+	assert.Equal("", span.Meta["_top_level"], "should have no _top_level:true flag")
+	assert.Equal("staging", span.Meta["env"], "former tags should still be here")
 }
 
 func TestForceMetrics(t *testing.T) {

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -136,7 +136,6 @@ func TestTopLevelGetSetMeta(t *testing.T) {
 	span := Span{}
 
 	span.setTopLevel(false)
-	assert.Nil(span.Meta, "no meta at all")
 	assert.Equal("true", span.Meta["_sub_name"], "should have a _sub_name:true flag")
 	span.setTopLevel(true)
 	assert.Nil(span.Meta, "no meta at all")


### PR DESCRIPTION
This adds:
- a `TopLevel` func on spans which returns a boolean telling wether it's top-level or not
- a `TopLevel`member to stats, which contains the number of top-level spans contributing to it