### PR TITLE
Add missing packages from linting/testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,12 +55,14 @@ PACKAGES = %w(
   ./config
   ./filters
   ./fixtures
+  ./info
   ./model
   ./quantile
   ./quantizer
   ./sampler
   ./statsd
   ./watchdog
+  ./writer
 )
 
 EXCLUDE_LINT = [

--- a/info/info.go
+++ b/info/info.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	infoMu              sync.RWMutex
-	receiverStats       []tagStats    // only for the last minute
+	receiverStats       []TagStats    // only for the last minute
 	endpointStats       EndpointStats // only for the last minute
 	watchdogInfo        watchdog.Info
 	samplerInfo         SamplerInfo
@@ -91,13 +91,14 @@ const (
 `
 )
 
+// UpdateReceiverStats updates internal stats about the receiver
 func UpdateReceiverStats(rs *ReceiverStats) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
 	rs.RLock()
 	defer rs.RUnlock()
 
-	s := make([]tagStats, 0, len(rs.Stats))
+	s := make([]TagStats, 0, len(rs.Stats))
 	for _, tagStats := range rs.Stats {
 		if !tagStats.isEmpty() {
 			s = append(s, *tagStats)
@@ -113,6 +114,7 @@ func publishReceiverStats() interface{} {
 	return receiverStats
 }
 
+// UpdateEndpointStats updates internal stats about API endpoints
 func UpdateEndpointStats(es EndpointStats) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -125,6 +127,7 @@ func publishEndpointStats() interface{} {
 	return endpointStats
 }
 
+// UpdateSamplerInfo updates internal stats about signature sampling
 func UpdateSamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -138,6 +141,7 @@ func publishSamplerInfo() interface{} {
 	return samplerInfo
 }
 
+// UpdatePrioritySamplerInfo updates internal stats about priority sampking
 func UpdatePrioritySamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -151,6 +155,7 @@ func publishPrioritySamplerInfo() interface{} {
 	return prioritySamplerInfo
 }
 
+// UpdateRateByService updates the RateByService map
 func UpdateRateByService(rbs map[string]float64) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -163,6 +168,7 @@ func publishRateByService() interface{} {
 	return rateByService
 }
 
+// UpdateWatchdogInfo updates internal stats about the watchdog
 func UpdateWatchdogInfo(wi watchdog.Info) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -175,6 +181,7 @@ func publishWatchdogInfo() interface{} {
 	return watchdogInfo
 }
 
+// UpdatePreSampler updates internal stats about the pre-sampling
 func UpdatePreSampler(ss sampler.PreSamplerStats) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -265,7 +272,7 @@ type StatusInfo struct {
 		Alloc uint64
 	} `json:"memstats"`
 	Version       infoVersion             `json:"version"`
-	Receiver      []tagStats              `json:"receiver"`
+	Receiver      []TagStats              `json:"receiver"`
 	RateByService map[string]float64      `json:"ratebyservice"`
 	Endpoint      EndpointStats           `json:"endpoint"`
 	Watchdog      watchdog.Info           `json:"watchdog"`

--- a/info/info_test.go
+++ b/info/info_test.go
@@ -339,15 +339,15 @@ func TestInfoReceiverStats(t *testing.T) {
 	assert.NotNil(conf)
 
 	stats := NewReceiverStats()
-	t1 := &tagStats{
+	t1 := &TagStats{
 		Tags{Lang: "python"},
 		Stats{TracesReceived: 23, TracesDropped: 2, TracesBytes: 3244, SpansReceived: 213, SpansDropped: 14},
 	}
-	t2 := &tagStats{
+	t2 := &TagStats{
 		Tags{Lang: "go"},
 		Stats{ServicesReceived: 4, ServicesBytes: 1543},
 	}
-	stats.Stats = map[Tags]*tagStats{
+	stats.Stats = map[Tags]*TagStats{
 		t1.Tags: t1,
 		t2.Tags: t2,
 	}
@@ -375,7 +375,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	}
 	s := publishReceiverStats()
 	switch s := s.(type) {
-	case []tagStats:
+	case []TagStats:
 		for _, tagStats := range s {
 			assert.Equal(*stats.Stats[tagStats.Tags], tagStats)
 		}
@@ -386,7 +386,7 @@ func TestInfoReceiverStats(t *testing.T) {
 	UpdateReceiverStats(stats)
 	s = publishReceiverStats()
 	switch s := s.(type) {
-	case []tagStats:
+	case []TagStats:
 		for _, tagStats := range s {
 			if tagStats.Tags == t1.Tags {
 				assert.Equal(t1.Stats.TracesReceived, tagStats.Stats.TracesReceived)

--- a/info/sampler.go
+++ b/info/sampler.go
@@ -2,6 +2,7 @@ package info
 
 import "github.com/DataDog/datadog-trace-agent/sampler"
 
+// SamplerInfo represents internal stats and state of a sampler
 type SamplerInfo struct {
 	// EngineType contains the type of the engine (tells old sampler and new distributed sampler apart)
 	EngineType string
@@ -11,7 +12,7 @@ type SamplerInfo struct {
 	State sampler.InternalState
 }
 
-// samplerStats contains sampler statistics
+// SamplerStats contains sampler statistics
 type SamplerStats struct {
 	// KeptTPS is the number of traces kept (average per second for last flush)
 	KeptTPS float64

--- a/info/stats.go
+++ b/info/stats.go
@@ -11,15 +11,16 @@ import (
 // ReceiverStats is used to store all the stats per tags.
 type ReceiverStats struct {
 	sync.RWMutex
-	Stats map[Tags]*tagStats
+	Stats map[Tags]*TagStats
 }
 
+// NewReceiverStats returns a new ReceiverStats
 func NewReceiverStats() *ReceiverStats {
-	return &ReceiverStats{sync.RWMutex{}, map[Tags]*tagStats{}}
+	return &ReceiverStats{sync.RWMutex{}, map[Tags]*TagStats{}}
 }
 
 // GetTagStats returns the struct in which the stats will be stored depending of their tags.
-func (rs *ReceiverStats) GetTagStats(tags Tags) *tagStats {
+func (rs *ReceiverStats) GetTagStats(tags Tags) *TagStats {
 	rs.Lock()
 	tagStats, ok := rs.Stats[tags]
 	if !ok {
@@ -41,6 +42,7 @@ func (rs *ReceiverStats) Acc(recent *ReceiverStats) {
 	recent.Unlock()
 }
 
+// Publish updates stats about per-tag stats
 func (rs *ReceiverStats) Publish() {
 	rs.RLock()
 	for _, tagStats := range rs.Stats {
@@ -49,6 +51,7 @@ func (rs *ReceiverStats) Publish() {
 	rs.RUnlock()
 }
 
+// Reset resets the ReceiverStats internal data
 func (rs *ReceiverStats) Reset() {
 	rs.Lock()
 	for key, tagStats := range rs.Stats {
@@ -81,17 +84,17 @@ func (rs *ReceiverStats) Strings() []string {
 	return strings
 }
 
-// tagStats is the struct used to associate the stats with their set of tags.
-type tagStats struct {
+// TagStats is the struct used to associate the stats with their set of tags.
+type TagStats struct {
 	Tags
 	Stats
 }
 
-func newTagStats(tags Tags) *tagStats {
-	return &tagStats{tags, Stats{}}
+func newTagStats(tags Tags) *TagStats {
+	return &TagStats{tags, Stats{}}
 }
 
-func (ts *tagStats) publish() {
+func (ts *TagStats) publish() {
 	// Atomically load the stats from ts
 	tracesReceived := atomic.LoadInt64(&ts.TracesReceived)
 	tracesDropped := atomic.LoadInt64(&ts.TracesDropped)

--- a/info/version.go
+++ b/info/version.go
@@ -14,7 +14,7 @@ var (
 	GoVersion string
 )
 
-// versionString returns the version information filled in at build time
+// VersionString returns the version information filled in at build time
 func VersionString() string {
 	var buf bytes.Buffer
 


### PR DESCRIPTION
Lint `info` and `writer` packages, which were missing as the Rakefile wasn't processing them since the last code reorganization.