### PR TITLE
Always drain requests before responding

### DIFF
--- a/agent/receiver.go
+++ b/agent/receiver.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"sort"
@@ -195,6 +196,7 @@ func (r *HTTPReceiver) replyTraces(v APIVersion, w http.ResponseWriter) {
 // handleTraces knows how to handle a bunch of traces
 func (r *HTTPReceiver) handleTraces(v APIVersion, w http.ResponseWriter, req *http.Request) {
 	if !r.preSampler.Sample(req) {
+		io.Copy(ioutil.Discard, req.Body)
 		HTTPOK(w)
 		return
 	}

--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/sampler"
 	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
 )
@@ -523,6 +527,69 @@ func TestHandleTraces(t *testing.T) {
 	}
 	// make sure we have all our languages registered
 	assert.Equal("C#|go|java|python|ruby", receiver.Languages())
+}
+
+// chunkedReader is a reader which forces partial reads, this is required
+// to trigger some network related bugs, such as body not being read fully by server.
+// Without this, all the data could be read/written at once, not triggering the issue.
+type chunkedReader struct {
+	reader io.Reader
+}
+
+func (sr *chunkedReader) Read(p []byte) (n int, err error) {
+	size := 1024
+	if size > len(p) {
+		size = len(p)
+	}
+	buf := p[0:size]
+	return sr.reader.Read(buf)
+}
+
+func TestReceiverPreSamplerCancel(t *testing.T) {
+	assert := assert.New(t)
+
+	var wg sync.WaitGroup
+	var buf bytes.Buffer
+
+	n := 100 // Payloads need to be big enough, else bug is not triggered
+	msgp.Encode(&buf, fixtures.GetTestTrace(n, n))
+
+	conf := config.NewDefaultAgentConfig()
+	conf.APIKey = "test"
+	conf.PreSampleRate = 0.000001 // Make sure we sample aggressively
+	dynConf := config.NewDynamicConfig()
+
+	receiver := NewHTTPReceiver(conf, dynConf)
+	server := httptest.NewServer(http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces)))
+
+	defer server.Close()
+	url := server.URL + "/v0.4/traces"
+
+	// Make sure we use share clients, and they are reused.
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConnsPerHost: 100,
+	}}
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			for j := 0; j < 3; j++ {
+				reader := &chunkedReader{reader: bytes.NewReader(buf.Bytes())}
+				req, err := http.NewRequest("POST", url, reader)
+				req.Header.Set("Content-Type", "application/msgpack")
+				req.Header.Set(sampler.TraceCountHeader, strconv.Itoa(n))
+				assert.Nil(err)
+
+				resp, err := client.Do(req)
+				assert.Nil(err)
+				assert.NotNil(resp)
+				if resp != nil {
+					assert.Equal(http.StatusOK, resp.StatusCode)
+				}
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
 }
 
 func BenchmarkHandleTracesFromOneApp(b *testing.B) {

--- a/agent/receiver_test.go
+++ b/agent/receiver_test.go
@@ -160,15 +160,15 @@ func TestReceiverJSONDecoder(t *testing.T) {
 		contentType string
 		traces      []model.Trace
 	}{
-		{"v02 with empty content-type", NewHTTPReceiver(conf, dynConf), v02, "", fixtures.GetTestTrace(1, 1)},
-		{"v03 with empty content-type", NewHTTPReceiver(conf, dynConf), v03, "", fixtures.GetTestTrace(1, 1)},
-		{"v04 with empty content-type", NewHTTPReceiver(conf, dynConf), v04, "", fixtures.GetTestTrace(1, 1)},
-		{"v02 with application/json", NewHTTPReceiver(conf, dynConf), v02, "application/json", fixtures.GetTestTrace(1, 1)},
-		{"v03 with application/json", NewHTTPReceiver(conf, dynConf), v03, "application/json", fixtures.GetTestTrace(1, 1)},
-		{"v04 with application/json", NewHTTPReceiver(conf, dynConf), v04, "application/json", fixtures.GetTestTrace(1, 1)},
-		{"v02 with text/json", NewHTTPReceiver(conf, dynConf), v02, "text/json", fixtures.GetTestTrace(1, 1)},
-		{"v03 with text/json", NewHTTPReceiver(conf, dynConf), v03, "text/json", fixtures.GetTestTrace(1, 1)},
-		{"v04 with text/json", NewHTTPReceiver(conf, dynConf), v04, "text/json", fixtures.GetTestTrace(1, 1)},
+		{"v02 with empty content-type", NewHTTPReceiver(conf, dynConf), v02, "", fixtures.GetTestTrace(1, 1, false)},
+		{"v03 with empty content-type", NewHTTPReceiver(conf, dynConf), v03, "", fixtures.GetTestTrace(1, 1, false)},
+		{"v04 with empty content-type", NewHTTPReceiver(conf, dynConf), v04, "", fixtures.GetTestTrace(1, 1, false)},
+		{"v02 with application/json", NewHTTPReceiver(conf, dynConf), v02, "application/json", fixtures.GetTestTrace(1, 1, false)},
+		{"v03 with application/json", NewHTTPReceiver(conf, dynConf), v03, "application/json", fixtures.GetTestTrace(1, 1, false)},
+		{"v04 with application/json", NewHTTPReceiver(conf, dynConf), v04, "application/json", fixtures.GetTestTrace(1, 1, false)},
+		{"v02 with text/json", NewHTTPReceiver(conf, dynConf), v02, "text/json", fixtures.GetTestTrace(1, 1, false)},
+		{"v03 with text/json", NewHTTPReceiver(conf, dynConf), v03, "text/json", fixtures.GetTestTrace(1, 1, false)},
+		{"v04 with text/json", NewHTTPReceiver(conf, dynConf), v04, "text/json", fixtures.GetTestTrace(1, 1, false)},
 	}
 
 	for _, tc := range testCases {
@@ -225,10 +225,10 @@ func TestReceiverMsgpackDecoder(t *testing.T) {
 		contentType string
 		traces      model.Traces
 	}{
-		{"v01 with application/msgpack", NewHTTPReceiver(conf, dynConf), v01, "application/msgpack", fixtures.GetTestTrace(1, 1)},
-		{"v02 with application/msgpack", NewHTTPReceiver(conf, dynConf), v02, "application/msgpack", fixtures.GetTestTrace(1, 1)},
-		{"v03 with application/msgpack", NewHTTPReceiver(conf, dynConf), v03, "application/msgpack", fixtures.GetTestTrace(1, 1)},
-		{"v04 with application/msgpack", NewHTTPReceiver(conf, dynConf), v04, "application/msgpack", fixtures.GetTestTrace(1, 1)},
+		{"v01 with application/msgpack", NewHTTPReceiver(conf, dynConf), v01, "application/msgpack", fixtures.GetTestTrace(1, 1, false)},
+		{"v02 with application/msgpack", NewHTTPReceiver(conf, dynConf), v02, "application/msgpack", fixtures.GetTestTrace(1, 1, false)},
+		{"v03 with application/msgpack", NewHTTPReceiver(conf, dynConf), v03, "application/msgpack", fixtures.GetTestTrace(1, 1, false)},
+		{"v04 with application/msgpack", NewHTTPReceiver(conf, dynConf), v04, "application/msgpack", fixtures.GetTestTrace(1, 1, false)},
 	}
 
 	for _, tc := range testCases {
@@ -486,7 +486,7 @@ func TestHandleTraces(t *testing.T) {
 
 	// prepare the msgpack payload
 	var buf bytes.Buffer
-	msgp.Encode(&buf, fixtures.GetTestTrace(10, 10))
+	msgp.Encode(&buf, fixtures.GetTestTrace(10, 10, true))
 
 	// prepare the receiver
 	conf := config.NewDefaultAgentConfig()
@@ -523,7 +523,7 @@ func TestHandleTraces(t *testing.T) {
 		ts, ok := rs.Stats[info.Tags{Lang: lang}]
 		assert.True(ok)
 		assert.Equal(int64(20), ts.TracesReceived)
-		assert.Equal(int64(57622), ts.TracesBytes)
+		assert.Equal(int64(59222), ts.TracesBytes)
 	}
 	// make sure we have all our languages registered
 	assert.Equal("C#|go|java|python|ruby", receiver.Languages())
@@ -552,7 +552,7 @@ func TestReceiverPreSamplerCancel(t *testing.T) {
 	var buf bytes.Buffer
 
 	n := 100 // Payloads need to be big enough, else bug is not triggered
-	msgp.Encode(&buf, fixtures.GetTestTrace(n, n))
+	msgp.Encode(&buf, fixtures.GetTestTrace(n, n, true))
 
 	conf := config.NewDefaultAgentConfig()
 	conf.APIKey = "test"
@@ -596,7 +596,7 @@ func BenchmarkHandleTracesFromOneApp(b *testing.B) {
 	// prepare the payload
 	// msgpack payload
 	var buf bytes.Buffer
-	msgp.Encode(&buf, fixtures.GetTestTrace(1, 1))
+	msgp.Encode(&buf, fixtures.GetTestTrace(1, 1, true))
 
 	// prepare the receiver
 	conf := config.NewDefaultAgentConfig()
@@ -638,7 +638,7 @@ func BenchmarkHandleTracesFromMultipleApps(b *testing.B) {
 	// prepare the payload
 	// msgpack payload
 	var buf bytes.Buffer
-	msgp.Encode(&buf, fixtures.GetTestTrace(1, 1))
+	msgp.Encode(&buf, fixtures.GetTestTrace(1, 1, true))
 
 	// prepare the receiver
 	conf := config.NewDefaultAgentConfig()
@@ -678,7 +678,7 @@ func BenchmarkHandleTracesFromMultipleApps(b *testing.B) {
 
 func BenchmarkDecoderJSON(b *testing.B) {
 	assert := assert.New(b)
-	traces := fixtures.GetTestTrace(150, 66)
+	traces := fixtures.GetTestTrace(150, 66, true)
 
 	// json payload
 	payload, err := json.Marshal(traces)
@@ -703,7 +703,7 @@ func BenchmarkDecoderMsgpack(b *testing.B) {
 
 	// msgpack payload
 	var buf bytes.Buffer
-	err := msgp.Encode(&buf, fixtures.GetTestTrace(150, 66))
+	err := msgp.Encode(&buf, fixtures.GetTestTrace(150, 66, true))
 	assert.Nil(err)
 
 	// benchmark

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -83,7 +83,7 @@ func RandomTrace(maxLevels, maxSpans int) model.Trace {
 
 // GetTestTrace returns a []Trace that is composed by ``traceN`` number
 // of traces, each one composed by ``size`` number of spans.
-func GetTestTrace(traceN, size int) model.Traces {
+func GetTestTrace(traceN, size int, realisticIDs bool) model.Traces {
 	traces := model.Traces{}
 
 	r := rand.New(rand.NewSource(42))
@@ -97,11 +97,13 @@ func GetTestTrace(traceN, size int) model.Traces {
 		trace := model.Trace{}
 		for j := 0; j < size; j++ {
 			span := GetTestSpan()
-			// Need to have different span IDs else traces are rejected
-			// because they are not correct (indeed, a trace with several
-			// spans boasting the same span ID is not valid)
-			span.SpanID += uint64(j)
-			span.TraceID = traceID
+			if realisticIDs {
+				// Need to have different span IDs else traces are rejected
+				// because they are not correct (indeed, a trace with several
+				// spans boasting the same span ID is not valid)
+				span.SpanID += uint64(j)
+				span.TraceID = traceID
+			}
 			trace = append(trace, span)
 		}
 		traces = append(traces, trace)

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -86,10 +86,23 @@ func RandomTrace(maxLevels, maxSpans int) model.Trace {
 func GetTestTrace(traceN, size int) model.Traces {
 	traces := model.Traces{}
 
+	r := rand.New(rand.NewSource(42))
+
 	for i := 0; i < traceN; i++ {
+		// Calculate a trace ID which is predictable (this is why we seed)
+		// but still spreads on a wide spectrum so that, among other things,
+		// sampling algorithms work in a realistic way.
+		traceID := r.Uint64()
+
 		trace := model.Trace{}
 		for j := 0; j < size; j++ {
-			trace = append(trace, GetTestSpan())
+			span := GetTestSpan()
+			// Need to have different span IDs else traces are rejected
+			// because they are not correct (indeed, a trace with several
+			// spans boasting the same span ID is not valid)
+			span.SpanID += uint64(j)
+			span.TraceID = traceID
+			trace = append(trace, span)
 		}
 		traces = append(traces, trace)
 	}


### PR DESCRIPTION
This PR targets a bug we've observed where sometimes the agent will send a HTTP 200 response before all the request's body has been received, which leads to the connection being reset and dropping traces.