### PR TITLE
Fix minor bugs in Windows build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,18 @@
 require "./gorake.rb"
 
+def os
+  case RUBY_PLATFORM
+  when /linux/
+    "linux"
+  when /darwin/
+    "darwin"
+  when /x64-mingw32/
+    "windows"
+  else
+    fail 'Unsupported OS'
+  end
+end
+
 desc 'Bootstrap CI environment'
 task :bootstrap do
   tools = {
@@ -69,8 +82,14 @@ end
 desc "Build Datadog Trace agent for windows"
 task :windows do
   ["386", "amd64"].each do |arch|
+    case os
+    when "windows"
+        set_env = "set \"GOOS=windows\" && set \"GOARCH=#{arch}\""
+    else
+        set_env = "GOOS=windows GOARCH=#{arch}"
+    end
     go_build("github.com/DataDog/datadog-trace-agent/agent", {
-               :cmd => "GOOS=windows GOARCH=#{arch} go build -a -o trace-agent-windows-#{arch}.exe",
+               :cmd => set_env + " go build -a -o trace-agent-windows-#{arch}.exe",
                :race => ENV['GO_RACE'] == 'true'
              })
   end

--- a/gorake.rb
+++ b/gorake.rb
@@ -1,3 +1,4 @@
+require 'time'
 
 def go_build(program, opts={})
   default_cmd = "go build -a"
@@ -13,7 +14,7 @@ def go_build(program, opts={})
   dd = 'main'
   commit = `git rev-parse --short HEAD`.strip
   branch = `git rev-parse --abbrev-ref HEAD`.strip
-  date = `date +%FT%T%z`.strip
+  date = Time.now.iso8601
   goversion = `go version`.strip
   agentversion = ENV["TRACE_AGENT_VERSION"] || "0.99.0"
 


### PR DESCRIPTION
These are really small changes to make the Windows build work better.

The date command on Windows does not behave like the unix one so I switched to a ruby function, this changes slightly the format:
before: 2017-06-14T12:35:34-0400
after: 2017-06-14T12:35:34-07:00

And I changed the way environment variables are set in rake for windows since it broke in the windows cmd shell.