### PR TITLE
[toplevelname] minor fixes concerning top-level name support

### DIFF
--- a/fixtures/span.go
+++ b/fixtures/span.go
@@ -267,7 +267,7 @@ func RandomSpan() model.Span {
 
 // GetTestSpan returns a Span with different fields set
 func GetTestSpan() model.Span {
-	return model.Span{
+	span := model.Span{
 		TraceID:  42,
 		SpanID:   52,
 		ParentID: 42,
@@ -280,11 +280,15 @@ func GetTestSpan() model.Span {
 		Meta:     map[string]string{"http.host": "192.168.0.1"},
 		Metrics:  map[string]float64{"http.monitor": 41.99},
 	}
+	trace := model.Trace{span}
+	trace.ComputeWeight(model.Span{})
+	trace.ComputeTopLevel()
+	return trace[0]
 }
 
 // TestSpan returns a fix span with hardcoded info, useful for reproducible tests
 func TestSpan() model.Span {
-	return model.Span{
+	span := model.Span{
 		Duration: 10000000,
 		Error:    0,
 		Resource: "GET /some/raclette",
@@ -303,4 +307,8 @@ func TestSpan() model.Span {
 		ParentID: 1111,
 		Type:     "http",
 	}
+	trace := model.Trace{span}
+	trace.ComputeWeight(model.Span{})
+	trace.ComputeTopLevel()
+	return trace[0]
 }

--- a/model/span.go
+++ b/model/span.go
@@ -74,6 +74,9 @@ func (s *Span) End() int64 {
 // Weight returns the weight of the span as defined for sampling, i.e. the
 // inverse of the sampling rate.
 func (s *Span) Weight() float64 {
+	if s == nil {
+		return 1.0
+	}
 	sampleRate, ok := s.Metrics[SpanSampleRateMetricKey]
 	if !ok || sampleRate <= 0.0 || sampleRate > 1.0 {
 		return 1.0

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -60,3 +60,11 @@ func TestSpanWeight(t *testing.T) {
 	span.Metrics[SpanSampleRateMetricKey] = 1.5
 	assert.Equal(1.0, span.Weight())
 }
+
+func TestSpanWeightNil(t *testing.T) {
+	assert := assert.New(t)
+
+	var span *Span
+
+	assert.Equal(1.0, span.Weight(), "Weight should be callable on nil and return a default value")
+}


### PR DESCRIPTION
Two things here:
- allowing a call to `Weight` on a nil span (stumbled on that case during a test of some internal tool, it's not a mainstream case, but I prefer to anticipate it)
- some fixtures fixes (same thing, used by internal tool, which can not tweak the `weight` and `topLevel` fields as those are private)