### PR TITLE
[toplevelname] added sampling support to top-level count

### DIFF
--- a/model/stats.go
+++ b/model/stats.go
@@ -28,7 +28,7 @@ type Count struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time" (was Name)
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	TopLevel int64 `json:"top_level"` // number of top-level spans contributing to this count
+	TopLevel float64 `json:"top_level"` // number of top-level spans contributing to this count
 
 	Value float64 `json:"value"` // accumulated values
 }
@@ -40,7 +40,7 @@ type Distribution struct {
 	Measure string `json:"measure"` // represents the entity we count, e.g. "hits", "errors", "time"
 	TagSet  TagSet `json:"tagset"`  // set of tags for which we account this Distribution
 
-	TopLevel int64 `json:"top_level"` // number of top-level spans contributing to this count
+	TopLevel float64 `json:"top_level"` // number of top-level spans contributing to this count
 
 	Summary *quantile.SliceSummary `json:"summary"` // actual representation of data
 }

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -90,12 +90,12 @@ func TestGrainKey(t *testing.T) {
 
 type expectedCount struct {
 	value    float64
-	topLevel int64
+	topLevel float64
 }
 
 type expectedDistribution struct {
 	entries  []quantile.Entry
-	topLevel int64
+	topLevel float64
 }
 
 func TestStatsBucketDefault(t *testing.T) {
@@ -281,42 +281,42 @@ func TestStatsBucketSublayers(t *testing.T) {
 	sb := srb.Export()
 
 	expectedCounts := map[string]expectedCount{
-		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:A":                                        expectedCount{value: 160, topLevel: 1},
-		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:B":                                        expectedCount{value: 24, topLevel: 1},
-		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:C":                                        expectedCount{value: 16, topLevel: 1},
-		"A.foo|_sublayers.duration.by_type|env:default,resource:α,service:A,sublayer_type:sql":                                            expectedCount{value: 16, topLevel: 1},
-		"A.foo|_sublayers.duration.by_type|env:default,resource:α,service:A,sublayer_type:web":                                            expectedCount{value: 184, topLevel: 1},
-		"A.foo|_sublayers.span_count|env:default,resource:α,service:A,:":                                                                  expectedCount{value: 8, topLevel: 1},
-		"A.foo|duration|env:default,resource:α,service:A":                                                                                 expectedCount{value: 200, topLevel: 1},
-		"A.foo|errors|env:default,resource:α,service:A":                                                                                   expectedCount{value: 0, topLevel: 1},
-		"A.foo|hits|env:default,resource:α,service:A":                                                                                     expectedCount{value: 2, topLevel: 1},
-		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:A":                                        expectedCount{value: 160, topLevel: 1},
-		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:B":                                        expectedCount{value: 24, topLevel: 1},
-		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:C":                                        expectedCount{value: 16, topLevel: 1},
-		"B.bar|_sublayers.duration.by_type|env:default,resource:α,service:B,sublayer_type:sql":                                            expectedCount{value: 16, topLevel: 1},
-		"B.bar|_sublayers.duration.by_type|env:default,resource:α,service:B,sublayer_type:web":                                            expectedCount{value: 184, topLevel: 1},
-		"B.bar|_sublayers.span_count|env:default,resource:α,service:B,:":                                                                  expectedCount{value: 8, topLevel: 1},
-		"B.bar|duration|env:default,resource:α,service:B":                                                                                 expectedCount{value: 40, topLevel: 1},
-		"B.bar|errors|env:default,resource:α,service:B":                                                                                   expectedCount{value: 0, topLevel: 1},
-		"B.bar|hits|env:default,resource:α,service:B":                                                                                     expectedCount{value: 2, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:A": expectedCount{value: 160, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:B": expectedCount{value: 24, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:C": expectedCount{value: 16, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:A":              expectedCount{value: 160, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:B":              expectedCount{value: 24, topLevel: 1},
-		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:C":              expectedCount{value: 16, topLevel: 1},
-		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_type:sql":     expectedCount{value: 16, topLevel: 1},
-		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_type:web":     expectedCount{value: 184, topLevel: 1},
-		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT value FROM table,service:C,sublayer_type:sql":                  expectedCount{value: 16, topLevel: 1},
-		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT value FROM table,service:C,sublayer_type:web":                  expectedCount{value: 184, topLevel: 1},
-		"sql.query|_sublayers.span_count|env:default,resource:SELECT ololololo... value FROM table,service:C,:":                           expectedCount{value: 8, topLevel: 1},
-		"sql.query|_sublayers.span_count|env:default,resource:SELECT value FROM table,service:C,:":                                        expectedCount{value: 8, topLevel: 1},
-		"sql.query|duration|env:default,resource:SELECT ololololo... value FROM table,service:C":                                          expectedCount{value: 6, topLevel: 1},
-		"sql.query|duration|env:default,resource:SELECT value FROM table,service:C":                                                       expectedCount{value: 10, topLevel: 1},
-		"sql.query|errors|env:default,resource:SELECT ololololo... value FROM table,service:C":                                            expectedCount{value: 2, topLevel: 1},
-		"sql.query|errors|env:default,resource:SELECT value FROM table,service:C":                                                         expectedCount{value: 0, topLevel: 1},
-		"sql.query|hits|env:default,resource:SELECT ololololo... value FROM table,service:C":                                              expectedCount{value: 2, topLevel: 1},
-		"sql.query|hits|env:default,resource:SELECT value FROM table,service:C":                                                           expectedCount{value: 2, topLevel: 1},
+		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:A":                                        expectedCount{value: 160, topLevel: 2},
+		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:B":                                        expectedCount{value: 24, topLevel: 2},
+		"A.foo|_sublayers.duration.by_service|env:default,resource:α,service:A,sublayer_service:C":                                        expectedCount{value: 16, topLevel: 2},
+		"A.foo|_sublayers.duration.by_type|env:default,resource:α,service:A,sublayer_type:sql":                                            expectedCount{value: 16, topLevel: 2},
+		"A.foo|_sublayers.duration.by_type|env:default,resource:α,service:A,sublayer_type:web":                                            expectedCount{value: 184, topLevel: 2},
+		"A.foo|_sublayers.span_count|env:default,resource:α,service:A,:":                                                                  expectedCount{value: 8, topLevel: 2},
+		"A.foo|duration|env:default,resource:α,service:A":                                                                                 expectedCount{value: 200, topLevel: 2},
+		"A.foo|errors|env:default,resource:α,service:A":                                                                                   expectedCount{value: 0, topLevel: 2},
+		"A.foo|hits|env:default,resource:α,service:A":                                                                                     expectedCount{value: 2, topLevel: 2},
+		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:A":                                        expectedCount{value: 160, topLevel: 2},
+		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:B":                                        expectedCount{value: 24, topLevel: 2},
+		"B.bar|_sublayers.duration.by_service|env:default,resource:α,service:B,sublayer_service:C":                                        expectedCount{value: 16, topLevel: 2},
+		"B.bar|_sublayers.duration.by_type|env:default,resource:α,service:B,sublayer_type:sql":                                            expectedCount{value: 16, topLevel: 2},
+		"B.bar|_sublayers.duration.by_type|env:default,resource:α,service:B,sublayer_type:web":                                            expectedCount{value: 184, topLevel: 2},
+		"B.bar|_sublayers.span_count|env:default,resource:α,service:B,:":                                                                  expectedCount{value: 8, topLevel: 2},
+		"B.bar|duration|env:default,resource:α,service:B":                                                                                 expectedCount{value: 40, topLevel: 2},
+		"B.bar|errors|env:default,resource:α,service:B":                                                                                   expectedCount{value: 0, topLevel: 2},
+		"B.bar|hits|env:default,resource:α,service:B":                                                                                     expectedCount{value: 2, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:A": expectedCount{value: 160, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:B": expectedCount{value: 24, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_service:C": expectedCount{value: 16, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:A":              expectedCount{value: 160, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:B":              expectedCount{value: 24, topLevel: 2},
+		"sql.query|_sublayers.duration.by_service|env:default,resource:SELECT value FROM table,service:C,sublayer_service:C":              expectedCount{value: 16, topLevel: 2},
+		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_type:sql":     expectedCount{value: 16, topLevel: 2},
+		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT ololololo... value FROM table,service:C,sublayer_type:web":     expectedCount{value: 184, topLevel: 2},
+		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT value FROM table,service:C,sublayer_type:sql":                  expectedCount{value: 16, topLevel: 2},
+		"sql.query|_sublayers.duration.by_type|env:default,resource:SELECT value FROM table,service:C,sublayer_type:web":                  expectedCount{value: 184, topLevel: 2},
+		"sql.query|_sublayers.span_count|env:default,resource:SELECT ololololo... value FROM table,service:C,:":                           expectedCount{value: 8, topLevel: 2},
+		"sql.query|_sublayers.span_count|env:default,resource:SELECT value FROM table,service:C,:":                                        expectedCount{value: 8, topLevel: 2},
+		"sql.query|duration|env:default,resource:SELECT ololololo... value FROM table,service:C":                                          expectedCount{value: 6, topLevel: 2},
+		"sql.query|duration|env:default,resource:SELECT value FROM table,service:C":                                                       expectedCount{value: 10, topLevel: 2},
+		"sql.query|errors|env:default,resource:SELECT ololololo... value FROM table,service:C":                                            expectedCount{value: 2, topLevel: 2},
+		"sql.query|errors|env:default,resource:SELECT value FROM table,service:C":                                                         expectedCount{value: 0, topLevel: 2},
+		"sql.query|hits|env:default,resource:SELECT ololololo... value FROM table,service:C":                                              expectedCount{value: 2, topLevel: 2},
+		"sql.query|hits|env:default,resource:SELECT value FROM table,service:C":                                                           expectedCount{value: 2, topLevel: 2},
 	}
 
 	assert.Len(sb.Counts, len(expectedCounts), "Missing counts!")
@@ -334,13 +334,13 @@ func TestStatsBucketSublayers(t *testing.T) {
 
 	expectedDistributions := map[string]expectedDistribution{
 		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{
-			entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 1},
+			entries: []quantile.Entry{quantile.Entry{V: 100, G: 1, Delta: 0}}, topLevel: 2},
 		"B.bar|duration|env:default,resource:α,service:B": expectedDistribution{
-			entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 1},
+			entries: []quantile.Entry{quantile.Entry{V: 20, G: 1, Delta: 0}}, topLevel: 2},
 		"sql.query|duration|env:default,resource:SELECT value FROM table,service:C": expectedDistribution{
-			entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 1},
+			entries: []quantile.Entry{quantile.Entry{V: 5, G: 1, Delta: 0}}, topLevel: 2},
 		"sql.query|duration|env:default,resource:SELECT ololololo... value FROM table,service:C": expectedDistribution{
-			entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 1},
+			entries: []quantile.Entry{quantile.Entry{V: 3, G: 1, Delta: 0}}, topLevel: 2},
 	}
 
 	assert.Len(sb.Distributions, len(expectedDistributions), "Missing distributions!")

--- a/model/statsraw.go
+++ b/model/statsraw.go
@@ -13,7 +13,7 @@ import (
 type groupedStats struct {
 	tags TagSet
 
-	topLevel int64
+	topLevel float64
 
 	hits                 float64
 	errors               float64
@@ -24,7 +24,7 @@ type groupedStats struct {
 type sublayerStats struct {
 	tags TagSet
 
-	topLevel int64
+	topLevel float64
 
 	value int64
 }
@@ -210,7 +210,7 @@ func (sb *StatsRawBucket) add(s Span, weight float64, aggr string, tags TagSet) 
 	}
 
 	if s.TopLevel() {
-		gs.topLevel++
+		gs.topLevel += weight
 	}
 
 	gs.hits += weight
@@ -247,7 +247,7 @@ func (sb *StatsRawBucket) addSublayer(s Span, weight float64, aggr string, tags 
 	}
 
 	if s.TopLevel() {
-		ss.topLevel++
+		ss.topLevel += weight
 	}
 
 	ss.value += int64(weight * sub.Value)


### PR DESCRIPTION
Similar to https://github.com/DataDog/datadog-trace-agent/pull/281 to some extent. Switching from int64 to float64 is fine (new code reading float64 will also accept int64 as it transits in JSON).