### PR TITLE
Extract info and writer packages from main

### DIFF
--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
@@ -515,23 +516,13 @@ func TestHandleTraces(t *testing.T) {
 
 	// We test stats for each app
 	for _, lang := range langs {
-		ts, ok := rs.Stats[Tags{Lang: lang}]
+		ts, ok := rs.Stats[info.Tags{Lang: lang}]
 		assert.True(ok)
 		assert.Equal(int64(20), ts.TracesReceived)
 		assert.Equal(int64(57622), ts.TracesBytes)
 	}
 	// make sure we have all our languages registered
 	assert.Equal("C#|go|java|python|ruby", receiver.Languages())
-
-	// now check for a subset of languages
-	rs.Stats = make(map[Tags]*tagStats)
-	assert.Equal("", receiver.Languages())
-
-	for _, lang := range []string{"python", "go"} {
-		rs.Stats[Tags{Lang: lang}] = &tagStats{}
-	}
-	assert.Equal("go|python", receiver.Languages())
-
 }
 
 func BenchmarkHandleTracesFromOneApp(b *testing.B) {

--- a/gorake.rb
+++ b/gorake.rb
@@ -12,7 +12,7 @@ def go_build(program, opts={})
     :add_build_vars => true
   }.merge(opts)
 
-  dd = 'main'
+  dd = 'info'
   commit = `git rev-parse --short HEAD`.strip
   branch = `git rev-parse --abbrev-ref HEAD`.strip
   date = Time.now.iso8601
@@ -32,7 +32,7 @@ def go_build(program, opts={})
 
   cmd = opts[:cmd]
   cmd += ' -race' if opts[:race]
-  
+
   if ENV['windres'] then
     # first compile the message table, as it's an input to the resource file
     msgcmd = "windmc --target pe-x86-64 -r agent/windows_resources agent/windows_resources/trace-agent-msg.mc"
@@ -45,7 +45,7 @@ def go_build(program, opts={})
     sh rescmd
 
   end
-  
+
   sh "#{cmd} -ldflags \"#{ldflags.join(' ')}\" #{program}"
 end
 

--- a/info/endpoint.go
+++ b/info/endpoint.go
@@ -1,0 +1,30 @@
+package info
+
+// EndpointStats contains stats about the volume of data written
+type EndpointStats struct {
+	// TracesPayload is the number of traces payload sent, including errors.
+	// If several URLs are given, each URL counts for one.
+	TracesPayload int64
+	// TracesPayloadError is the number of traces payload sent with an error.
+	// If several URLs are given, each URL counts for one.
+	TracesPayloadError int64
+	// TracesBytes is the size of the traces payload data sent, including errors.
+	// If several URLs are given, it does not change the size (shared for all).
+	// This is the raw data, encoded, compressed.
+	TracesBytes int64
+	// TracesCount is the number of traces in the traces payload data sent, including errors.
+	// If several URLs are given, it does not change the size (shared for all).
+	TracesCount int64
+	// TracesStats is the number of stats in the traces payload data sent, including errors.
+	// If several URLs are given, it does not change the size (shared for all).
+	TracesStats int64
+	// TracesPayload is the number of services payload sent, including errors.
+	// If several URLs are given, each URL counts for one.
+	ServicesPayload int64
+	// ServicesPayloadError is the number of services payload sent with an error.
+	// If several URLs are given, each URL counts for one.
+	ServicesPayloadError int64
+	// TracesBytes is the size of the services payload data sent, including errors.
+	// If several URLs are given, it does not change the size (shared for all).
+	ServicesBytes int64
+}

--- a/info/info_test.go
+++ b/info/info_test.go
@@ -1,4 +1,4 @@
-package main
+package info
 
 import (
 	"bytes"
@@ -186,13 +186,13 @@ func testServerError(t *testing.T) *httptest.Server {
 }
 
 // run this at the beginning of each test, this is because we *really*
-// need to have initInfo be called before doing anything
+// need to have InitInfo be called before doing anything
 func testInit(t *testing.T) *config.AgentConfig {
 	assert := assert.New(t)
 	conf := config.NewDefaultAgentConfig()
 	assert.NotNil(conf)
 
-	err := initInfo(conf)
+	err := InitInfo(conf)
 	assert.Nil(err)
 
 	return conf
@@ -338,7 +338,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	conf := testInit(t)
 	assert.NotNil(conf)
 
-	stats := newReceiverStats()
+	stats := NewReceiverStats()
 	t1 := &tagStats{
 		Tags{Lang: "python"},
 		Stats{TracesReceived: 23, TracesDropped: 2, TracesBytes: 3244, SpansReceived: 213, SpansDropped: 14},
@@ -357,7 +357,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		go func() {
 			for j := 0; j < 1000; j++ {
-				updateReceiverStats(stats)
+				UpdateReceiverStats(stats)
 			}
 			done <- struct{}{}
 		}()
@@ -383,7 +383,7 @@ func TestInfoReceiverStats(t *testing.T) {
 		t.Errorf("bad stats type: %v", s)
 	}
 	stats.Stats[t1.Tags].TracesReceived++
-	updateReceiverStats(stats)
+	UpdateReceiverStats(stats)
 	s = publishReceiverStats()
 	switch s := s.(type) {
 	case []tagStats:

--- a/info/sampler.go
+++ b/info/sampler.go
@@ -1,0 +1,20 @@
+package info
+
+import "github.com/DataDog/datadog-trace-agent/sampler"
+
+type SamplerInfo struct {
+	// EngineType contains the type of the engine (tells old sampler and new distributed sampler apart)
+	EngineType string
+	// Stats contains statistics about what the sampler is doing.
+	Stats SamplerStats
+	// State is the internal state of the sampler (for debugging mostly)
+	State sampler.InternalState
+}
+
+// samplerStats contains sampler statistics
+type SamplerStats struct {
+	// KeptTPS is the number of traces kept (average per second for last flush)
+	KeptTPS float64
+	// TotalTPS is the total number of traces (average per second for last flush)
+	TotalTPS float64
+}

--- a/info/stats.go
+++ b/info/stats.go
@@ -1,4 +1,4 @@
-package main
+package info
 
 import (
 	"fmt"
@@ -8,18 +8,18 @@ import (
 	"github.com/DataDog/datadog-trace-agent/statsd"
 )
 
-// receiverStats is used to store all the stats per tags.
-type receiverStats struct {
+// ReceiverStats is used to store all the stats per tags.
+type ReceiverStats struct {
 	sync.RWMutex
 	Stats map[Tags]*tagStats
 }
 
-func newReceiverStats() *receiverStats {
-	return &receiverStats{sync.RWMutex{}, map[Tags]*tagStats{}}
+func NewReceiverStats() *ReceiverStats {
+	return &ReceiverStats{sync.RWMutex{}, map[Tags]*tagStats{}}
 }
 
-// getTagStats returns the struct in which the stats will be stored depending of their tags.
-func (rs *receiverStats) getTagStats(tags Tags) *tagStats {
+// GetTagStats returns the struct in which the stats will be stored depending of their tags.
+func (rs *ReceiverStats) GetTagStats(tags Tags) *tagStats {
 	rs.Lock()
 	tagStats, ok := rs.Stats[tags]
 	if !ok {
@@ -31,17 +31,17 @@ func (rs *receiverStats) getTagStats(tags Tags) *tagStats {
 	return tagStats
 }
 
-// acc will accumulate the stats from another receiverStats struct.
-func (rs *receiverStats) acc(recent *receiverStats) {
+// Acc accumulates the stats from another ReceiverStats struct.
+func (rs *ReceiverStats) Acc(recent *ReceiverStats) {
 	recent.Lock()
 	for _, tagStats := range recent.Stats {
-		ts := rs.getTagStats(tagStats.Tags)
+		ts := rs.GetTagStats(tagStats.Tags)
 		ts.update(tagStats.Stats)
 	}
 	recent.Unlock()
 }
 
-func (rs *receiverStats) publish() {
+func (rs *ReceiverStats) Publish() {
 	rs.RLock()
 	for _, tagStats := range rs.Stats {
 		tagStats.publish()
@@ -49,7 +49,7 @@ func (rs *receiverStats) publish() {
 	rs.RUnlock()
 }
 
-func (rs *receiverStats) reset() {
+func (rs *ReceiverStats) Reset() {
 	rs.Lock()
 	for key, tagStats := range rs.Stats {
 		// If a tagStats was empty, let's drop it.
@@ -62,8 +62,8 @@ func (rs *receiverStats) reset() {
 	rs.Unlock()
 }
 
-// Strings gives a multi strings representation of the receiverStats struct.
-func (rs *receiverStats) Strings() []string {
+// Strings gives a multi strings representation of the ReceiverStats struct.
+func (rs *ReceiverStats) Strings() []string {
 	rs.RLock()
 	defer rs.RUnlock()
 

--- a/info/version.go
+++ b/info/version.go
@@ -1,0 +1,56 @@
+package info
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// version info sourced from build flags
+var (
+	Version   string
+	GitCommit string
+	GitBranch string
+	BuildDate string
+	GoVersion string
+)
+
+// versionString returns the version information filled in at build time
+func VersionString() string {
+	var buf bytes.Buffer
+
+	if Version != "" {
+		fmt.Fprintf(&buf, "Version: %s\n", Version)
+	}
+	if GitCommit != "" {
+		fmt.Fprintf(&buf, "Git hash: %s\n", GitCommit)
+	}
+	if GitBranch != "" {
+		fmt.Fprintf(&buf, "Git branch: %s\n", GitBranch)
+	}
+	if BuildDate != "" {
+		fmt.Fprintf(&buf, "Build date: %s\n", BuildDate)
+	}
+	if GoVersion != "" {
+		fmt.Fprintf(&buf, "Go Version: %s\n", GoVersion)
+	}
+
+	return buf.String()
+}
+
+type infoVersion struct {
+	Version   string
+	GitCommit string
+	GitBranch string
+	BuildDate string
+	GoVersion string
+}
+
+func publishVersion() interface{} {
+	return infoVersion{
+		Version:   Version,
+		GitCommit: GitCommit,
+		GitBranch: GitBranch,
+		BuildDate: BuildDate,
+		GoVersion: GoVersion,
+	}
+}

--- a/writer/endpoint_test.go
+++ b/writer/endpoint_test.go
@@ -1,4 +1,4 @@
-package main
+package writer
 
 import (
 	"testing"

--- a/writer/writer_test.go
+++ b/writer/writer_test.go
@@ -1,4 +1,4 @@
-package main
+package writer
 
 import (
 	"fmt"
@@ -69,7 +69,7 @@ func TestWriterServices(t *testing.T) {
 	conf.APIKey = "xxxxxxx"
 
 	w := NewWriter(conf)
-	w.inServices = make(chan model.ServicesMetadata)
+	w.InServices = make(chan model.ServicesMetadata)
 
 	go w.Run()
 
@@ -80,7 +80,7 @@ func TestWriterServices(t *testing.T) {
 		},
 	}
 
-	w.inServices <- services
+	w.InServices <- services
 
 receivingLoop:
 	for {
@@ -115,7 +115,7 @@ func TestWriterPayload(t *testing.T) {
 	w := NewWriter(conf)
 	go w.Run()
 
-	w.inPayloads <- newTestPayload("test")
+	w.InPayloads <- newTestPayload("test")
 
 receivingLoop:
 	for {
@@ -152,7 +152,7 @@ func TestWriterPayloadErrors(t *testing.T) {
 	w := NewWriter(conf)
 	go w.Run()
 
-	w.inPayloads <- newTestPayload("test")
+	w.InPayloads <- newTestPayload("test")
 
 receivingLoop:
 	for {
@@ -204,11 +204,11 @@ func TestWriterBuffering(t *testing.T) {
 
 	w := NewWriter(conf)
 	// Make the chan unbuffered to block on write
-	w.inPayloads = make(chan model.AgentPayload)
+	w.InPayloads = make(chan model.AgentPayload)
 	go w.Run()
 
 	for _, payload := range payloads {
-		w.inPayloads <- payload
+		w.InPayloads <- payload
 	}
 
 	w.Stop()
@@ -234,10 +234,10 @@ func TestWriterDisabledBuffering(t *testing.T) {
 
 	w := NewWriter(conf)
 	// Make the chan unbuffered to block on write
-	w.inPayloads = make(chan model.AgentPayload)
+	w.InPayloads = make(chan model.AgentPayload)
 	go w.Run()
 
-	w.inPayloads <- newTestPayload("test")
+	w.InPayloads <- newTestPayload("test")
 
 	w.Stop()
 


### PR DESCRIPTION
Extract `info` and `writer` packages to reduce the size of the `main`, simplify future development, help separate concerns.

As future work is going to add various elements to the writer, I initially extracted the `writer` (with the `endpoint.go`) into another package. But for it to work I needed to extract `info` too.


The PR introduces no logic change. It is just about moving struct/functions/variables to other packages, and making public the ones that have to.