### PR TITLE
[normalizer] Normalize Third Party Integrations

### DIFF
--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -237,6 +237,24 @@ func TestNormalizeEnv(t *testing.T) {
 	assert.Equal(t, "development", s.Meta["env"])
 }
 
+func TestNormalizeThirdPartyIntegrationsMissingStatusCode(t *testing.T) {
+	s := testSpan()
+	s.Name = "django.request"
+	s.Meta = map[string]string{}
+	s.Normalize()
+	assert.Equal(t, "500", s.Meta["http.status_code"])
+}
+
+func TestNormalizeThirdPartyIntegrationsNoMissingStatusCode(t *testing.T) {
+	s := testSpan()
+	s.Name = "django.request"
+	s.Meta = map[string]string{
+		"http.status_code": "404",
+	}
+	s.Normalize()
+	assert.Equal(t, "404", s.Meta["http.status_code"])
+}
+
 func TestSpecialZipkinRootSpan(t *testing.T) {
 	s := testSpan()
 	s.ParentID = 42


### PR DESCRIPTION
Sometimes, our client libraries third party integrations might end up sending malformed spans. For example, we noticed some spans tracing a web framework with a missing `http.status_code` tag.

This patch series adds the `normalizeThirdPartyIntegrations` function, called when a span is normalized. For now, the function makes sure web framework integrations sets a `http.status_code` tag, and if not will manually set it to 500.