### PR TITLE
Add commit in default version number

### DIFF
--- a/gorake.rb
+++ b/gorake.rb
@@ -17,7 +17,7 @@ def go_build(program, opts={})
   branch = `git rev-parse --abbrev-ref HEAD`.strip
   date = Time.now.iso8601
   goversion = `go version`.strip
-  agentversion = ENV["TRACE_AGENT_VERSION"] || "0.99.0"
+  agentversion = ENV["TRACE_AGENT_VERSION"] || "0.99.0-#{commit}"
 
   vars = {}
   vars["#{dd}.Version"] = agentversion


### PR DESCRIPTION
This will make it possible to identify precisely which build is running from the version number.