### PR TITLE
Fix tagStats logging

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -170,6 +170,7 @@ func (a *Agent) Process(t model.Trace) {
 	root := t.GetRoot()
 
 	// We get the address of the struct holding the stats associated to no tags
+	// TODO: get the real tagStats related to this trace payload.
 	ts := a.Receiver.stats.getTagStats(Tags{})
 
 	// We choose the sampler dynamically, depending on trace content,

--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -314,7 +314,7 @@ func (r *HTTPReceiver) logStats() {
 			// We expose the stats accumulated to expvar
 			updateReceiverStats(accStats)
 
-			for logStr := range accStats.Strings() {
+			for _, logStr := range accStats.Strings() {
 				log.Info(logStr)
 			}
 

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -53,7 +53,7 @@ func (rs *receiverStats) reset() {
 	rs.Lock()
 	for key, tagStats := range rs.Stats {
 		// If a tagStats was empty, let's drop it.
-		// That's a way to avoid empty stats entries or over-time leaks.
+		// That's a way to avoid over-time leaks.
 		if tagStats.isEmpty() {
 			delete(rs.Stats, key)
 		}
@@ -71,7 +71,7 @@ func (rs *receiverStats) Strings() []string {
 		return []string{"no data received"}
 	}
 
-	strings := make([]string, len(rs.Stats))
+	strings := make([]string, 0, len(rs.Stats))
 
 	for _, ts := range rs.Stats {
 		strings = append(strings, fmt.Sprintf("%v -> %s", ts.Tags.toArray(), ts.String()))

--- a/agent/stats.go
+++ b/agent/stats.go
@@ -74,7 +74,9 @@ func (rs *receiverStats) Strings() []string {
 	strings := make([]string, 0, len(rs.Stats))
 
 	for _, ts := range rs.Stats {
-		strings = append(strings, fmt.Sprintf("%v -> %s", ts.Tags.toArray(), ts.String()))
+		if !ts.isEmpty() {
+			strings = append(strings, fmt.Sprintf("%v -> %s", ts.Tags.toArray(), ts.String()))
+		}
 	}
 	return strings
 }


### PR DESCRIPTION
- log the actual content of the stats `Strings`, not its indexes 
- proper `strings` init, to avoid having empty strings from initialization.
- hide the empty `""` tagStats.