### PR TITLE
drop legacy receiver port

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -19,10 +19,6 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
-// The trace agent used to listen on port 7777, but now uses port 8126. Keep
-// listening on 7777 during the transition.
-const legacyReceiverPort = 7777
-
 const (
 	maxRequestBodyLength = 10 * 1024 * 1024
 	tagTraceHandler      = "handler:traces"
@@ -99,11 +95,6 @@ func (r *HTTPReceiver) Run() {
 	addr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, r.conf.ReceiverPort)
 	if err := r.Listen(addr, ""); err != nil {
 		die("%v", err)
-	}
-
-	legacyAddr := fmt.Sprintf("%s:%d", r.conf.ReceiverHost, legacyReceiverPort)
-	if err := r.Listen(legacyAddr, " (legacy)"); err != nil {
-		log.Error(err)
 	}
 
 	watchdog.Go(func() {


### PR DESCRIPTION
follows up on the discussion in #266 to actually stop binding to the legacy port 7777