### PR TITLE
[lexer] group question mark even without a comma

### DIFF
--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -103,7 +103,7 @@ func (f *GroupingFilter) Filter(token, lastToken int, buffer []byte) (int, []byt
 		if f.groupFilter > 1 {
 			return Filtered, nil
 		}
-	case f.groupFilter > 0 && token == ',':
+	case f.groupFilter > 0 && (token == ',' || token == '?'):
 		// if we are in a group drop all commas
 		return Filtered, nil
 	case f.groupMulti > 1:

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -253,6 +253,10 @@ func TestSQLQuantizer(t *testing.T) {
 			"INSERT INTO `qual-aa`.issues (alert0 , alert1) VALUES (NULL, NULL)",
 			"INSERT INTO qual-aa . issues ( alert0, alert1 ) VALUES ( ? )",
 		},
+		{
+			"INSERT INTO user (id, email, name) VALUES (null, ?, ?)",
+			"INSERT INTO user ( id, email, name ) VALUES ( ? )",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
### Overview

The `GroupFilter` doesn't take in account question marks that are not separated by commas. In that case, the result is a wrong query quantization:
```
--- FAIL: TestSQLQuantizer (0.00s)
        Error Trace:    sql_test.go:263
	Error:		Not equal: "insert into user ( id, email, name ) values ( ? )" (expected)
			        != "insert into user ( id, email, name ) values ( ? ?, ? )" (actual)
```

This PR ensures that `( ? ?, ? )` is `( ? )`.