### PR TITLE
Add Error Duration Distribution to Stats

### DIFF
--- a/agent/concentrator.go
+++ b/agent/concentrator.go
@@ -76,6 +76,9 @@ func (c *Concentrator) Flush() []model.StatsBucket {
 		for _, d := range bucket.Distributions {
 			statsd.Client.Histogram("datadog.trace_agent.distribution.len", float64(d.Summary.N), nil, 1)
 		}
+		for _, d := range bucket.ErrDistributions {
+			statsd.Client.Histogram("datadog.trace_agent.err_distribution.len", float64(d.Summary.N), nil, 1)
+		}
 		sb = append(sb, bucket)
 		delete(c.buckets, ts)
 	}

--- a/model/stats.go
+++ b/model/stats.go
@@ -119,26 +119,28 @@ func (d Distribution) Copy() Distribution {
 
 // StatsBucket is a time bucket to track statistic around multiple Counts
 type StatsBucket struct {
-	Start    int64 // timestamp of start in our format
-	Duration int64 // duration of a bucket in nanoseconds
+	Start    int64 // Timestamp of start in our format
+	Duration int64 // Duration of a bucket in nanoseconds
 
-	// stats indexed by keys
-	Counts        map[string]Count        // All the true counts we keep
-	Distributions map[string]Distribution // All the true distribution we keep to answer quantile queries
+	// Stats indexed by keys
+	Counts           map[string]Count        // All the counts
+	Distributions    map[string]Distribution // All the distributions (e.g.: for quantile queries)
+	ErrDistributions map[string]Distribution // All the error distributions (e.g.: for apdex, as they account for frustrated)
 }
 
 // NewStatsBucket opens a new bucket for time ts and initializes it properly
 func NewStatsBucket(ts, d int64) StatsBucket {
 	// The only non-initialized value is the Duration which should be set by whoever closes that bucket
 	return StatsBucket{
-		Start:         ts,
-		Duration:      d,
-		Counts:        make(map[string]Count),
-		Distributions: make(map[string]Distribution),
+		Start:            ts,
+		Duration:         d,
+		Counts:           make(map[string]Count),
+		Distributions:    make(map[string]Distribution),
+		ErrDistributions: make(map[string]Distribution),
 	}
 }
 
 // IsEmpty just says if this stats bucket has no information (in which case it's useless)
 func (sb StatsBucket) IsEmpty() bool {
-	return len(sb.Counts) == 0 && len(sb.Distributions) == 0
+	return len(sb.Counts) == 0 && len(sb.Distributions) == 0 && len(sb.ErrDistributions) == 0
 }

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -176,6 +176,36 @@ func TestStatsBucketDefault(t *testing.T) {
 		assert.Equal(val.entries, d.Summary.Entries, "Distribution %s wrong value", dkey)
 		assert.Equal(val.topLevel, d.TopLevel, "Distribution %s wrong topLevel", dkey)
 	}
+
+	expectedErrDistributions := map[string]expectedDistribution{
+		"A.foo|duration|env:default,resource:α,service:A": expectedDistribution{
+			entries: nil, topLevel: 1},
+		"A.foo|duration|env:default,resource:β,service:A": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 2, G: 1, Delta: 0}}, topLevel: 1},
+		"B.foo|duration|env:default,resource:γ,service:B": expectedDistribution{
+			entries: nil, topLevel: 1},
+		"B.foo|duration|env:default,resource:ε,service:B": expectedDistribution{
+			entries: []quantile.Entry{quantile.Entry{V: 4, G: 1, Delta: 0}}, topLevel: 1},
+		"B.foo|duration|env:default,resource:ζ,service:B": expectedDistribution{
+			entries: nil, topLevel: 1},
+		"sql.query|duration|env:default,resource:ζ,service:B": expectedDistribution{
+			entries: nil, topLevel: 1},
+		"sql.query|duration|env:default,resource:δ,service:C": expectedDistribution{
+			entries: nil, topLevel: 2},
+	}
+
+	for k, v := range sb.ErrDistributions {
+		t.Logf("%v: %v", k, v.Summary.Entries)
+	}
+	assert.Len(sb.ErrDistributions, len(expectedErrDistributions), "Missing distributions!")
+	for dkey, d := range sb.ErrDistributions {
+		val, ok := expectedErrDistributions[dkey]
+		if !ok {
+			assert.Fail("Unexpected distribution %s", dkey)
+		}
+		assert.Equal(val.entries, d.Summary.Entries, "ErrDistribution %s wrong value", dkey)
+		assert.Equal(val.topLevel, d.TopLevel, "ErrDistribution %s wrong topLevel", dkey)
+	}
 }
 
 func TestStatsBucketExtraAggregators(t *testing.T) {


### PR DESCRIPTION
StatsBucket bucket already holds the duration distribution, but there's not other dimension to that information. Thus, when we have 50 spans in the 20ms duration slice, we don't know how many were errors.

This PR adds the ErrDistributions map to StatsBuckeet, and only spans makred as errors are considered when adding to it.

Commit  bec6280 updates stats.go and statsraw.go to add the mapping and consider the span if it's an error, as well as stats_test.go to if spans marked as errors are counted correctly.