### PR TITLE
Replace Trace []Span with []*Span

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,10 +64,16 @@ PACKAGES = %w(
 )
 
 EXCLUDE_LINT = [
-    'model/services_gen.go',
-    'model/trace_gen.go',
-    'model/span_gen.go',
-    'model/span.pb.go',
+  'model/services_gen.go',
+  'model/trace_gen.go',
+  'model/span_gen.go',
+  'model/span.pb.go',
+]
+
+MSGP_MODELS = [
+  'model/span.pb.go',
+  'model/trace.go',
+  'model/services.go',
 ]
 
 task :default => [:ci]
@@ -77,7 +83,7 @@ task :build do
   case os
   when "windows"
     bin = "trace-agent.exe"
-  else 
+  else
     bin = "trace-agent"
   end
   go_build("github.com/DataDog/datadog-trace-agent/agent", {
@@ -170,7 +176,17 @@ task :err do
   sh "errcheck github.com/DataDog/datadog-trace-agent"
 end
 
+desc "Regenerate protobuf files"
 task :protobuf do
   # be sure to have protobuf 3.x and go vendor installed
   sh "protoc -I=model -I=vendor --gogofaster_out=model model/*.proto"
+end
+
+desc "Regenerate msgpack files"
+task :msgp do
+  fail "Don't do it since we modified manually the generated files for services.go and span.go."
+  # TODO: make it clean and automatic again.
+  MSGP_MODELS.each do |file|
+   sh "msgp -file=#{file} -marshal=false"
+  end
 end

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -227,7 +227,7 @@ func (a *Agent) Process(t model.Trace) {
 	model.SetSublayersOnSpan(root, sublayers)
 
 	for i := range t {
-		t[i] = quantizer.Quantize(t[i])
+		quantizer.Quantize(t[i])
 		t[i].Truncate()
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -85,7 +85,7 @@ func TestFormatTrace(t *testing.T) {
 	rep := strings.Repeat(" AND age = 42", 5000)
 	resource = resource + rep
 	testTrace := model.Trace{
-		model.Span{
+		&model.Span{
 			Resource: resource,
 			Type:     "sql",
 		},
@@ -156,7 +156,7 @@ func BenchmarkWatchdog(b *testing.B) {
 // Mimicks behaviour of agent Process function
 func formatTrace(t model.Trace) model.Trace {
 	for i := range t {
-		t[i] = quantizer.Quantize(t[i])
+		quantizer.Quantize(t[i])
 		t[i].Truncate()
 	}
 	return t

--- a/agent/concentrator_test.go
+++ b/agent/concentrator_test.go
@@ -22,11 +22,11 @@ func getTsInBucket(alignedNow int64, bsize int64, offset int64) int64 {
 
 // testSpan avoids typo and inconsistency in test spans (typical pitfall: duration, start time,
 // and end time are aligned, and end time is the one that needs to be aligned
-func testSpan(c *Concentrator, spanID uint64, duration, offset int64, service, resource string, err int32) model.Span {
+func testSpan(c *Concentrator, spanID uint64, duration, offset int64, service, resource string, err int32) *model.Span {
 	now := model.Now()
 	alignedNow := now - now%c.bsize
 
-	return model.Span{
+	return &model.Span{
 		SpanID:   spanID,
 		Duration: duration,
 		Start:    getTsInBucket(alignedNow, c.bsize, offset) - duration,

--- a/filters/resource_test.go
+++ b/filters/resource_test.go
@@ -41,7 +41,7 @@ func TestRegexCompilationFailure(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		span := fixtures.RandomSpan()
-		assert.True(t, filter.Keep(&span))
+		assert.True(t, filter.Keep(span))
 	}
 }
 
@@ -75,5 +75,5 @@ func newTestFilter(blacklist ...string) Filter {
 func newTestSpan(resource string) *model.Span {
 	span := fixtures.RandomSpan()
 	span.Resource = resource
-	return &span
+	return span
 }

--- a/fixtures/span.go
+++ b/fixtures/span.go
@@ -248,8 +248,8 @@ func RandomSpanType() string {
 }
 
 // RandomSpan generates a wide-variety of spans, useful to test robustness & performance
-func RandomSpan() model.Span {
-	return model.Span{
+func RandomSpan() *model.Span {
+	return &model.Span{
 		Duration: RandomSpanDuration(),
 		Error:    RandomSpanError(),
 		Resource: RandomSpanResource(),
@@ -269,15 +269,15 @@ func RandomSpan() model.Span {
 func RandomWeightedSpan() *model.WeightedSpan {
 	s := RandomSpan()
 	return &model.WeightedSpan{
-		Span:     &s,
+		Span:     s,
 		Weight:   1,
 		TopLevel: true,
 	}
 }
 
 // GetTestSpan returns a Span with different fields set
-func GetTestSpan() model.Span {
-	span := model.Span{
+func GetTestSpan() *model.Span {
+	span := &model.Span{
 		TraceID:  42,
 		SpanID:   52,
 		ParentID: 42,
@@ -296,8 +296,8 @@ func GetTestSpan() model.Span {
 }
 
 // TestSpan returns a fix span with hardcoded info, useful for reproducible tests
-func TestSpan() model.Span {
-	span := model.Span{
+func TestSpan() *model.Span {
+	return &model.Span{
 		Duration: 10000000,
 		Error:    0,
 		Resource: "GET /some/raclette",
@@ -316,14 +316,13 @@ func TestSpan() model.Span {
 		ParentID: 1111,
 		Type:     "http",
 	}
-	return span
 }
 
 // TestWeightedSpan returns a static test weighted span for reproductive stats tests
 func TestWeightedSpan() *model.WeightedSpan {
 	s := TestSpan()
 	return &model.WeightedSpan{
-		Span:     &s,
+		Span:     s,
 		Weight:   1,
 		TopLevel: true,
 	}

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -8,8 +8,8 @@ import (
 
 // genNextLevel generates a new level for the trace tree structure,
 // having maxSpans as the max number of spans for this level
-func genNextLevel(prevLevel []model.Span, maxSpans int) []model.Span {
-	var spans []model.Span
+func genNextLevel(prevLevel []*model.Span, maxSpans int) []*model.Span {
+	var spans []*model.Span
 	numSpans := rand.Intn(maxSpans) + 1
 
 	// the spans have to be "nested" in the previous level
@@ -39,7 +39,7 @@ func genNextLevel(prevLevel []model.Span, maxSpans int) []model.Span {
 		timeLeft := prev.Duration
 
 		// create the spans
-		curSpans := make([]model.Span, 0, childSpans)
+		curSpans := make([]*model.Span, 0, childSpans)
 		for j := 0; j < childSpans && timeLeft > 0; j++ {
 			news := RandomSpan()
 			news.TraceID = prev.TraceID

--- a/model/client_api_test.go
+++ b/model/client_api_test.go
@@ -21,7 +21,7 @@ import (
 func getTestTrace() Traces {
 	return Traces{
 		Trace{
-			Span{
+			&Span{
 				TraceID:  math.MaxUint64,
 				SpanID:   math.MaxUint64,
 				ParentID: math.MaxUint64,

--- a/model/compat.go
+++ b/model/compat.go
@@ -6,9 +6,9 @@ package model
 // clients
 func TracesFromSpans(spans []Span) Traces {
 	traces := Traces{}
-	byID := make(map[uint64][]Span)
+	byID := make(map[uint64][]*Span)
 	for _, s := range spans {
-		byID[s.TraceID] = append(byID[s.TraceID], s)
+		byID[s.TraceID] = append(byID[s.TraceID], &s)
 	}
 	for _, t := range byID {
 		traces = append(traces, t)

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -227,7 +227,7 @@ func TestNormalizeTraceTraceIdMismatch(t *testing.T) {
 	span2 := testSpan()
 	span2.TraceID = 2
 
-	trace := Trace{*span1, *span2}
+	trace := Trace{span1, span2}
 
 	_, err := NormalizeTrace(trace)
 	assert.Error(t, err)
@@ -239,7 +239,7 @@ func TestNormalizeTraceInvalidSpan(t *testing.T) {
 	span2 := testSpan()
 	span2.Name = "" // invalid
 
-	trace := Trace{*span1, *span2}
+	trace := Trace{span1, span2}
 
 	_, err := NormalizeTrace(trace)
 	assert.Error(t, err)
@@ -250,7 +250,7 @@ func TestNormalizeTraceDuplicateSpanID(t *testing.T) {
 	span2 := testSpan()
 	span2.SpanID = span1.SpanID
 
-	trace := Trace{*span1, *span2}
+	trace := Trace{span1, span2}
 
 	_, err := NormalizeTrace(trace)
 	assert.Error(t, err)
@@ -262,7 +262,7 @@ func TestNormalizeTrace(t *testing.T) {
 	span2 := testSpan()
 	span2.SpanID++
 
-	trace := Trace{*span1, *span2}
+	trace := Trace{span1, span2}
 
 	_, err := NormalizeTrace(trace)
 	assert.NoError(t, err)

--- a/model/span.go
+++ b/model/span.go
@@ -22,8 +22,8 @@ func (s *Span) IsFlushMarker() bool {
 }
 
 // NewFlushMarker returns a new flush marker
-func NewFlushMarker() Span {
-	return Span{Type: flushMarkerType}
+func NewFlushMarker() *Span {
+	return &Span{Type: flushMarkerType}
 }
 
 // End returns the end time of the span.

--- a/model/stats_test.go
+++ b/model/stats_test.go
@@ -43,15 +43,15 @@ func testTrace() Trace {
 	// B   |----------------------|                                        duration: 20
 	// C     |-----| |---|                                                 duration: 5+3
 	trace := Trace{
-		Span{TraceID: 42, SpanID: 42, ParentID: 0, Service: "A",
+		&Span{TraceID: 42, SpanID: 42, ParentID: 0, Service: "A",
 			Name: "A.foo", Type: "web", Resource: "α", Start: 0, Duration: 100,
 			Metrics: map[string]float64{SpanSampleRateMetricKey: 0.5}},
-		Span{TraceID: 42, SpanID: 100, ParentID: 42, Service: "B",
+		&Span{TraceID: 42, SpanID: 100, ParentID: 42, Service: "B",
 			Name: "B.bar", Type: "web", Resource: "α", Start: 1, Duration: 20},
-		Span{TraceID: 42, SpanID: 2000, ParentID: 100, Service: "C",
+		&Span{TraceID: 42, SpanID: 2000, ParentID: 100, Service: "C",
 			Name: "sql.query", Type: "sql", Resource: "SELECT value FROM table",
 			Start: 2, Duration: 5},
-		Span{TraceID: 42, SpanID: 3000, ParentID: 100, Service: "C",
+		&Span{TraceID: 42, SpanID: 3000, ParentID: 100, Service: "C",
 			Name: "sql.query", Type: "sql", Resource: "SELECT ololololo... value FROM table",
 			Start: 10, Duration: 3, Error: 1},
 	}
@@ -69,15 +69,15 @@ func testTraceTopLevel() Trace {
 	// B   |----------------------|                                        duration: 20
 	// B     |-----| |---|                                                 duration: 5+3
 	trace := Trace{
-		Span{TraceID: 42, SpanID: 42, ParentID: 0, Service: "A",
+		&Span{TraceID: 42, SpanID: 42, ParentID: 0, Service: "A",
 			Name: "A.foo", Type: "web", Resource: "α", Start: 0, Duration: 100,
 			Metrics: map[string]float64{SpanSampleRateMetricKey: 1}},
-		Span{TraceID: 42, SpanID: 100, ParentID: 42, Service: "B",
+		&Span{TraceID: 42, SpanID: 100, ParentID: 42, Service: "B",
 			Name: "B.bar", Type: "web", Resource: "α", Start: 1, Duration: 20},
-		Span{TraceID: 42, SpanID: 2000, ParentID: 100, Service: "B",
+		&Span{TraceID: 42, SpanID: 2000, ParentID: 100, Service: "B",
 			Name: "B.bar.1", Type: "web", Resource: "α",
 			Start: 2, Duration: 5},
-		Span{TraceID: 42, SpanID: 3000, ParentID: 100, Service: "B",
+		&Span{TraceID: 42, SpanID: 3000, ParentID: 100, Service: "B",
 			Name: "B.bar.2", Type: "web", Resource: "α",
 			Start: 10, Duration: 3, Error: 1},
 	}

--- a/model/sublayers.go
+++ b/model/sublayers.go
@@ -172,7 +172,7 @@ func (a activeSpansMap) Add(ts int64, span *Span) {
 	a[ts] = append(a[ts], span)
 }
 
-// buildTraceActiveSpansMapping returns a mappging from timestamps to
+// buildTraceActiveSpansMapping returns a mapping from timestamps to
 // a set of active spans
 func buildTraceActiveSpansMapping(trace Trace, timestamps []int64) map[int64][]*Span {
 	activeSpans := make(activeSpansMap, len(timestamps))
@@ -198,7 +198,7 @@ func buildTraceActiveSpansMapping(trace Trace, timestamps []int64) map[int64][]*
 			}
 
 			if !hasChild {
-				activeSpans.Add(ts, &trace[sIdx])
+				activeSpans.Add(ts, trace[sIdx])
 			}
 		}
 	}

--- a/model/sublayers_test.go
+++ b/model/sublayers_test.go
@@ -30,8 +30,8 @@ func (values sublayerValues) Less(i, j int) bool {
 func TestComputeSublayers(t *testing.T) {
 	assert := assert.New(t)
 
-	span := func(id, parentId uint64, service, spanType string, start, duration int64) Span {
-		return Span{
+	span := func(id, parentId uint64, service, spanType string, start, duration int64) *Span {
+		return &Span{
 			TraceID:  1,
 			SpanID:   id,
 			ParentID: parentId,
@@ -245,8 +245,8 @@ func TestComputeSublayers(t *testing.T) {
 func TestBuildTraceTimestamps(t *testing.T) {
 	assert := assert.New(t)
 
-	span := func(id, parentId uint64, service, spanType string, start, duration int64) Span {
-		return Span{
+	span := func(id, parentId uint64, service, spanType string, start, duration int64) *Span {
+		return &Span{
 			TraceID:  1,
 			SpanID:   id,
 			ParentID: parentId,
@@ -296,8 +296,8 @@ func TestBuildTraceTimestamps(t *testing.T) {
 func TestBuildTraceActiveSpansMapping(t *testing.T) {
 	assert := assert.New(t)
 
-	span := func(id, parentId uint64, service, spanType string, start, duration int64) Span {
-		return Span{
+	span := func(id, parentId uint64, service, spanType string, start, duration int64) *Span {
+		return &Span{
 			TraceID:  1,
 			SpanID:   id,
 			ParentID: parentId,
@@ -405,8 +405,8 @@ func TestSetSublayersOnSpan(t *testing.T) {
 }
 
 func BenchmarkComputeSublayers(b *testing.B) {
-	span := func(id, parentId uint64, service, spanType string, start, duration int64) Span {
-		return Span{
+	span := func(id, parentId uint64, service, spanType string, start, duration int64) *Span {
+		return &Span{
 			TraceID:  1,
 			SpanID:   id,
 			ParentID: parentId,

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -10,11 +10,11 @@ func TestTopLevelTypical(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
-		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
-		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
-		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
-		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
+		&Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
+		&Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
+		&Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
+		&Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
 	}
 
 	tr.ComputeTopLevel()
@@ -30,7 +30,7 @@ func TestTopLevelSingle(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
-		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
 	}
 
 	tr.ComputeTopLevel()
@@ -52,11 +52,11 @@ func TestTopLevelOneService(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
-		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: "web"},
 	}
 
 	tr.ComputeTopLevel()
@@ -72,13 +72,13 @@ func TestTopLevelLocalRoot(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
-		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
-		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
-		Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
-		Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
-		Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
-		Span{TraceID: 1, SpanID: 6, ParentID: 4, Service: "redis", Type: "redis"},
-		Span{TraceID: 1, SpanID: 7, ParentID: 4, Service: "redis", Type: "redis"},
+		&Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web"},
+		&Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "sql"},
+		&Span{TraceID: 1, SpanID: 3, ParentID: 2, Service: "master-db", Type: "sql"},
+		&Span{TraceID: 1, SpanID: 4, ParentID: 1, Service: "redis", Type: "redis"},
+		&Span{TraceID: 1, SpanID: 5, ParentID: 1, Service: "mcnulty", Type: ""},
+		&Span{TraceID: 1, SpanID: 6, ParentID: 4, Service: "redis", Type: "redis"},
+		&Span{TraceID: 1, SpanID: 7, ParentID: 4, Service: "redis", Type: "redis"},
 	}
 
 	tr.ComputeTopLevel()
@@ -96,8 +96,8 @@ func TestTopLevelWithTag(t *testing.T) {
 	assert := assert.New(t)
 
 	tr := Trace{
-		Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web", Metrics: map[string]float64{"custom": 42}},
-		Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web", Metrics: map[string]float64{"custom": 42}},
+		&Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "mcnulty", Type: "web", Metrics: map[string]float64{"custom": 42}},
+		&Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "mcnulty", Type: "web", Metrics: map[string]float64{"custom": 42}},
 	}
 
 	tr.ComputeTopLevel()

--- a/model/trace.go
+++ b/model/trace.go
@@ -7,9 +7,9 @@ import (
 //go:generate msgp -marshal=false
 
 // Trace is a collection of spans with the same trace ID
-type Trace []Span
+type Trace []*Span
 
-// Traces is a list of traces that represents the  ...
+// Traces is a list of traces. This model matters as this is what we unpack from msgp.
 type Traces []Trace
 
 // GetEnv returns the meta value for the "env" key for
@@ -40,9 +40,9 @@ func (t Trace) GetRoot() *Span {
 		// since some clients report the root last
 		j := len(t) - 1 - i
 		if t[j].ParentID == 0 {
-			return &t[j]
+			return t[j]
 		}
-		parentIDToChild[t[j].ParentID] = &t[j]
+		parentIDToChild[t[j].ParentID] = t[j]
 	}
 
 	for i := range t {
@@ -63,7 +63,7 @@ func (t Trace) GetRoot() *Span {
 	}
 
 	// Gracefully fail with the last span of the trace
-	return &t[len(t)-1]
+	return t[len(t)-1]
 }
 
 // ChildrenMap returns a map containing for each span id the list of its
@@ -72,7 +72,7 @@ func (t Trace) ChildrenMap() map[uint64][]*Span {
 	childrenMap := make(map[uint64][]*Span)
 
 	for i := range t {
-		span := &t[i]
+		span := t[i]
 
 		if span.ParentID == 0 {
 			continue
@@ -97,5 +97,5 @@ func (t Trace) ChildrenMap() map[uint64][]*Span {
 
 // NewTraceFlushMarker returns a trace with a single span as flush marker
 func NewTraceFlushMarker() Trace {
-	return []Span{NewFlushMarker()}
+	return []*Span{NewFlushMarker()}
 }

--- a/model/trace_gen.go
+++ b/model/trace_gen.go
@@ -4,24 +4,37 @@ package model
 // MSGP CODE GENERATION TOOL (github.com/tinylib/msgp)
 // DO NOT EDIT
 
-import "github.com/tinylib/msgp/msgp"
+import (
+	"github.com/tinylib/msgp/msgp"
+)
 
 // DecodeMsg implements msgp.Decodable
 func (z *Trace) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zbai uint32
-	zbai, err = dc.ReadArrayHeader()
+	var xsz uint32
+	xsz, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zbai) {
-		(*z) = (*z)[:zbai]
+	if cap((*z)) >= int(xsz) {
+		(*z) = (*z)[:xsz]
 	} else {
-		(*z) = make(Trace, zbai)
+		(*z) = make(Trace, xsz)
 	}
-	for zbzg := range *z {
-		err = (*z)[zbzg].DecodeMsg(dc)
-		if err != nil {
-			return
+	for bzg := range *z {
+		if dc.IsNil() {
+			err = dc.ReadNil()
+			if err != nil {
+				return
+			}
+			(*z)[bzg] = nil
+		} else {
+			if (*z)[bzg] == nil {
+				(*z)[bzg] = new(Span)
+			}
+			err = (*z)[bzg].DecodeMsg(dc)
+			if err != nil {
+				return
+			}
 		}
 	}
 	return
@@ -33,51 +46,72 @@ func (z Trace) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zcmr := range z {
-		err = z[zcmr].EncodeMsg(en)
-		if err != nil {
-			return
+	for bai := range z {
+		if z[bai] == nil {
+			err = en.WriteNil()
+			if err != nil {
+				return
+			}
+		} else {
+			err = z[bai].EncodeMsg(en)
+			if err != nil {
+				return
+			}
 		}
 	}
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z Trace) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zcmr := range z {
-		s += z[zcmr].Msgsize()
+	for bai := range z {
+		if z[bai] == nil {
+			s += msgp.NilSize
+		} else {
+			s += z[bai].Msgsize()
+		}
 	}
 	return
 }
 
 // DecodeMsg implements msgp.Decodable
 func (z *Traces) DecodeMsg(dc *msgp.Reader) (err error) {
-	var zxhx uint32
-	zxhx, err = dc.ReadArrayHeader()
+	var xsz uint32
+	xsz, err = dc.ReadArrayHeader()
 	if err != nil {
 		return
 	}
-	if cap((*z)) >= int(zxhx) {
-		(*z) = (*z)[:zxhx]
+	if cap((*z)) >= int(xsz) {
+		(*z) = (*z)[:xsz]
 	} else {
-		(*z) = make(Traces, zxhx)
+		(*z) = make(Traces, xsz)
 	}
-	for zhct := range *z {
-		var zlqf uint32
-		zlqf, err = dc.ReadArrayHeader()
+	for wht := range *z {
+		var xsz uint32
+		xsz, err = dc.ReadArrayHeader()
 		if err != nil {
 			return
 		}
-		if cap((*z)[zhct]) >= int(zlqf) {
-			(*z)[zhct] = ((*z)[zhct])[:zlqf]
+		if cap((*z)[wht]) >= int(xsz) {
+			(*z)[wht] = (*z)[wht][:xsz]
 		} else {
-			(*z)[zhct] = make(Trace, zlqf)
+			(*z)[wht] = make(Trace, xsz)
 		}
-		for zcua := range (*z)[zhct] {
-			err = (*z)[zhct][zcua].DecodeMsg(dc)
-			if err != nil {
-				return
+		for hct := range (*z)[wht] {
+			if dc.IsNil() {
+				err = dc.ReadNil()
+				if err != nil {
+					return
+				}
+				(*z)[wht][hct] = nil
+			} else {
+				if (*z)[wht][hct] == nil {
+					(*z)[wht][hct] = new(Span)
+				}
+				err = (*z)[wht][hct].DecodeMsg(dc)
+				if err != nil {
+					return
+				}
 			}
 		}
 	}
@@ -90,28 +124,38 @@ func (z Traces) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	for zdaf := range z {
-		err = en.WriteArrayHeader(uint32(len(z[zdaf])))
+	for cua := range z {
+		err = en.WriteArrayHeader(uint32(len(z[cua])))
 		if err != nil {
 			return
 		}
-		for zpks := range z[zdaf] {
-			err = z[zdaf][zpks].EncodeMsg(en)
-			if err != nil {
-				return
+		for xhx := range z[cua] {
+			if z[cua][xhx] == nil {
+				err = en.WriteNil()
+				if err != nil {
+					return
+				}
+			} else {
+				err = z[cua][xhx].EncodeMsg(en)
+				if err != nil {
+					return
+				}
 			}
 		}
 	}
 	return
 }
 
-// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z Traces) Msgsize() (s int) {
 	s = msgp.ArrayHeaderSize
-	for zdaf := range z {
+	for cua := range z {
 		s += msgp.ArrayHeaderSize
-		for zpks := range z[zdaf] {
-			s += z[zdaf][zpks].Msgsize()
+		for xhx := range z[cua] {
+			if z[cua][xhx] == nil {
+				s += msgp.NilSize
+			} else {
+				s += z[cua][xhx].Msgsize()
+			}
 		}
 	}
 	return

--- a/model/trace_test.go
+++ b/model/trace_test.go
@@ -10,11 +10,11 @@ func TestGetRootFromCompleteTrace(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := Trace{
-		Span{TraceID: uint64(1234), SpanID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12342), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12343), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12344), ParentID: uint64(12342), Service: "s2", Name: "n2", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12345), ParentID: uint64(12344), Service: "s2", Name: "n2", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12342), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12343), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12344), ParentID: uint64(12342), Service: "s2", Name: "n2", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12345), ParentID: uint64(12344), Service: "s2", Name: "n2", Resource: ""},
 	}
 
 	assert.Equal(trace.GetRoot().SpanID, uint64(12341))
@@ -24,9 +24,9 @@ func TestGetRootFromPartialTrace(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := Trace{
-		Span{TraceID: uint64(1234), SpanID: uint64(12341), ParentID: uint64(12340), Service: "s1", Name: "n1", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12342), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
-		Span{TraceID: uint64(1234), SpanID: uint64(12343), ParentID: uint64(12342), Service: "s2", Name: "n2", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12341), ParentID: uint64(12340), Service: "s1", Name: "n1", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12342), ParentID: uint64(12341), Service: "s1", Name: "n1", Resource: ""},
+		&Span{TraceID: uint64(1234), SpanID: uint64(12343), ParentID: uint64(12342), Service: "s2", Name: "n2", Resource: ""},
 	}
 
 	assert.Equal(trace.GetRoot().SpanID, uint64(12341))
@@ -36,20 +36,20 @@ func TestTraceChildrenMap(t *testing.T) {
 	assert := assert.New(t)
 
 	trace := Trace{
-		Span{SpanID: 1, ParentID: 0},
-		Span{SpanID: 2, ParentID: 1},
-		Span{SpanID: 3, ParentID: 1},
-		Span{SpanID: 4, ParentID: 2},
-		Span{SpanID: 5, ParentID: 3},
-		Span{SpanID: 6, ParentID: 4},
+		&Span{SpanID: 1, ParentID: 0},
+		&Span{SpanID: 2, ParentID: 1},
+		&Span{SpanID: 3, ParentID: 1},
+		&Span{SpanID: 4, ParentID: 2},
+		&Span{SpanID: 5, ParentID: 3},
+		&Span{SpanID: 6, ParentID: 4},
 	}
 
 	childrenMap := trace.ChildrenMap()
 
-	assert.Equal([]*Span{&trace[1], &trace[2]}, childrenMap[1])
-	assert.Equal([]*Span{&trace[3]}, childrenMap[2])
-	assert.Equal([]*Span{&trace[4]}, childrenMap[3])
-	assert.Equal([]*Span{&trace[5]}, childrenMap[4])
+	assert.Equal([]*Span{trace[1], trace[2]}, childrenMap[1])
+	assert.Equal([]*Span{trace[3]}, childrenMap[2])
+	assert.Equal([]*Span{trace[4]}, childrenMap[3])
+	assert.Equal([]*Span{trace[5]}, childrenMap[4])
 	assert.Equal([]*Span{}, childrenMap[5])
 	assert.Equal([]*Span{}, childrenMap[6])
 }

--- a/model/weighted_span.go
+++ b/model/weighted_span.go
@@ -12,14 +12,14 @@ type WeightedSpan struct {
 type WeightedTrace []*WeightedSpan
 
 // NewWeightedTrace returns a weighted trace, with coefficient required by the concentrator.
-func NewWeightedTrace(trace []Span, root *Span) WeightedTrace {
+func NewWeightedTrace(trace Trace, root *Span) WeightedTrace {
 	wt := make(WeightedTrace, len(trace))
 
 	weight := root.Weight()
 
 	for i := range trace {
 		wt[i] = &WeightedSpan{
-			Span:     &trace[i],
+			Span:     trace[i],
 			Weight:   weight,
 			TopLevel: trace[i].TopLevel(),
 		}

--- a/quantizer/cassandra_test.go
+++ b/quantizer/cassandra_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/DataDog/datadog-trace-agent/model"
 )
 
-func CassSpan(query string) model.Span {
-	return model.Span{
+func CassSpan(query string) *model.Span {
+	return &model.Span{
 		Resource: query,
 		Type:     "cassandra",
 		Meta: map[string]string{
@@ -52,6 +52,8 @@ func TestCassQuantizer(t *testing.T) {
 	}
 
 	for _, testCase := range queryToExpected {
-		assert.Equal(testCase.expected, Quantize(CassSpan(testCase.in)).Resource)
+		s := CassSpan(testCase.in)
+		Quantize(s)
+		assert.Equal(testCase.expected, s.Resource)
 	}
 }

--- a/quantizer/main.go
+++ b/quantizer/main.go
@@ -17,20 +17,15 @@ const (
 
 var nonUniformSpacesRegexp = regexp.MustCompile("\\s+")
 
-// QuantizeFunction is a function which will return an updated span with a quantized resource
-type QuantizeFunction func(model.Span) model.Span
-
 // Quantize generates meaningful resource for a span, depending on its type
-func Quantize(span model.Span) model.Span {
+func Quantize(span *model.Span) {
 	switch span.Type {
 	case sqlType:
-		return QuantizeSQL(span)
+		QuantizeSQL(span)
 	case cassandraType:
-		return QuantizeSQL(span)
+		QuantizeSQL(span)
 	case redisType:
-		return QuantizeRedis(span)
-	default:
-		return span
+		QuantizeRedis(span)
 	}
 }
 

--- a/quantizer/redis.go
+++ b/quantizer/redis.go
@@ -18,7 +18,7 @@ var redisCompoundCommandSet = map[string]bool{
 	"CLIENT": true, "CLUSTER": true, "COMMAND": true, "CONFIG": true, "DEBUG": true, "SCRIPT": true}
 
 // QuantizeRedis generates resource for Redis spans
-func QuantizeRedis(span model.Span) model.Span {
+func QuantizeRedis(span *model.Span) {
 	query := compactWhitespaces(span.Resource)
 
 	var resource bytes.Buffer
@@ -75,6 +75,4 @@ func QuantizeRedis(span model.Span) model.Span {
 	}
 
 	span.Resource = strings.Trim(resource.String(), " ")
-
-	return span
 }

--- a/quantizer/redis_test.go
+++ b/quantizer/redis_test.go
@@ -13,8 +13,8 @@ type redisTestCase struct {
 	expectedResource string
 }
 
-func RedisSpan(query string) model.Span {
-	return model.Span{
+func RedisSpan(query string) *model.Span {
+	return &model.Span{
 		Resource: query,
 		Type:     "redis",
 	}
@@ -80,7 +80,9 @@ func TestRedisQuantizer(t *testing.T) {
 	}
 
 	for _, testCase := range queryToExpected {
-		assert.Equal(testCase.expectedResource, Quantize(RedisSpan(testCase.query)).Resource)
+		s := RedisSpan(testCase.query)
+		Quantize(s)
+		assert.Equal(testCase.expectedResource, s.Resource)
 	}
 
 }
@@ -90,6 +92,6 @@ func BenchmarkTestRedisQuantizer(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		span := RedisSpan(`DEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"\nDEL k1\nDEL k2\nHMSET k1 "a" 1 "b" 2 "c" 3\nHMSET k2 "d" "4" "e" "4"\nDEL k3\nHMSET k3 "f" "5"`)
-		_ = QuantizeRedis(span)
+		QuantizeRedis(span)
 	}
 }

--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -202,9 +202,9 @@ var tokenQuantizer = NewTokenConsumer(
 	})
 
 // QuantizeSQL generates resource and sql.query meta for SQL spans
-func QuantizeSQL(span model.Span) model.Span {
+func QuantizeSQL(span *model.Span) {
 	if span.Resource == "" {
-		return span
+		return
 	}
 
 	quantizedString, err := tokenQuantizer.Process(span.Resource)
@@ -220,7 +220,7 @@ func QuantizeSQL(span model.Span) model.Span {
 			span.Meta[sqlQueryTag] = span.Resource
 		}
 		span.Resource = "Non-parsable SQL query"
-		return span
+		return
 	}
 
 	span.Resource = quantizedString
@@ -232,7 +232,7 @@ func QuantizeSQL(span model.Span) model.Span {
 	// obfuscation == quantization. This is not true in real environments because we're
 	// removing data that could be interesting for users.
 	if span.Meta != nil && span.Meta[sqlQueryTag] != "" {
-		return span
+		return
 	}
 
 	if span.Meta == nil {
@@ -240,5 +240,5 @@ func QuantizeSQL(span model.Span) model.Span {
 	}
 
 	span.Meta[sqlQueryTag] = quantizedString
-	return span
+	return
 }

--- a/sampler/prioritysampler_test.go
+++ b/sampler/prioritysampler_test.go
@@ -32,8 +32,8 @@ func getTestPriorityEngine() *PriorityEngine {
 func getTestTraceWithService(t *testing.T, service string, s *PriorityEngine) (model.Trace, *model.Span) {
 	tID := randomTraceID()
 	trace := model.Trace{
-		model.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: service, Type: "web", Meta: map[string]string{"env": defaultEnv}},
-		model.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: service, Type: "sql"},
+		&model.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: service, Type: "web", Meta: map[string]string{"env": defaultEnv}},
+		&model.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: service, Type: "sql"},
 	}
 	r := rand.Float64()
 	priority := 0.0
@@ -49,7 +49,7 @@ func getTestTraceWithService(t *testing.T, service string, s *PriorityEngine) (m
 		priority = 1
 	}
 	trace[0].Metrics = map[string]float64{samplingPriorityKey: priority}
-	return trace, &trace[0]
+	return trace, trace[0]
 }
 
 func TestMaxTPSByService(t *testing.T) {

--- a/sampler/scoresampler_test.go
+++ b/sampler/scoresampler_test.go
@@ -27,10 +27,10 @@ func getTestScoreEngine() *ScoreEngine {
 func getTestTrace() (model.Trace, *model.Span) {
 	tID := randomTraceID()
 	trace := model.Trace{
-		model.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: "mcnulty", Type: "web"},
-		model.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: "mcnulty", Type: "sql"},
+		&model.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: "mcnulty", Type: "web"},
+		&model.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: "mcnulty", Type: "sql"},
 	}
-	return trace, &trace[0]
+	return trace, trace[0]
 }
 
 func TestExtraSampleRate(t *testing.T) {
@@ -146,13 +146,13 @@ func BenchmarkSampler(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		trace := model.Trace{
-			model.Span{TraceID: 1, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000000, Service: "mcnulty", Type: "web", Resource: string(rand.Intn(signatureCount))},
-			model.Span{TraceID: 1, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000000, Service: "mcnulty", Type: "sql"},
-			model.Span{TraceID: 1, SpanID: 3, ParentID: 2, Start: 150, Duration: 199999000, Service: "master-db", Type: "sql"},
-			model.Span{TraceID: 1, SpanID: 4, ParentID: 1, Start: 500000000, Duration: 500000, Service: "redis", Type: "redis"},
-			model.Span{TraceID: 1, SpanID: 5, ParentID: 1, Start: 700000000, Duration: 700000, Service: "mcnulty", Type: ""},
+			&model.Span{TraceID: 1, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000000, Service: "mcnulty", Type: "web", Resource: string(rand.Intn(signatureCount))},
+			&model.Span{TraceID: 1, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000000, Service: "mcnulty", Type: "sql"},
+			&model.Span{TraceID: 1, SpanID: 3, ParentID: 2, Start: 150, Duration: 199999000, Service: "master-db", Type: "sql"},
+			&model.Span{TraceID: 1, SpanID: 4, ParentID: 1, Start: 500000000, Duration: 500000, Service: "redis", Type: "redis"},
+			&model.Span{TraceID: 1, SpanID: 5, ParentID: 1, Start: 700000000, Duration: 700000, Service: "mcnulty", Type: ""},
 		}
-		s.Sample(trace, &trace[0], defaultEnv)
+		s.Sample(trace, trace[0], defaultEnv)
 	}
 }
 

--- a/sampler/signature.go
+++ b/sampler/signature.go
@@ -54,7 +54,7 @@ func computeServiceSignature(root *model.Span, env string) Signature {
 	return Signature(computeServiceHash(*root, env))
 }
 
-func computeSpanHash(span model.Span, env string) spanHash {
+func computeSpanHash(span *model.Span, env string) spanHash {
 	h := fnv.New32a()
 	h.Write([]byte(env))
 	h.Write([]byte(span.Service))

--- a/sampler/signature_test.go
+++ b/sampler/signature_test.go
@@ -17,15 +17,15 @@ func TestSignatureSimilar(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 102, SpanID: 1021, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312},
-		model.Span{TraceID: 102, SpanID: 1022, ParentID: 1021, Service: "x1", Name: "y1", Resource: "z1", Duration: 34347},
-		model.Span{TraceID: 102, SpanID: 1023, ParentID: 1022, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
+		&model.Span{TraceID: 102, SpanID: 1021, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312},
+		&model.Span{TraceID: 102, SpanID: 1022, ParentID: 1021, Service: "x1", Name: "y1", Resource: "z1", Duration: 34347},
+		&model.Span{TraceID: 102, SpanID: 1023, ParentID: 1022, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
 	}
 
 	assert.Equal(testComputeSignature(t1), testComputeSignature(t2))
@@ -35,15 +35,15 @@ func TestSignatureDifferentError(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 110, SpanID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312},
-		model.Span{TraceID: 110, SpanID: 1102, ParentID: 1101, Service: "x1", Name: "y1", Resource: "z1", Error: 1, Duration: 34347},
-		model.Span{TraceID: 110, SpanID: 1103, ParentID: 1101, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
+		&model.Span{TraceID: 110, SpanID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312},
+		&model.Span{TraceID: 110, SpanID: 1102, ParentID: 1101, Service: "x1", Name: "y1", Resource: "z1", Error: 1, Duration: 34347},
+		&model.Span{TraceID: 110, SpanID: 1103, ParentID: 1101, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
 	}
 
 	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
@@ -53,15 +53,15 @@ func TestSignatureDifferentRoot(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z2", Duration: 19207},
-		model.Span{TraceID: 103, SpanID: 1032, ParentID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 234923874},
-		model.Span{TraceID: 103, SpanID: 1033, ParentID: 1032, Service: "x1", Name: "y1", Resource: "z1", Duration: 152342344},
+		&model.Span{TraceID: 103, SpanID: 1031, Service: "x1", Name: "y1", Resource: "z2", Duration: 19207},
+		&model.Span{TraceID: 103, SpanID: 1032, ParentID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 234923874},
+		&model.Span{TraceID: 103, SpanID: 1033, ParentID: 1032, Service: "x1", Name: "y1", Resource: "z1", Duration: 152342344},
 	}
 
 	assert.NotEqual(testComputeSignature(t1), testComputeSignature(t2))
@@ -77,15 +77,15 @@ func TestServiceSignatureSimilar(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 102, SpanID: 1021, Service: "x1", Name: "y2", Resource: "z2", Duration: 992312},
-		model.Span{TraceID: 102, SpanID: 1022, ParentID: 1021, Service: "x1", Name: "y1", Resource: "z1", Error: 1, Duration: 34347},
-		model.Span{TraceID: 102, SpanID: 1023, ParentID: 1022, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
+		&model.Span{TraceID: 102, SpanID: 1021, Service: "x1", Name: "y2", Resource: "z2", Duration: 992312},
+		&model.Span{TraceID: 102, SpanID: 1022, ParentID: 1021, Service: "x1", Name: "y1", Resource: "z1", Error: 1, Duration: 34347},
+		&model.Span{TraceID: 102, SpanID: 1023, ParentID: 1022, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
 	}
 	assert.Equal(testComputeServiceSignature(t1), testComputeServiceSignature(t2))
 }
@@ -94,15 +94,15 @@ func TestServiceSignatureDifferentService(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 103, SpanID: 1031, Service: "x2", Name: "y1", Resource: "z1", Duration: 19207},
-		model.Span{TraceID: 103, SpanID: 1032, ParentID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 234923874},
-		model.Span{TraceID: 103, SpanID: 1033, ParentID: 1032, Service: "x1", Name: "y1", Resource: "z1", Duration: 152342344},
+		&model.Span{TraceID: 103, SpanID: 1031, Service: "x2", Name: "y1", Resource: "z1", Duration: 19207},
+		&model.Span{TraceID: 103, SpanID: 1032, ParentID: 1031, Service: "x1", Name: "y1", Resource: "z1", Duration: 234923874},
+		&model.Span{TraceID: 103, SpanID: 1033, ParentID: 1032, Service: "x1", Name: "y1", Resource: "z1", Duration: 152342344},
 	}
 
 	assert.NotEqual(testComputeServiceSignature(t1), testComputeServiceSignature(t2))
@@ -112,15 +112,15 @@ func TestServiceSignatureDifferentEnv(t *testing.T) {
 	assert := assert.New(t)
 
 	t1 := model.Trace{
-		model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965, Meta: map[string]string{"env": "test"}},
-		model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
-		model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
-		model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
+		&model.Span{TraceID: 101, SpanID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 26965, Meta: map[string]string{"env": "test"}},
+		&model.Span{TraceID: 101, SpanID: 1012, ParentID: 1011, Service: "x1", Name: "y1", Resource: "z1", Duration: 197884},
+		&model.Span{TraceID: 101, SpanID: 1013, ParentID: 1012, Service: "x1", Name: "y1", Resource: "z1", Duration: 12304982304},
+		&model.Span{TraceID: 101, SpanID: 1014, ParentID: 1013, Service: "x2", Name: "y2", Resource: "z2", Duration: 34384993},
 	}
 	t2 := model.Trace{
-		model.Span{TraceID: 110, SpanID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312, Meta: map[string]string{"env": "prod"}},
-		model.Span{TraceID: 110, SpanID: 1102, ParentID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 34347},
-		model.Span{TraceID: 110, SpanID: 1103, ParentID: 1101, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
+		&model.Span{TraceID: 110, SpanID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 992312, Meta: map[string]string{"env": "prod"}},
+		&model.Span{TraceID: 110, SpanID: 1102, ParentID: 1101, Service: "x1", Name: "y1", Resource: "z1", Duration: 34347},
+		&model.Span{TraceID: 110, SpanID: 1103, ParentID: 1101, Service: "x2", Name: "y2", Resource: "z2", Duration: 349944},
 	}
 
 	assert.NotEqual(testComputeServiceSignature(t1), testComputeServiceSignature(t2))


### PR DESCRIPTION
Another step before the global introduction of protobuf.

By using references it will simplify the code migration (as generated protobuf structs also include themselves by reference).

That should also avoid various struct copies.

Notes:

- for `model/trace_gen.go`, I simply ran `msgp -file=model/trace.go -marshal=false`. That should be enough as `trace_gen.go` isn't a file we manually modified. I also checked to simply regenerate the file without the `Trace` change and I got exactly the same file as before so the generation method is good. 
- `Quantize` is now in-place.
- The PR is based on the protobuf PR ; I'll merge them together once I've tested them enough.