### PR TITLE
Prevent flush Services <1s

### DIFF
--- a/agent/writer.go
+++ b/agent/writer.go
@@ -118,6 +118,7 @@ func (w *Writer) main() {
 
 	flushTicker := time.NewTicker(time.Second)
 	defer flushTicker.Stop()
+	servicesUpdated := false
 
 	for {
 		select {
@@ -130,11 +131,12 @@ func (w *Writer) main() {
 			w.Flush()
 		case <-flushTicker.C:
 			w.Flush()
-		case sm := <-w.inServices:
-			updated := w.serviceBuffer.Update(sm)
-			if updated {
+			if servicesUpdated {
 				w.FlushServices()
+				servicesUpdated = false
 			}
+		case sm := <-w.inServices:
+			servicesUpdated = servicesUpdated || w.serviceBuffer.Update(sm)
 		case <-w.exit:
 			log.Info("exiting, trying to flush all remaining data")
 			w.Flush()

--- a/agent/writer_test.go
+++ b/agent/writer_test.go
@@ -94,7 +94,7 @@ receivingLoop:
 			assert.Equal("", received.header.Get("Content-Encoding"))
 			assert.Equal(`{"mcnulty":{"app_type":"web"}}`, received.body)
 			break receivingLoop
-		case <-time.After(time.Second):
+		case <-time.After(2 * time.Second):
 			t.Fatal("did not receive service data in time")
 		}
 	}


### PR DESCRIPTION
The agent flushes currently service metadata whenever a service meta is changed. This PR aims to give it a time limit (two flushed can't be done in under 1 second)