### PR TITLE
Raphael/log errors

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -168,12 +168,14 @@ func (a *Agent) Process(t model.Trace) {
 	}
 
 	weight := pt.weight() // need to do this now because sampler edits .Metrics map
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		a.Concentrator.Add(pt, weight)
-	})
-	watchdog.Go(func() {
+	}()
+	go func() {
+		defer watchdog.LogOnPanic()
 		a.Sampler.Add(pt)
-	})
+	}()
 }
 
 func (a *Agent) watchdog() {

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -64,9 +64,10 @@ func NewAPIEndpoint(url, apiKey string) *APIEndpoint {
 		url:    url,
 		client: http.DefaultClient,
 	}
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		ae.logStats()
-	})
+	}()
 	return &ae
 }
 

--- a/agent/log.go
+++ b/agent/log.go
@@ -148,7 +148,8 @@ func (r *ThrottledReceiver) AfterParse(args log.CustomReceiverInitArgs) error {
 	r.tick = time.Tick(time.Duration(interval))
 
 	// Start the goroutine resetting the log count
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		for {
 			select {
 			case <-r.tick:
@@ -158,7 +159,7 @@ func (r *ThrottledReceiver) AfterParse(args log.CustomReceiverInitArgs) error {
 			}
 		}
 
-	})
+	}()
 
 	return nil
 }

--- a/agent/main.go
+++ b/agent/main.go
@@ -224,9 +224,10 @@ func main() {
 	agent := NewAgent(agentConf)
 
 	// Handle stops properly
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		handleSignal(agent.exit)
-	})
+	}()
 
 	log.Infof("trace-agent running on host %s", agentConf.HostName)
 	agent.Run()

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -96,12 +96,14 @@ func (r *HTTPReceiver) Run() {
 		die("%v", err)
 	}
 
-	watchdog.Go(func() {
+	go func() {
 		r.preSampler.Run()
-	})
-	watchdog.Go(func() {
+	}()
+
+	go func() {
+		defer watchdog.LogOnPanic()
 		r.logStats()
-	})
+	}()
 }
 
 // Listen creates a new HTTP server listening on the provided address.
@@ -129,12 +131,14 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 
 	log.Infof("listening for traces at http://%s%s", addr, logExtra)
 
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		stoppableListener.Refresh(r.conf.ConnectionLimit)
-	})
-	watchdog.Go(func() {
+	}()
+	go func() {
+		defer watchdog.LogOnPanic()
 		server.Serve(stoppableListener)
-	})
+	}()
 
 	return nil
 }

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -55,9 +55,10 @@ func NewSampler(conf *config.AgentConfig) *Sampler {
 
 // Run starts sampling traces
 func (s *Sampler) Run() {
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		s.samplerEngine.Run()
-	})
+	}()
 }
 
 // Add samples a trace then keep it until the next flush

--- a/agent/writer.go
+++ b/agent/writer.go
@@ -103,9 +103,10 @@ func (w *Writer) isPayloadBufferingEnabled() bool {
 // Run starts the writer.
 func (w *Writer) Run() {
 	w.exitWG.Add(1)
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		w.main()
-	})
+	}()
 }
 
 // main is the main loop of the writer goroutine. If buffers payloads and

--- a/sampler/sampler.go
+++ b/sampler/sampler.go
@@ -87,9 +87,10 @@ func (s *Sampler) UpdateMaxTPS(maxTPS float64) {
 
 // Run runs and block on the Sampler main loop
 func (s *Sampler) Run() {
-	watchdog.Go(func() {
+	go func() {
+		defer watchdog.LogOnPanic()
 		s.Backend.Run()
-	})
+	}()
 	s.RunAdjustScoring()
 }
 

--- a/watchdog/logonpanic.go
+++ b/watchdog/logonpanic.go
@@ -41,11 +41,3 @@ func LogOnPanic() {
 		panic(err)
 	}
 }
-
-// Go is a helper func that calls LogOnPanic and f in a goroutine.
-func Go(f func()) {
-	go func() {
-		defer LogOnPanic()
-		f()
-	}()
-}


### PR DESCRIPTION
# Problem
After a trace-agent crash `/var/log/datadog/trace-agent.log` did not contain the error.
In  `/var/log/datadog/supervisord.log` you could find this error:
```
2017-05-22 20:15:01,832 INFO exited: trace-agent (exit status 2; not expected)
2017-05-22 20:15:02,482 INFO gave up: trace-agent entered FATAL state, too many start retries too quickly
```
And by running the trace agent manually you could see the goroutines spans.
More details on trello

# Fix and test
The root of the problem is watchdog.Go() function : if you add a `panic(...)` in it https://github.com/DataDog/datadog-trace-agent/blob/master/watchdog/logonpanic.go#L49, you will reproduce the error.
Now if you go back to the old way (before factoring) of creating go routines
```
	go func() {
		defer watchdog.LogOnPanic()
 		server.Serve(stoppableListener)
	})
	}()
```
and add panics in it, the crash will properly log.

Did tests by running different versions of the trace-agent on one node of staging, adding panics and changing code.

Adding a panic at this exact line: https://github.com/DataDog/datadog-trace-agent/blob/master/model/statsraw.go#L211 reproduces the error explained in the trello card. Doing it with the reverts below will solve the issue (tested it and it does log)