### PR TITLE
Change default log path on Windows

### DIFF
--- a/agent/log.go
+++ b/agent/log.go
@@ -7,10 +7,9 @@ import (
 
 	log "github.com/cihub/seelog"
 
+	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
-
-const defaultLogFilePath = "/var/log/datadog/trace-agent.log"
 
 const agentLoggerConfigFmt = `
 <seelog minlevel="%[1]s">
@@ -198,7 +197,7 @@ func SetupLogger(minLogLvl log.LogLevel, logFilePath string, logsDropInterval ti
 	log.RegisterReceiver("throttled", &ThrottledReceiver{})
 
 	// Build our config string
-	config := fmt.Sprintf(
+	logConfig := fmt.Sprintf(
 		agentLoggerConfigFmt,
 		minLogLvl,
 		logsDropInterval,
@@ -206,7 +205,7 @@ func SetupLogger(minLogLvl log.LogLevel, logFilePath string, logsDropInterval ti
 		logFilePath,
 	)
 
-	logger, err := log.LoggerFromConfigAsString(config)
+	logger, err := log.LoggerFromConfigAsString(logConfig)
 	if err != nil {
 		return err
 	}
@@ -216,9 +215,9 @@ func SetupLogger(minLogLvl log.LogLevel, logFilePath string, logsDropInterval ti
 // SetupDefaultLogger sets up a default logger for the agent, showing
 // all log messages and with no throttling.
 func SetupDefaultLogger() error {
-	config := fmt.Sprintf(rawLoggerConfigFmt, defaultLogFilePath)
+	logConfig := fmt.Sprintf(rawLoggerConfigFmt, config.DefaultLogFilePath)
 
-	logger, err := log.LoggerFromConfigAsString(config)
+	logger, err := log.LoggerFromConfigAsString(logConfig)
 	if err != nil {
 		return err
 	}

--- a/config/agent.go
+++ b/config/agent.go
@@ -184,7 +184,7 @@ func NewDefaultAgentConfig() *AgentConfig {
 		StatsdPort: 8125,
 
 		LogLevel:             "INFO",
-		LogFilePath:          "/var/log/datadog/trace-agent.log",
+		LogFilePath:          DefaultLogFilePath,
 		LogThrottlingEnabled: true,
 
 		MaxMemory:        5e8, // 500 Mb, should rarely go above 50 Mb

--- a/config/agent_nix.go
+++ b/config/agent_nix.go
@@ -1,0 +1,6 @@
+// +build !windows
+
+package config
+
+// DefaultLogFilePath is where the agent will write logs if not overriden in the conf
+const DefaultLogFilePath = "/var/log/datadog/trace-agent.log"

--- a/config/agent_windows.go
+++ b/config/agent_windows.go
@@ -1,0 +1,4 @@
+package config
+
+// DefaultLogFilePath is where the agent will write logs if not overriden in the conf
+const DefaultLogFilePath = "c:\\programdata\\datadog\\logs\\trace-agent.log"


### PR DESCRIPTION
The previous default log path assumed that the agent was running on a Unix system. This PR fixes that.