### PR TITLE
Fix bug in Windows rake command

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -91,12 +91,12 @@ task :windows do
   ["386", "amd64"].each do |arch|
     case os
     when "windows"
-        set_env = "set \"GOOS=windows\" && set \"GOARCH=#{arch}\""
+        set_env = "set \"GOOS=windows\" && set \"GOARCH=#{arch}\" &&"
     else
         set_env = "GOOS=windows GOARCH=#{arch}"
     end
     go_build("github.com/DataDog/datadog-trace-agent/agent", {
-               :cmd => set_env + "&& go build -a -o trace-agent-windows-#{arch}.exe",
+               :cmd => set_env + " go build -a -o trace-agent-windows-#{arch}.exe",
                :race => ENV['GO_RACE'] == 'true'
              })
   end

--- a/Rakefile
+++ b/Rakefile
@@ -96,7 +96,7 @@ task :windows do
         set_env = "GOOS=windows GOARCH=#{arch}"
     end
     go_build("github.com/DataDog/datadog-trace-agent/agent", {
-               :cmd => set_env + " go build -a -o trace-agent-windows-#{arch}.exe",
+               :cmd => set_env + "&& go build -a -o trace-agent-windows-#{arch}.exe",
                :race => ENV['GO_RACE'] == 'true'
              })
   end


### PR DESCRIPTION
The command to build the windows target was broken because of mistake when concatenating the two parts of the command.