### PR TITLE
trace: fix deadlock when no stats present

### DIFF
--- a/agent/stats.go
+++ b/agent/stats.go
@@ -59,16 +59,16 @@ func (rs *receiverStats) reset() {
 
 // String gives a string representation of the receiverStats struct.
 func (rs *receiverStats) String() string {
-	str := ""
 	rs.RLock()
+	defer rs.RUnlock()
+
+	str := ""
 	if len(rs.Stats) == 0 {
 		return "no data received"
 	}
 	for _, ts := range rs.Stats {
 		str += fmt.Sprintf("\n\t%v -> %s", ts.Tags.toArray(), ts.String())
-
 	}
-	rs.RUnlock()
 	return str
 }
 


### PR DESCRIPTION
If a restarted trace-agent doesn't receive traces within the first stats
reporting window (10 seconds) it can deadlock in the [receiver stats loop](https://github.com/DataDog/datadog-trace-agent/blob/e3d35255d748cdb9aa5d4f8c30763b8aa752fbb3/agent/receiver.go#L277-L298).
The direct symptom of this is that stats under `datadog.trace_agent.receiver.*`
and `datadog.trace_agent.heartbeat` fail to report

This ensures we always release the read lock even in the absence of Stats.

Example stack dump of a blocked goroutine:

 ```

goroutine 44 [semacquire, 21 minutes]:
sync.runtime_Semacquire(0xc420191808)
	/usr/local/go18/go/src/runtime/sema.go:47 +0x34
sync.(*RWMutex).Lock(0xc420191800)
	/usr/local/go18/go/src/sync/rwmutex.go:91 +0x6e
main.(*receiverStats).reset(0xc420191800)
	/var/cache/omnibus/cache/src/datadog-trace-agent/src/github.com/DataDog/datadog-trace-agent/agent/stats.go:53 +0x37
main.(*HTTPReceiver).logStats(0xc420198c80)
	/var/cache/omnibus/cache/src/datadog-trace-agent/src/github.com/DataDog/datadog-trace-agent/agent/receiver.go:295 +0x3a1
main.(*HTTPReceiver).Run.func2(0xc420198c80)
	/var/cache/omnibus/cache/src/datadog-trace-agent/src/github.com/DataDog/datadog-trace-agent/agent/receiver.go:107 +0x47
created by main.(*HTTPReceiver).Run
	/var/cache/omnibus/cache/src/datadog-trace-agent/src/github.com/DataDog/datadog-trace-agent/agent/receiver.go:108 +0x684```