### PR TITLE
propagate language data in payload headers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -97,6 +97,7 @@ func (a *Agent) Run() {
 			p := model.AgentPayload{
 				HostName: a.conf.HostName,
 				Env:      a.conf.DefaultEnv,
+				extras:   make(map[string]string),
 			}
 			var wg sync.WaitGroup
 			wg.Add(3)

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -99,7 +99,7 @@ func (a *Agent) Run() {
 				Env:      a.conf.DefaultEnv,
 			}
 			var wg sync.WaitGroup
-			wg.Add(2)
+			wg.Add(3)
 			go func() {
 				defer watchdog.LogOnPanic()
 				p.Stats = a.Concentrator.Flush()
@@ -108,6 +108,11 @@ func (a *Agent) Run() {
 			go func() {
 				defer watchdog.LogOnPanic()
 				p.Traces = a.Sampler.Flush()
+				wg.Done()
+			}()
+			go func() {
+				defer watchdog.LogOnPanic()
+				p.SetExtra("X-Datadog-Reported-Languages", a.Receiver.Languages())
 				wg.Done()
 			}()
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -97,7 +97,6 @@ func (a *Agent) Run() {
 			p := model.AgentPayload{
 				HostName: a.conf.HostName,
 				Env:      a.conf.DefaultEnv,
-				extras:   make(map[string]string),
 			}
 			var wg sync.WaitGroup
 			wg.Add(3)

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -90,7 +90,7 @@ func (ae *APIEndpoint) Write(p model.AgentPayload) (int, error) {
 	startFlush := time.Now()
 
 	// Serialize the payload to send it to the API
-	data, err := model.EncodeAgentPayload(p)
+	data, err := model.EncodeAgentPayload(&p)
 	if err != nil {
 		log.Errorf("encoding issue: %v", err)
 		return 0, err

--- a/agent/endpoint.go
+++ b/agent/endpoint.go
@@ -119,7 +119,8 @@ func (ae *APIEndpoint) Write(p model.AgentPayload) (int, error) {
 	queryParams := req.URL.Query()
 	queryParams.Add("api_key", ae.apiKey)
 	req.URL.RawQuery = queryParams.Encode()
-	model.SetAgentPayloadHeaders(req.Header)
+
+	model.SetAgentPayloadHeaders(req.Header, p.Extras())
 	resp, err := ae.client.Do(req)
 
 	// If the request fails, we'll try again later.

--- a/agent/endpoint_test.go
+++ b/agent/endpoint_test.go
@@ -36,7 +36,7 @@ func BenchmarkEncodeAgentPayload(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		if _, err := model.EncodeAgentPayload(payload); err != nil {
+		if _, err := model.EncodeAgentPayload(&payload); err != nil {
 			b.Fatalf("error encoding payload: %v", b)
 		}
 	}

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -309,13 +309,13 @@ func (r *HTTPReceiver) Languages() string {
 	r.stats.RLock()
 	for tags := range r.stats.Stats {
 		if _, ok := langs[tags.Lang]; !ok {
-			str += tags.Lang + ","
+			str += tags.Lang + "|"
 			langs[tags.Lang] = true
 		}
 	}
 	r.stats.RUnlock()
 
-	str = strings.TrimRight(str, ",")
+	str = strings.TrimRight(str, "|")
 	return str
 }
 

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -143,6 +143,10 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 	return nil
 }
 
+func (r *HTTPReceiver) Languages() string {
+	return "go,python"
+}
+
 func (r *HTTPReceiver) httpHandle(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		req.Body = model.NewLimitedReader(req.Body, r.maxRequestBodyLength)

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -143,6 +143,7 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 	return nil
 }
 
+// Languages returns a string of comma-separated languages which the receiver has seen traces of
 func (r *HTTPReceiver) Languages() string {
 	return "go,python"
 }

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -144,11 +144,6 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 	return nil
 }
 
-// Languages returns a string of comma-separated languages which the receiver has seen traces of
-func (r *HTTPReceiver) Languages() string {
-	return "go,python"
-}
-
 func (r *HTTPReceiver) httpHandle(fn http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		req.Body = model.NewLimitedReader(req.Body, r.maxRequestBodyLength)

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -302,19 +303,19 @@ func (r *HTTPReceiver) logStats() {
 func (r *HTTPReceiver) Languages() string {
 	// We need to use this map because we can have several tags for a same language.
 	langs := make(map[string]bool)
-	str := ""
+	str := []string{}
 
 	r.stats.RLock()
 	for tags := range r.stats.Stats {
 		if _, ok := langs[tags.Lang]; !ok {
-			str += tags.Lang + "|"
+			str = append(str, tags.Lang)
 			langs[tags.Lang] = true
 		}
 	}
 	r.stats.RUnlock()
 
-	str = strings.TrimRight(str, "|")
-	return str
+	sort.Strings(str)
+	return strings.Join(str, "|")
 }
 
 func getTraces(v APIVersion, w http.ResponseWriter, req *http.Request) (model.Traces, bool) {

--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -454,6 +454,18 @@ func TestHandleTraces(t *testing.T) {
 		assert.Equal(int64(20), ts.TracesReceived)
 		assert.Equal(int64(57622), ts.TracesBytes)
 	}
+	// make sure we have all our languages registered
+	assert.Equal("C#|go|java|python|ruby", receiver.Languages())
+
+	// now check for a subset of languages
+	rs.Stats = make(map[Tags]*tagStats)
+	assert.Equal("", receiver.Languages())
+
+	for _, lang := range []string{"python", "go"} {
+		rs.Stats[Tags{Lang: lang}] = &tagStats{}
+	}
+	assert.Equal("go|python", receiver.Languages())
+
 }
 
 func BenchmarkHandleTracesFromOneApp(b *testing.B) {

--- a/agent/writer_test.go
+++ b/agent/writer_test.go
@@ -185,7 +185,7 @@ func TestWriterBuffering(t *testing.T) {
 		payload := newTestPayload(fmt.Sprintf("p%d", i))
 		payloads[i] = payload
 
-		data, err := model.EncodeAgentPayload(payload)
+		data, err := model.EncodeAgentPayload(&payload)
 		if err != nil {
 			t.Fatalf("cannot encode test payload: %v", err)
 		}

--- a/model/payload.go
+++ b/model/payload.go
@@ -41,6 +41,10 @@ func (p *AgentPayload) SetExtra(key, val string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	if p.extras == nil {
+		p.extras = make(map[string]string)
+	}
+
 	p.extras[key] = val
 }
 

--- a/model/payload.go
+++ b/model/payload.go
@@ -61,7 +61,7 @@ var (
 
 // EncodeAgentPayload will return a slice of bytes representing the
 // payload (according to GlobalAgentPayloadVersion)
-func EncodeAgentPayload(p AgentPayload) ([]byte, error) {
+func EncodeAgentPayload(p *AgentPayload) ([]byte, error) {
 	var b bytes.Buffer
 	var err error
 


### PR DESCRIPTION
Since the Receiver now collects data about incoming languages, compose an HTTP header that contains this info for reporting to the backend. 

Header value is a pipe-separated alphabetical string of languages, like so:
```
X-Datadog-Reported-Languages: go|java|python
```