### PR TITLE
Remove empty tag set from info page

### DIFF
--- a/agent/info.go
+++ b/agent/info.go
@@ -103,7 +103,9 @@ func updateReceiverStats(rs *receiverStats) {
 
 	s := make([]tagStats, 0, len(rs.Stats))
 	for _, tagStats := range rs.Stats {
-		s = append(s, *tagStats)
+		if !tagStats.isEmpty() {
+			s = append(s, *tagStats)
+		}
 	}
 
 	infoReceiverStats = s


### PR DESCRIPTION
Similar to https://github.com/DataDog/datadog-trace-agent/pull/328 but for the info page.

Currently we report things like: 

```
  --- Receiver stats (1 min) ---

  -> tags: go, 1.9.1, gc-amd64-linux, v0.5.0

    Traces received: 30425 (19674323 bytes)
    Spans received: 60850
    Services received: 0 (0 bytes)
    Total data received: 19674323 bytes

  ------------------------------

  --- Receiver stats (1 min) ---

  -> tags: None

    Traces received: 0 (0 bytes)
    Spans received: 0
    Services received: 0 (0 bytes)
    Total data received: 0 bytes

  ------------------------------
```

This PR removes the latter section.
