### PR TITLE
config: add the http.status_code aggregator by default

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -162,7 +162,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		APIPayloadBufferMaxSize: 16 * 1024 * 1024,
 
 		BucketInterval:   time.Duration(10) * time.Second,
-		ExtraAggregators: []string{},
+		ExtraAggregators: []string{"http.status_code"},
 
 		ExtraSampleRate: 1.0,
 		PreSampleRate:   1.0,
@@ -296,7 +296,7 @@ APM_CONF:
 	}
 
 	if v, e := conf.GetStrArray("trace.concentrator", "extra_aggregators", ","); e == nil {
-		c.ExtraAggregators = v
+		c.ExtraAggregators = append(c.ExtraAggregators, v...)
 	} else {
 		log.Debug("No aggregator configuration, using defaults")
 	}

--- a/config/agent.go
+++ b/config/agent.go
@@ -296,7 +296,7 @@ APM_CONF:
 	}
 
 	if v, e := conf.GetStrArray("trace.concentrator", "extra_aggregators", ","); e == nil {
-		c.ExtraAggregators = append(c.ExtraAggregators, v...)
+		c.ExtraAggregators = v
 	} else {
 		log.Debug("No aggregator configuration, using defaults")
 	}

--- a/config/agent.go
+++ b/config/agent.go
@@ -296,7 +296,7 @@ APM_CONF:
 	}
 
 	if v, e := conf.GetStrArray("trace.concentrator", "extra_aggregators", ","); e == nil {
-		c.ExtraAggregators = v
+		c.ExtraAggregators = append(c.ExtraAggregators, v...)
 	} else {
 		log.Debug("No aggregator configuration, using defaults")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -96,6 +96,9 @@ func (c *File) GetStrArray(section, name, sep string) ([]string, error) {
 	}
 
 	value := c.instance.Section(section).Key(name).String()
+	if value == "" {
+		return []string{}, nil
+	}
 	return strings.Split(value, sep), nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -104,7 +104,7 @@ func TestDDAgentConfigWithLegacy(t *testing.T) {
 	// Properly loaded attributes
 	assert.Equal("pommedapi", agentConfig.APIKey)
 	assert.Equal("an_endpoint", agentConfig.APIEndpoint)
-	assert.Equal([]string{"resource", "error"}, agentConfig.ExtraAggregators)
+	assert.Equal([]string{"http.status_code", "resource", "error"}, agentConfig.ExtraAggregators)
 	assert.Equal(0.33, agentConfig.ExtraSampleRate)
 
 	// Check some defaults
@@ -127,7 +127,7 @@ func TestDDAgentConfigWithNewOpts(t *testing.T) {
 
 	conf := &File{instance: dd, Path: "whatever"}
 	agentConfig, _ := NewAgentConfig(conf, nil)
-	assert.Equal([]string{"resource", "error"}, agentConfig.ExtraAggregators)
+	assert.Equal([]string{"http.status_code", "resource", "error"}, agentConfig.ExtraAggregators)
 	assert.Equal(0.33, agentConfig.ExtraSampleRate)
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -152,7 +152,7 @@ func TestZeroingExtraAggregatorsFromConfig(t *testing.T) {
 		"hostname = thing",
 		"api_key = apikey_12",
 		"[trace.concentrator]",
-		"extra_aggregators=",
+		"extra_aggregators = ",
 	}, "\n")))
 
 	conf := &File{instance: dd, Path: "whatever"}


### PR DESCRIPTION
`ExtraAggregators` allow certain span metadata fields to be
elevated to top-level keys in `StatsBucket`s. The downstream
effect is to generate metrics with this additional dimension in Datadog's backend

A default `http.status_code` aggregator will inspect incoming spans for the eponymous
metadata, and create the following metrics downstream:
- `trace.<name>.errors.by_http_status`
- `trace.<name>.hits.by_http_status`
both tagged by `http.status_code` (e.g. `500`) and `http.status_class` (e.g. `5xx`)