### PR TITLE
[Windows]  Add windows specific executable name for the :build target

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,8 +73,14 @@ task :default => [:ci]
 
 desc "Build Datadog Trace agent"
 task :build do
+  case os
+  when "windows"
+    bin = "trace-agent.exe"
+  else 
+    bin = "trace-agent"
+  end
   go_build("github.com/DataDog/datadog-trace-agent/agent", {
-    :cmd => "go build -a -o trace-agent",
+    :cmd => "go build -a -o #{bin}",
     :race => ENV['GO_RACE'] == 'true',
     :add_build_vars => ENV['TRACE_AGENT_ADD_BUILD_VARS'] != 'false'
   })


### PR DESCRIPTION
(which is used by the windows agent build script)

Made this change because the :windows target appears to be intended for cross-compilation.  Made change for the :build target for native Windows builds, which allows for (among other things) the agent6 build to build (and include) the APM agent.