### PR TITLE
Misc improvements

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -183,8 +183,10 @@ func (a *Agent) Process(t model.Trace) {
 
 			if priority == 0 {
 				priorityPtr = &ts.TracesPriority0
-			} else {
+			} else if priority == 1 {
 				priorityPtr = &ts.TracesPriority1
+			} else {
+				priorityPtr = &ts.TracesPriority2
 			}
 		}
 	}

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -313,7 +313,10 @@ func (r *HTTPReceiver) logStats() {
 		if now.Sub(lastLog) >= time.Minute {
 			// We expose the stats accumulated to expvar
 			updateReceiverStats(accStats)
-			log.Info(accStats.String())
+
+			for logStr := range accStats.Strings() {
+				log.Info(logStr)
+			}
 
 			// We reset the stats accumulated during the last minute
 			accStats.reset()

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -57,19 +57,21 @@ func (rs *receiverStats) reset() {
 	rs.Unlock()
 }
 
-// String gives a string representation of the receiverStats struct.
-func (rs *receiverStats) String() string {
+// Strings gives a multi strings representation of the receiverStats struct.
+func (rs *receiverStats) Strings() []string {
 	rs.RLock()
 	defer rs.RUnlock()
 
-	str := ""
 	if len(rs.Stats) == 0 {
-		return "no data received"
+		return []string{"no data received"}
 	}
+
+	strings := make([]string, len(rs.Stats))
+
 	for _, ts := range rs.Stats {
-		str += fmt.Sprintf("\n\t%v -> %s", ts.Tags.toArray(), ts.String())
+		strings = append(strings, fmt.Sprintf("%v -> %s", ts.Tags.toArray(), ts.String()))
 	}
-	return str
+	return strings
 }
 
 // tagStats is the struct used to associate the stats with their set of tags.

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -97,6 +97,7 @@ func (ts *tagStats) publish() {
 	tracesPriorityNone := atomic.LoadInt64(&ts.TracesPriorityNone)
 	tracesPriority0 := atomic.LoadInt64(&ts.TracesPriority0)
 	tracesPriority1 := atomic.LoadInt64(&ts.TracesPriority1)
+	tracesPriority2 := atomic.LoadInt64(&ts.TracesPriority2)
 	tracesBytes := atomic.LoadInt64(&ts.TracesBytes)
 	spansReceived := atomic.LoadInt64(&ts.SpansReceived)
 	spansDropped := atomic.LoadInt64(&ts.SpansDropped)
@@ -114,6 +115,7 @@ func (ts *tagStats) publish() {
 	statsd.Client.Count("datadog.trace_agent.receiver.traces_priority", tracesPriorityNone, append(tags, "priority:none"), 1)
 	statsd.Client.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority0, append(tags, "priority:0"), 1)
 	statsd.Client.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority1, append(tags, "priority:1"), 1)
+	statsd.Client.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority2, append(tags, "priority:2"), 1)
 	statsd.Client.Count("datadog.trace_agent.receiver.traces_bytes", tracesBytes, tags, 1)
 	statsd.Client.Count("datadog.trace_agent.receiver.spans_received", spansReceived, tags, 1)
 	statsd.Client.Count("datadog.trace_agent.receiver.spans_dropped", spansDropped, tags, 1)
@@ -135,8 +137,10 @@ type Stats struct {
 	TracesPriorityNone int64
 	// TracesPriority0 is the number of traces with sampling priority set to zero.
 	TracesPriority0 int64
-	// TracesPriority1 is the number of traces with sampling priority set to a non-zero value.
+	// TracesPriority1 is the number of traces with sampling priority automatically set to 1.
 	TracesPriority1 int64
+	// TracesPriority2 is the number of traces with sampling priority manually set to 2 or more.
+	TracesPriority2 int64
 	// TracesBytes is the amount of data received on the traces endpoint (raw data, encoded, compressed).
 	TracesBytes int64
 	// SpansReceived is the total number of spans received, including the dropped ones.
@@ -158,6 +162,7 @@ func (s *Stats) update(recent Stats) {
 	atomic.AddInt64(&s.TracesPriorityNone, recent.TracesPriorityNone)
 	atomic.AddInt64(&s.TracesPriority0, recent.TracesPriority0)
 	atomic.AddInt64(&s.TracesPriority1, recent.TracesPriority1)
+	atomic.AddInt64(&s.TracesPriority2, recent.TracesPriority2)
 	atomic.AddInt64(&s.TracesBytes, recent.TracesBytes)
 	atomic.AddInt64(&s.SpansReceived, recent.SpansReceived)
 	atomic.AddInt64(&s.SpansDropped, recent.SpansDropped)
@@ -173,6 +178,7 @@ func (s *Stats) reset() {
 	atomic.StoreInt64(&s.TracesPriorityNone, 0)
 	atomic.StoreInt64(&s.TracesPriority0, 0)
 	atomic.StoreInt64(&s.TracesPriority1, 0)
+	atomic.StoreInt64(&s.TracesPriority2, 0)
 	atomic.StoreInt64(&s.TracesBytes, 0)
 	atomic.StoreInt64(&s.SpansReceived, 0)
 	atomic.StoreInt64(&s.SpansDropped, 0)


### PR DESCRIPTION
- use a different metric tag to count traces manually prioritized
- fix multiline logging
- expire receiverStats tagset

Example of previous output: multi-line, one tag set.

```
2017-10-12 12:19:39 INFO (receiver.go:316) -
        [lang:go lang_version:1.9.1 interpreter:gc-amd64-linux tracer_version:v0.5.0] -> traces received: 21358, traces dropped: 0, traces filtered: 0, traces amount: 14167935 bytes, services received: 0, services amount: 0 bytes
        [] -> traces received: 0, traces dropped: 0, traces filtered: 0, traces amount: 0 bytes, services received: 0, services amount: 0 bytes
```

After this PR, is should simply look like:

```
2017-10-12 12:19:39 INFO (receiver.go:316) - [lang:go lang_version:1.9.1 interpreter:gc-amd64-linux tracer_version:v0.5.0] -> traces received: 21358, traces dropped: 0, traces filtered: 0, traces amount: 14167935 bytes, services received: 0, services amount: 0 bytes
```

