### PR TITLE
[toplevelname] fix concurrent map access

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -167,10 +167,13 @@ func (a *Agent) Process(t model.Trace) {
 		pt.Env = tenv
 	}
 
-	weight := pt.weight() // need to do this now because sampler edits .Metrics map
-	topLevelSpans := t.TopLevelSpans()
+	// Need to do this computation before entering the concentrator
+	// as they access the Metrics map, which is not thread safe.
+	t.ComputeWeight(*root)
+	t.ComputeTopLevel()
+
 	watchdog.Go(func() {
-		a.Concentrator.Add(pt, weight, topLevelSpans)
+		a.Concentrator.Add(pt)
 	})
 	watchdog.Go(func() {
 		a.Sampler.Add(pt)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -168,8 +168,9 @@ func (a *Agent) Process(t model.Trace) {
 	}
 
 	weight := pt.weight() // need to do this now because sampler edits .Metrics map
+	topLevelSpans := t.TopLevelSpans()
 	watchdog.Go(func() {
-		a.Concentrator.Add(pt, weight)
+		a.Concentrator.Add(pt, weight, topLevelSpans)
 	})
 	watchdog.Go(func() {
 		a.Sampler.Add(pt)

--- a/agent/concentrator.go
+++ b/agent/concentrator.go
@@ -34,7 +34,7 @@ func NewConcentrator(aggregators []string, bsize int64) *Concentrator {
 }
 
 // Add appends to the proper stats bucket this trace's statistics
-func (c *Concentrator) Add(t processedTrace, weight float64, topLevelSpans map[uint64]struct{}) {
+func (c *Concentrator) Add(t processedTrace) {
 	c.mu.Lock()
 
 	for _, s := range t.Trace {
@@ -47,9 +47,9 @@ func (c *Concentrator) Add(t processedTrace, weight float64, topLevelSpans map[u
 
 		if t.Root != nil && s.SpanID == t.Root.SpanID && t.Sublayers != nil {
 			// handle sublayers
-			b.HandleSpan(s, t.Env, c.aggregators, weight, topLevelSpans, &t.Sublayers)
+			b.HandleSpan(s, t.Env, c.aggregators, &t.Sublayers)
 		} else {
-			b.HandleSpan(s, t.Env, c.aggregators, weight, topLevelSpans, nil)
+			b.HandleSpan(s, t.Env, c.aggregators, nil)
 		}
 	}
 

--- a/agent/concentrator.go
+++ b/agent/concentrator.go
@@ -34,7 +34,7 @@ func NewConcentrator(aggregators []string, bsize int64) *Concentrator {
 }
 
 // Add appends to the proper stats bucket this trace's statistics
-func (c *Concentrator) Add(t processedTrace, weight float64) {
+func (c *Concentrator) Add(t processedTrace, weight float64, topLevelSpans map[uint64]struct{}) {
 	c.mu.Lock()
 
 	for _, s := range t.Trace {
@@ -47,9 +47,9 @@ func (c *Concentrator) Add(t processedTrace, weight float64) {
 
 		if t.Root != nil && s.SpanID == t.Root.SpanID && t.Sublayers != nil {
 			// handle sublayers
-			b.HandleSpan(s, t.Env, c.aggregators, weight, &t.Sublayers)
+			b.HandleSpan(s, t.Env, c.aggregators, weight, topLevelSpans, &t.Sublayers)
 		} else {
-			b.HandleSpan(s, t.Env, c.aggregators, weight, nil)
+			b.HandleSpan(s, t.Env, c.aggregators, weight, topLevelSpans, nil)
 		}
 	}
 

--- a/agent/concentrator_test.go
+++ b/agent/concentrator_test.go
@@ -63,8 +63,9 @@ func TestConcentratorStatsCounts(t *testing.T) {
 			testSpan(c, 6, 24, 1, "A1", "resource2", 0),
 		},
 	}
+	testTrace.Trace.ComputeTopLevel()
 
-	c.Add(testTrace, testTrace.weight())
+	c.Add(testTrace, testTrace.weight(), testTrace.Trace.TopLevelSpans())
 	stats := c.Flush()
 
 	if !assert.Equal(2, len(stats), "We should get exactly 2 StatsBucket") {

--- a/agent/concentrator_test.go
+++ b/agent/concentrator_test.go
@@ -63,9 +63,10 @@ func TestConcentratorStatsCounts(t *testing.T) {
 			testSpan(c, 6, 24, 1, "A1", "resource2", 0),
 		},
 	}
+	testTrace.Trace.ComputeWeight(*testTrace.Trace.GetRoot())
 	testTrace.Trace.ComputeTopLevel()
 
-	c.Add(testTrace, testTrace.weight(), testTrace.Trace.TopLevelSpans())
+	c.Add(testTrace)
 	stats := c.Flush()
 
 	if !assert.Equal(2, len(stats), "We should get exactly 2 StatsBucket") {

--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -24,7 +24,7 @@ func BenchmarkHandleSpanRandom(b *testing.B) {
 		trace := fixtures.RandomTrace(10, 8)
 		root := trace.GetRoot()
 		for _, span := range trace {
-			sb.HandleSpan(span, defaultEnv, aggr, root.Weight(), nil)
+			sb.HandleSpan(span, defaultEnv, aggr, root.Weight(), nil, nil)
 		}
 	}
 }

--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -23,8 +23,10 @@ func BenchmarkHandleSpanRandom(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		trace := fixtures.RandomTrace(10, 8)
 		root := trace.GetRoot()
+		trace.ComputeWeight(*root)
+		trace.ComputeTopLevel()
 		for _, span := range trace {
-			sb.HandleSpan(span, defaultEnv, aggr, root.Weight(), nil, nil)
+			sb.HandleSpan(span, defaultEnv, aggr, nil)
 		}
 	}
 }

--- a/fixtures/stats.go
+++ b/fixtures/stats.go
@@ -12,7 +12,7 @@ const defaultEnv = "none"
 // TestStatsBucket returns a fixed stats bucket to be used in unit tests
 func TestStatsBucket() model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
-	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, 1.0, nil)
+	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, 1.0, nil, nil)
 	sb := srb.Export()
 
 	// marshalling then unmarshalling data to:
@@ -36,7 +36,7 @@ func TestStatsBucket() model.StatsBucket {
 func StatsBucketWithSpans(s []model.Span) model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
 	for _, s := range s {
-		srb.HandleSpan(s, defaultEnv, defaultAggregators, 1.0, nil)
+		srb.HandleSpan(s, defaultEnv, defaultAggregators, 1.0, nil, nil)
 	}
 	return srb.Export()
 }

--- a/fixtures/stats.go
+++ b/fixtures/stats.go
@@ -12,7 +12,7 @@ const defaultEnv = "none"
 // TestStatsBucket returns a fixed stats bucket to be used in unit tests
 func TestStatsBucket() model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
-	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, 1.0, nil, nil)
+	srb.HandleSpan(TestSpan(), defaultEnv, defaultAggregators, nil)
 	sb := srb.Export()
 
 	// marshalling then unmarshalling data to:
@@ -36,7 +36,7 @@ func TestStatsBucket() model.StatsBucket {
 func StatsBucketWithSpans(s []model.Span) model.StatsBucket {
 	srb := model.NewStatsRawBucket(0, 1e9)
 	for _, s := range s {
-		srb.HandleSpan(s, defaultEnv, defaultAggregators, 1.0, nil, nil)
+		srb.HandleSpan(s, defaultEnv, defaultAggregators, nil)
 	}
 	return srb.Export()
 }

--- a/model/span.go
+++ b/model/span.go
@@ -28,6 +28,12 @@ type Span struct {
 	Metrics  map[string]float64 `json:"metrics" msg:"metrics"`     // arbitrary metrics
 	ParentID uint64             `json:"parent_id" msg:"parent_id"` // span ID of the span in which this one was created
 	Type     string             `json:"type" msg:"type"`           // protocol associated with the span
+
+	// Those are cached information, they are here not only for optimization,
+	// but because the func which fill their values read
+	// the Metrics map and causes map read/write concurrent accesses.
+	weight   float64 // caches the result of Weight() called on the root span
+	topLevel bool    // caches the result of TopLevel()
 }
 
 // String formats a Span struct to be displayed as a string

--- a/model/statsraw.go
+++ b/model/statsraw.go
@@ -174,7 +174,7 @@ func assembleGrain(b *bytes.Buffer, env, resource, service string, m map[string]
 }
 
 // HandleSpan adds the span to this bucket stats, aggregated with the finest grain matching given aggregators
-func (sb *StatsRawBucket) HandleSpan(s Span, env string, aggregators []string, weight float64, topLevelSpans map[uint64]struct{}, sublayers *[]SublayerValue) {
+func (sb *StatsRawBucket) HandleSpan(s Span, env string, aggregators []string, sublayers *[]SublayerValue) {
 	if env == "" {
 		panic("env should never be empty")
 	}
@@ -190,17 +190,17 @@ func (sb *StatsRawBucket) HandleSpan(s Span, env string, aggregators []string, w
 	}
 
 	grain, tags := assembleGrain(&sb.keyBuf, env, s.Resource, s.Service, m)
-	sb.add(s, weight, topLevelSpans, grain, tags)
+	sb.add(s, grain, tags)
 
 	// sublayers - special case
 	if sublayers != nil {
 		for _, sub := range *sublayers {
-			sb.addSublayer(s, weight, topLevelSpans, grain, tags, sub)
+			sb.addSublayer(s, grain, tags, sub)
 		}
 	}
 }
 
-func (sb *StatsRawBucket) add(s Span, weight float64, topLevelSpans map[uint64]struct{}, aggr string, tags TagSet) {
+func (sb *StatsRawBucket) add(s Span, aggr string, tags TagSet) {
 	var gs groupedStats
 	var ok bool
 
@@ -209,16 +209,15 @@ func (sb *StatsRawBucket) add(s Span, weight float64, topLevelSpans map[uint64]s
 		gs = newGroupedStats(tags)
 	}
 
-	// Can't call s.TopLevel at it causes a race condition
-	if _, ok := topLevelSpans[s.SpanID]; ok {
-		gs.topLevel += weight
+	if s.topLevel {
+		gs.topLevel += s.weight
 	}
 
-	gs.hits += weight
+	gs.hits += s.weight
 	if s.Error != 0 {
-		gs.errors += weight
+		gs.errors += s.weight
 	}
-	gs.duration += float64(s.Duration) * weight
+	gs.duration += float64(s.Duration) * s.weight
 
 	// TODO add for s.Metrics ability to define arbitrary counts and distros, check some config?
 	// alter resolution of duration distro
@@ -228,7 +227,7 @@ func (sb *StatsRawBucket) add(s Span, weight float64, topLevelSpans map[uint64]s
 	sb.data[key] = gs
 }
 
-func (sb *StatsRawBucket) addSublayer(s Span, weight float64, topLevelSpans map[uint64]struct{}, aggr string, tags TagSet, sub SublayerValue) {
+func (sb *StatsRawBucket) addSublayer(s Span, aggr string, tags TagSet, sub SublayerValue) {
 	// This is not as efficient as a "regular" add as we don't update
 	// all sublayers at once (one call for HITS, and another one for ERRORS, DURATION...)
 	// when logically, if we have a sublayer for HITS, we also have one for DURATION,
@@ -247,12 +246,11 @@ func (sb *StatsRawBucket) addSublayer(s Span, weight float64, topLevelSpans map[
 		ss = newSublayerStats(subTags)
 	}
 
-	// Can't call s.TopLevel at it causes a race condition
-	if _, ok := topLevelSpans[s.SpanID]; ok {
-		ss.topLevel += weight
+	if s.topLevel {
+		ss.topLevel += s.weight
 	}
 
-	ss.value += int64(weight * sub.Value)
+	ss.value += int64(s.weight * sub.Value)
 
 	sb.sublayerData[key] = ss
 }

--- a/model/top_level.go
+++ b/model/top_level.go
@@ -22,8 +22,8 @@ const (
 func (t Trace) ComputeTopLevel() {
 	// build a lookup map
 	spanIDToIdx := make(map[uint64]int, len(t))
-	for i, v := range t {
-		spanIDToIdx[v.SpanID] = i
+	for i, span := range t {
+		spanIDToIdx[span.SpanID] = i
 	}
 
 	// iterate on each span and mark them as top-level if relevant
@@ -35,6 +35,18 @@ func (t Trace) ComputeTopLevel() {
 		}
 		t[i].setTopLevel(true)
 	}
+}
+
+// TopLevelSpans returns the list of all span ids which are marked as top-level.
+// You need to call ComputeTopLevel before, else it returns an empty map.
+func (t Trace) TopLevelSpans() map[uint64]struct{} {
+	ids := make(map[uint64]struct{}, len(t)) // possibly too big, but not gigantic yet ensure only one alloc is done
+	for _, span := range t {
+		if span.TopLevel() {
+			ids[span.SpanID] = struct{}{}
+		}
+	}
+	return ids
 }
 
 // setTopLevel sets the top-level attribute of the span.

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -24,6 +24,13 @@ func TestTopLevelTypical(t *testing.T) {
 	assert.True(tr[2].TopLevel(), "only 1 span for this service, should be top-level")
 	assert.True(tr[3].TopLevel(), "only 1 span for this service, should be top-level")
 	assert.False(tr[4].TopLevel(), "yet another sup span, not top-level")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{
+		1: struct{}{},
+		3: struct{}{},
+		4: struct{}{},
+	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelSingle(t *testing.T) {
@@ -36,6 +43,11 @@ func TestTopLevelSingle(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.True(tr[0].TopLevel(), "root span should be top-level")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{
+		1: struct{}{},
+	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelEmpty(t *testing.T) {
@@ -46,6 +58,10 @@ func TestTopLevelEmpty(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.Equal(0, len(tr), "trace should still be empty")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{},
+		topLevelSpans, "top-level spans map should be empty")
 }
 
 func TestTopLevelOneService(t *testing.T) {
@@ -66,6 +82,11 @@ func TestTopLevelOneService(t *testing.T) {
 	assert.True(tr[2].TopLevel(), "root span should be top-level")
 	assert.False(tr[3].TopLevel(), "just a sub-span, not top-level")
 	assert.False(tr[4].TopLevel(), "just a sub-span, not top-level")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{
+		1: struct{}{},
+	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelLocalRoot(t *testing.T) {
@@ -90,6 +111,13 @@ func TestTopLevelLocalRoot(t *testing.T) {
 	assert.False(tr[4].TopLevel(), "yet another sup span, not top-level")
 	assert.False(tr[5].TopLevel(), "yet another sup span, not top-level")
 	assert.False(tr[6].TopLevel(), "yet another sup span, not top-level")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{
+		1: struct{}{},
+		3: struct{}{},
+		4: struct{}{},
+	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelWithTag(t *testing.T) {
@@ -108,6 +136,11 @@ func TestTopLevelWithTag(t *testing.T) {
 	assert.Equal(float64(42), tr[0].Metrics["custom"], "custom metric should still be here")
 	assert.False(tr[1].TopLevel(), "not a top-level span")
 	assert.Equal(float64(42), tr[1].Metrics["custom"], "custom metric should still be here")
+
+	topLevelSpans := tr.TopLevelSpans()
+	assert.Equal(map[uint64]struct{}{
+		1: struct{}{},
+	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelGetSetBlackBox(t *testing.T) {

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -20,17 +20,15 @@ func TestTopLevelTypical(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.True(tr[0].TopLevel(), "root span should be top-level")
+	assert.True(tr[0].topLevel, "root span should be top-level")
 	assert.False(tr[1].TopLevel(), "main service, and not a root span, not top-level")
+	assert.False(tr[1].topLevel, "main service, and not a root span, not top-level")
 	assert.True(tr[2].TopLevel(), "only 1 span for this service, should be top-level")
+	assert.True(tr[2].topLevel, "only 1 span for this service, should be top-level")
 	assert.True(tr[3].TopLevel(), "only 1 span for this service, should be top-level")
+	assert.True(tr[3].topLevel, "only 1 span for this service, should be top-level")
 	assert.False(tr[4].TopLevel(), "yet another sup span, not top-level")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{
-		1: struct{}{},
-		3: struct{}{},
-		4: struct{}{},
-	}, topLevelSpans, "spans marked as top-level should be in the map")
+	assert.False(tr[4].topLevel, "yet another sup span, not top-level")
 }
 
 func TestTopLevelSingle(t *testing.T) {
@@ -43,11 +41,6 @@ func TestTopLevelSingle(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.True(tr[0].TopLevel(), "root span should be top-level")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{
-		1: struct{}{},
-	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelEmpty(t *testing.T) {
@@ -58,10 +51,6 @@ func TestTopLevelEmpty(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.Equal(0, len(tr), "trace should still be empty")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{},
-		topLevelSpans, "top-level spans map should be empty")
 }
 
 func TestTopLevelOneService(t *testing.T) {
@@ -78,15 +67,15 @@ func TestTopLevelOneService(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.False(tr[0].TopLevel(), "just a sub-span, not top-level")
+	assert.False(tr[0].topLevel, "just a sub-span, not top-level")
 	assert.False(tr[1].TopLevel(), "just a sub-span, not top-level")
+	assert.False(tr[1].topLevel, "just a sub-span, not top-level")
 	assert.True(tr[2].TopLevel(), "root span should be top-level")
+	assert.True(tr[2].topLevel, "root span should be top-level")
 	assert.False(tr[3].TopLevel(), "just a sub-span, not top-level")
+	assert.False(tr[3].topLevel, "just a sub-span, not top-level")
 	assert.False(tr[4].TopLevel(), "just a sub-span, not top-level")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{
-		1: struct{}{},
-	}, topLevelSpans, "spans marked as top-level should be in the map")
+	assert.False(tr[4].topLevel, "just a sub-span, not top-level")
 }
 
 func TestTopLevelLocalRoot(t *testing.T) {
@@ -105,19 +94,19 @@ func TestTopLevelLocalRoot(t *testing.T) {
 	tr.ComputeTopLevel()
 
 	assert.True(tr[0].TopLevel(), "root span should be top-level")
+	assert.True(tr[0].topLevel, "root span should be top-level")
 	assert.False(tr[1].TopLevel(), "main service, and not a root span, not top-level")
+	assert.False(tr[1].topLevel, "main service, and not a root span, not top-level")
 	assert.True(tr[2].TopLevel(), "only 1 span for this service, should be top-level")
+	assert.True(tr[2].topLevel, "only 1 span for this service, should be top-level")
 	assert.True(tr[3].TopLevel(), "top-level but not root")
+	assert.True(tr[3].topLevel, "top-level but not root")
 	assert.False(tr[4].TopLevel(), "yet another sup span, not top-level")
+	assert.False(tr[4].topLevel, "yet another sup span, not top-level")
 	assert.False(tr[5].TopLevel(), "yet another sup span, not top-level")
+	assert.False(tr[5].topLevel, "yet another sup span, not top-level")
 	assert.False(tr[6].TopLevel(), "yet another sup span, not top-level")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{
-		1: struct{}{},
-		3: struct{}{},
-		4: struct{}{},
-	}, topLevelSpans, "spans marked as top-level should be in the map")
+	assert.False(tr[6].topLevel, "yet another sup span, not top-level")
 }
 
 func TestTopLevelWithTag(t *testing.T) {
@@ -133,14 +122,11 @@ func TestTopLevelWithTag(t *testing.T) {
 	t.Logf("%v\n", tr[1].Metrics)
 
 	assert.True(tr[0].TopLevel(), "root span should be top-level")
+	assert.True(tr[0].topLevel, "root span should be top-level")
 	assert.Equal(float64(42), tr[0].Metrics["custom"], "custom metric should still be here")
 	assert.False(tr[1].TopLevel(), "not a top-level span")
+	assert.False(tr[1].topLevel, "not a top-level span")
 	assert.Equal(float64(42), tr[1].Metrics["custom"], "custom metric should still be here")
-
-	topLevelSpans := tr.TopLevelSpans()
-	assert.Equal(map[uint64]struct{}{
-		1: struct{}{},
-	}, topLevelSpans, "spans marked as top-level should be in the map")
 }
 
 func TestTopLevelGetSetBlackBox(t *testing.T) {
@@ -151,16 +137,20 @@ func TestTopLevelGetSetBlackBox(t *testing.T) {
 	assert.False(span.TopLevel(), "by default, all spans are considered non top-level")
 	span.setTopLevel(true)
 	assert.True(span.TopLevel(), "marked as top-level")
+	assert.True(span.topLevel, "marked as top-level")
 	span.setTopLevel(false)
 	assert.False(span.TopLevel(), "no more top-level")
+	assert.False(span.topLevel, "no more top-level")
 
 	span.Metrics = map[string]float64{"custom": 42}
 
 	assert.False(span.TopLevel(), "by default, all spans are considered non top-level")
 	span.setTopLevel(true)
 	assert.True(span.TopLevel(), "marked as top-level")
+	assert.True(span.topLevel, "marked as top-level")
 	span.setTopLevel(false)
 	assert.False(span.TopLevel(), "no more top-level")
+	assert.False(span.topLevel, "no more top-level")
 }
 
 func TestTopLevelGetSetMetrics(t *testing.T) {

--- a/model/trace.go
+++ b/model/trace.go
@@ -70,3 +70,14 @@ func (t Trace) GetRoot() *Span {
 func NewTraceFlushMarker() Trace {
 	return []Span{NewFlushMarker()}
 }
+
+// ComputeWeight sets the weight private attribute to the weight
+// of the root Span. This is because sampling ratio is stored as a metrics
+// only is the root span, but is required for computing values in any span.
+func (t Trace) ComputeWeight(root Span) {
+	weight := root.Weight()
+
+	for i := range t {
+		t[i].weight = weight
+	}
+}


### PR DESCRIPTION
I basically followed the pattern used when we met the same problem with the weight: compute the value beforehand and cache it in some external data struct. Main pros are:
- avoids locking the span fields
- avoids touching the span structure, as everything is out-of-band, not in the main data model

Cons:
- more parameters to functions, which already carry the span + the weight + the list of top_level spans within the trace + the sublayers + ... 