### PR TITLE
Fix quantizer edge case

### DIFF
--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -250,8 +250,8 @@ func TestSQLQuantizer(t *testing.T) {
 			"SELECT pg_try_advisory_lock ( ? )",
 		},
 		{
-			"`a-a` `a.a` \"a.a\" \"a-a\"",
-			"a-a a.a a.a a-a",
+			"INSERT INTO `qual-aa`.issues (alert0 , alert1) VALUES (NULL, NULL)",
+			"INSERT INTO qual-aa . issues ( alert0, alert1 ) VALUES ( ? )",
 		},
 	}
 

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -249,6 +249,10 @@ func TestSQLQuantizer(t *testing.T) {
 			"SELECT pg_try_advisory_lock (123) AS t46eef3f025cc27feb31ca5a2d668a09a",
 			"SELECT pg_try_advisory_lock ( ? )",
 		},
+		{
+			"`a-a` `a.a` \"a.a\" \"a-a\"",
+			"a-a a.a a.a a-a",
+		},
 	}
 
 	for _, c := range cases {

--- a/quantizer/tokenizer.go
+++ b/quantizer/tokenizer.go
@@ -198,10 +198,9 @@ func (tkn *Tokenizer) scanLiteralIdentifier(quote rune) (int, []byte) {
 	if !isLetter(tkn.lastChar) {
 		return LexError, buffer.Bytes()
 	}
-	for tkn.next(); isLetter(tkn.lastChar) || isDigit(tkn.lastChar); tkn.next() {
+	for tkn.next(); skipNonLiteralIdentifier(tkn.lastChar); tkn.next() {
 		buffer.WriteByte(byte(tkn.lastChar))
 	}
-
 	// literals identifier are enclosed between quotes
 	if tkn.lastChar != uint16(quote) {
 		return LexError, buffer.Bytes()
@@ -447,6 +446,10 @@ func (tkn *Tokenizer) next() {
 		tkn.lastChar = uint16(ch)
 	}
 	tkn.Position++
+}
+
+func skipNonLiteralIdentifier(ch uint16) bool {
+	return isLetter(ch) || isDigit(ch) || '.' == ch || '-' == ch
 }
 
 func isLetter(ch uint16) bool {


### PR DESCRIPTION
The quantizer would return "Non-parsable SQL query" whenever those patterns would be found:
```
`letter-letter` `letter.letter` "letter.letter" "letter-letter"
```
This bug was found by a client with the following sql query that won't be parsed : 
```
INSERT INTO `table-21`.issues
```