### PR TITLE
[trace] Moving quantization before truncation of spans

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -223,6 +223,7 @@ func (a *Agent) Process(t model.Trace) {
 
 	for i := range t {
 		t[i] = quantizer.Quantize(t[i])
+		t[i].Truncate()
 	}
 
 	pt := processedTrace{

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -78,13 +78,6 @@ func TestNormalizeEmptyResource(t *testing.T) {
 	assert.Error(t, s.Normalize())
 }
 
-func TestNormalizeLongResource(t *testing.T) {
-	s := testSpan()
-	s.Resource = strings.Repeat("SELECT ", 5000)
-	assert.NoError(t, s.Normalize())
-	assert.Equal(t, 5000, len(s.Resource))
-}
-
 func TestNormalizeTraceIDPassThru(t *testing.T) {
 	s := testSpan()
 	before := s.TraceID
@@ -165,41 +158,11 @@ func TestNormalizeMetricsPassThru(t *testing.T) {
 	assert.Equal(t, before, s.Metrics)
 }
 
-func TestNormalizeMetricsKeyTooLong(t *testing.T) {
-	s := testSpan()
-	key := strings.Repeat("TOOLONG", 1000)
-	s.Metrics[key] = 42
-	assert.NoError(t, s.Normalize())
-	for k := range s.Metrics {
-		assert.True(t, len(k) < MaxMetricsKeyLen+4)
-	}
-}
-
 func TestNormalizeMetaPassThru(t *testing.T) {
 	s := testSpan()
 	before := s.Meta
 	s.Normalize()
 	assert.Equal(t, before, s.Meta)
-}
-
-func TestNormalizeMetaKeyTooLong(t *testing.T) {
-	s := testSpan()
-	key := strings.Repeat("TOOLONG", 1000)
-	s.Meta[key] = "foo"
-	assert.NoError(t, s.Normalize())
-	for k := range s.Meta {
-		assert.True(t, len(k) < MaxMetaKeyLen+4)
-	}
-}
-
-func TestNormalizeMetaValueTooLong(t *testing.T) {
-	s := testSpan()
-	val := strings.Repeat("TOOLONG", 5000)
-	s.Meta["foo"] = val
-	assert.NoError(t, s.Normalize())
-	for _, v := range s.Meta {
-		assert.True(t, len(v) < MaxMetaValLen+4)
-	}
 }
 
 func TestNormalizeParentIDPassThru(t *testing.T) {

--- a/model/truncator.go
+++ b/model/truncator.go
@@ -1,0 +1,57 @@
+package model
+
+import log "github.com/cihub/seelog"
+
+const (
+	// MaxResourceLen the maximum length the resource can have
+	MaxResourceLen = 5000
+	// MaxMetaKeyLen the maximum length of metadata key
+	MaxMetaKeyLen = 100
+	// MaxMetaValLen the maximum length of metadata value
+	MaxMetaValLen = 5000
+	// MaxMetricsKeyLen the maximum length of a metric name key
+	MaxMetricsKeyLen = MaxMetaKeyLen
+)
+
+// Truncate checks that the span resource, meta and metrics are within the max length
+// and modifies them if they are not
+func (s *Span) Truncate() {
+	// Resource
+	if len(s.Resource) > MaxResourceLen {
+		s.Resource = s.Resource[:MaxResourceLen]
+		log.Debugf("span.truncate: truncated `Resource` (max %d chars): %s", MaxResourceLen, s.Resource)
+	}
+
+	// Error - Nothing to do
+	// Optional data, Meta & Metrics can be nil
+	// Soft fail on those
+	for k, v := range s.Meta {
+		modified := false
+
+		if len(k) > MaxMetaKeyLen {
+			log.Debugf("span.truncate: truncating `Meta` key (max %d chars): %s", MaxMetaKeyLen, k)
+			delete(s.Meta, k)
+			k = k[:MaxMetaKeyLen] + "..."
+			modified = true
+		}
+
+		if len(v) > MaxMetaValLen {
+			v = v[:MaxMetaValLen] + "..."
+			modified = true
+		}
+
+		if modified {
+			s.Meta[k] = v
+		}
+	}
+
+	for k, v := range s.Metrics {
+		if len(k) > MaxMetricsKeyLen {
+			log.Debugf("span.truncate: truncating `Metrics` key (max %d chars): %s", MaxMetricsKeyLen, k)
+			delete(s.Metrics, k)
+			k = k[:MaxMetricsKeyLen] + "..."
+
+			s.Metrics[k] = v
+		}
+	}
+}

--- a/model/truncator_test.go
+++ b/model/truncator_test.go
@@ -1,0 +1,66 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateResourcePassThru(t *testing.T) {
+	s := testSpan()
+	before := s.Resource
+	s.Truncate()
+	assert.Equal(t, before, s.Resource)
+}
+
+func TestTruncateLongResource(t *testing.T) {
+	s := testSpan()
+	s.Resource = strings.Repeat("SELECT ", 5000)
+	s.Truncate()
+	assert.Equal(t, 5000, len(s.Resource))
+}
+
+func TestTruncateMetricsPassThru(t *testing.T) {
+	s := testSpan()
+	before := s.Metrics
+	s.Truncate()
+	assert.Equal(t, before, s.Metrics)
+}
+
+func TestTruncateMetricsKeyTooLong(t *testing.T) {
+	s := testSpan()
+	key := strings.Repeat("TOOLONG", 1000)
+	s.Metrics[key] = 42
+	s.Truncate()
+	for k := range s.Metrics {
+		assert.True(t, len(k) < MaxMetricsKeyLen+4)
+	}
+}
+
+func TestTruncateMetaPassThru(t *testing.T) {
+	s := testSpan()
+	before := s.Meta
+	s.Truncate()
+	assert.Equal(t, before, s.Meta)
+}
+
+func TestTruncateMetaKeyTooLong(t *testing.T) {
+	s := testSpan()
+	key := strings.Repeat("TOOLONG", 1000)
+	s.Meta[key] = "foo"
+	s.Truncate()
+	for k := range s.Meta {
+		assert.True(t, len(k) < MaxMetaKeyLen+4)
+	}
+}
+
+func TestTruncateMetaValueTooLong(t *testing.T) {
+	s := testSpan()
+	val := strings.Repeat("TOOLONG", 5000)
+	s.Meta["foo"] = val
+	s.Truncate()
+	for _, v := range s.Meta {
+		assert.True(t, len(v) < MaxMetaValLen+4)
+	}
+}

--- a/model/truncator_test.go
+++ b/model/truncator_test.go
@@ -16,7 +16,7 @@ func TestTruncateResourcePassThru(t *testing.T) {
 
 func TestTruncateLongResource(t *testing.T) {
 	s := testSpan()
-	s.Resource = strings.Repeat("SELECT ", 5000)
+	s.Resource = strings.Repeat("TOOLONG", 5000)
 	s.Truncate()
 	assert.Equal(t, 5000, len(s.Resource))
 }


### PR DESCRIPTION
This is to ensure that strings (ex. query strings) stored in certain fields, such as `resources` are still parseable and are quantized properly. 
Tested in staging and prod 