### PR TITLE
Graceful shutdown for Windows Service

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -55,9 +55,7 @@ type Agent struct {
 }
 
 // NewAgent returns a new Agent object, ready to be started
-func NewAgent(conf *config.AgentConfig) *Agent {
-	exit := make(chan struct{})
-
+func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 	dynConf := config.NewDynamicConfig()
 	r := NewHTTPReceiver(conf, dynConf)
 	c := NewConcentrator(

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -28,7 +28,8 @@ func TestWatchdog(t *testing.T) {
 	defaultMux := http.DefaultServeMux
 	http.DefaultServeMux = http.NewServeMux()
 
-	agent := NewAgent(conf)
+	exit := make(chan struct{})
+	agent := NewAgent(conf, exit)
 
 	defer func() {
 		close(agent.exit)
@@ -99,7 +100,8 @@ func BenchmarkAgentTraceProcessingWithWorstCaseFiltering(b *testing.B) {
 }
 
 func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
-	agent := NewAgent(c)
+	exit := make(chan struct{})
+	agent := NewAgent(c, exit)
 	log.UseLogger(log.Disabled)
 
 	b.ResetTimer()
@@ -112,7 +114,8 @@ func runTraceProcessingBenchmark(b *testing.B, c *config.AgentConfig) {
 func BenchmarkWatchdog(b *testing.B) {
 	conf := config.NewDefaultAgentConfig()
 	conf.APIKey = "apikey_2"
-	agent := NewAgent(conf)
+	exit := make(chan struct{})
+	agent := NewAgent(conf, exit)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/agent/main.go
+++ b/agent/main.go
@@ -98,9 +98,8 @@ apm_enabled: true
 to your datadog.conf file.
 Exiting.`
 
-
 // runAgent is the entrypoint of our code
-func runAgent() {
+func runAgent(exit chan struct{}) {
 	// configure a default logger before anything so we can observe initialization
 	if opts.info || opts.version {
 		log.UseLogger(log.Disabled)
@@ -206,13 +205,7 @@ func runAgent() {
 	// Seed rand
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	agent := NewAgent(agentConf)
-
-	// Handle stops properly
-	go func() {
-		defer watchdog.LogOnPanic()
-		handleSignal(agent.exit)
-	}()
+	agent := NewAgent(agentConf, exit)
 
 	log.Infof("trace-agent running on host %s", agentConf.HostName)
 	agent.Run()

--- a/agent/main_nix.go
+++ b/agent/main_nix.go
@@ -2,26 +2,10 @@
 
 package main
 
-
 import (
-	"bytes"
 	"flag"
-	"fmt"
-	"math/rand"
-	"os"
-	"os/signal"
-	"runtime"
-	"runtime/pprof"
-	"strings"
-	"syscall"
-	"time"
-
-	log "github.com/cihub/seelog"
-	_ "net/http/pprof"
-
-	"github.com/DataDog/datadog-trace-agent/config"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
+	_ "net/http/pprof"
 )
 
 func init() {
@@ -41,5 +25,13 @@ func init() {
 
 // main is the main application entry point
 func main() {
-	runAgent()
+	exit := make(chan struct{})
+
+	// Handle stops properly
+	go func() {
+		defer watchdog.LogOnPanic()
+		handleSignal(exit)
+	}()
+
+	runAgent(exit)
 }

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -178,7 +178,7 @@ func main() {
 	}()
 
 	// Invoke the Agent
-	runAgent()
+	runAgent(exit)
 }
 
 func startService() error {

--- a/agent/main_windows.go
+++ b/agent/main_windows.go
@@ -2,7 +2,6 @@
 
 package main
 
-
 import (
 	"flag"
 	"fmt"
@@ -20,16 +19,16 @@ import (
 )
 
 var elog debug.Log
+
 const ServiceName = "datadog-trace-agent"
 
 // opts are the command-line options
 var winopts struct {
-	installService bool
+	installService   bool
 	uninstallService bool
-	startService bool
-	stopService bool
+	startService     bool
+	stopService      bool
 }
-
 
 func init() {
 	// command-line arguments
@@ -59,28 +58,30 @@ func (m *myservice) Execute(args []string, r <-chan svc.ChangeRequest, changes c
 	changes <- svc.Status{State: svc.StartPending}
 	changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 
-	runAgent()
+	exit := make(chan struct{})
 
-loop:
-	for {
-		select {
-		case c := <-r:
-			switch c.Cmd {
-			case svc.Interrogate:
-				changes <- c.CurrentStatus
-				// Testing deadlock from https://code.google.com/p/winsvc/issues/detail?id=4
-				time.Sleep(100 * time.Millisecond)
-				changes <- c.CurrentStatus
-			case svc.Stop, svc.Shutdown:
-				// FIXME need a way to stop!
-				//app.StopAgent()
-				break loop
-			default:
-				elog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
+	go func() {
+	loop:
+		for {
+			select {
+			case c := <-r:
+				switch c.Cmd {
+				case svc.Interrogate:
+					changes <- c.CurrentStatus
+					// Testing deadlock from https://code.google.com/p/winsvc/issues/detail?id=4
+					time.Sleep(100 * time.Millisecond)
+					changes <- c.CurrentStatus
+				case svc.Stop, svc.Shutdown:
+					close(exit)
+				default:
+					elog.Error(1, fmt.Sprintf("unexpected control request #%d", c))
+				}
 			}
-
 		}
-	}
+	}()
+
+	runAgent(exit)
+
 	elog.Info(1, fmt.Sprintf("prestopping %s service", ServiceName))
 	changes <- svc.Status{State: svc.StopPending}
 	return
@@ -168,8 +169,15 @@ func main() {
 	}
 
 	// if we are an interactive session, then just invoke the agent on the command line.
-	// Invoke the Agent
 
+	exit := make(chan struct{})
+	// Handle stops properly
+	go func() {
+		defer watchdog.LogOnPanic()
+		handleSignal(exitCommand)
+	}()
+
+	// Invoke the Agent
 	runAgent()
 }
 
@@ -288,7 +296,6 @@ func exePath() (string, error) {
 	return "", err
 }
 
-
 func removeService() error {
 	m, err := mgr.Connect()
 	if err != nil {
@@ -310,4 +317,3 @@ func removeService() error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
This PR extracts the logic of providing an exit channel out of the `runAgent` function, that way we can have different exit conditions:
- SIGINT or SIGTERM on unix
- service STOP or SHUTDOWN when it is running as a windows service