### PR TITLE
Async flushing of writer payloads with jittery exponential retrying

### DIFF
--- a/backoff/backoff.go
+++ b/backoff/backoff.go
@@ -1,0 +1,84 @@
+package backoff
+
+import "time"
+
+// Timer represents a timer that implements some backOff strategy that can adapt to number of schedulings.
+type Timer interface {
+	ScheduleRetry(err error) (int, time.Duration)
+	CurrentDelay() time.Duration
+	NumRetries() int
+	ReceiveTick() <-chan time.Time
+	Reset()
+	Stop()
+}
+
+// DelayProvider is a function that takes the current numRetries and last error and returns the delay until next retry.
+type DelayProvider func(numRetries int, err error) time.Duration
+
+// CustomTimer represents a backoff timer configured with a certain DelayProvider.
+type CustomTimer struct {
+	numRetries   int
+	currentDelay time.Duration
+
+	delayProvider DelayProvider
+
+	tickChannel chan time.Time
+	timer       *time.Timer
+}
+
+// NewCustomTimer creates a new custom timer using the provided delay provider.
+func NewCustomTimer(delayProvider DelayProvider) *CustomTimer {
+	return &CustomTimer{
+		delayProvider: delayProvider,
+		tickChannel:   make(chan time.Time),
+	}
+}
+
+// ScheduleRetry schedules the next retry tick according to the delay provider, returning retry num and retry delay.
+func (t *CustomTimer) ScheduleRetry(err error) (int, time.Duration) {
+	t.Stop()
+	t.currentDelay = t.delayProvider(t.numRetries, err)
+
+	t.timer = time.AfterFunc(t.currentDelay, func() {
+		t.tickChannel <- time.Now()
+	})
+
+	t.numRetries++
+
+	return t.numRetries, t.currentDelay
+}
+
+// CurrentDelay returns the delay of the current or last ticked retry.
+func (t *CustomTimer) CurrentDelay() time.Duration {
+	return t.currentDelay
+}
+
+// NumRetries returns the number of tries since this timer was last reset.
+func (t *CustomTimer) NumRetries() int {
+	return t.numRetries
+}
+
+// ReceiveTick returns a channel that will receive a time.Time object as soon as the previously scheduled retry ticks.
+func (t *CustomTimer) ReceiveTick() <-chan time.Time {
+	return t.tickChannel
+}
+
+// Reset stops and resets the number of retries counter of this timer.
+func (t *CustomTimer) Reset() {
+	t.Stop()
+	t.numRetries = 0
+	t.currentDelay = 0
+}
+
+// Stop prevents any current scheduled retry from ticking.
+func (t *CustomTimer) Stop() {
+	if t.timer != nil {
+		t.timer.Stop()
+	}
+}
+
+// Close cleans up the resources used by this timer. It cannot be reused after this call.
+func (t *CustomTimer) Close() {
+	t.Reset()
+	close(t.tickChannel)
+}

--- a/backoff/backoff_test.go
+++ b/backoff/backoff_test.go
@@ -1,0 +1,117 @@
+package backoff
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SpecialError struct{}
+
+func (*SpecialError) Error() string {
+	return "this is a very special error"
+}
+
+func TestCustomTimer_ScheduleRetry(t *testing.T) {
+	assert := assert.New(t)
+
+	testDelay := 200 * time.Millisecond
+
+	timer := NewCustomTimer(func(numRetries int, err error) time.Duration {
+		if _, ok := err.(*SpecialError); ok {
+			// If special error use fixed delay of 100 ms
+			return 100 * time.Millisecond
+		}
+
+		// If normal error (or nil)
+		return time.Duration(int64(1+numRetries) * int64(testDelay))
+	})
+
+	// First schedule (numRetries == 0)
+	callTime := time.Now()
+	timer.ScheduleRetry(nil)
+	assert.Equal(testDelay, timer.CurrentDelay(), "Timer should report correct retry delay")
+
+	select {
+	case tickTime := <-timer.ReceiveTick():
+		assert.WithinDuration(tickTime, callTime, time.Duration(1.5*float64(testDelay)),
+			"Tick time and call time should be within expected delay of each other (with a small margin)")
+	case <-time.After(1 * time.Second):
+		assert.Fail("Received no tick within 500ms")
+	}
+
+	// Second schedule (numRetries == 1)
+	callTime = time.Now()
+	timer.ScheduleRetry(nil)
+	assert.Equal(time.Duration(2*testDelay), timer.CurrentDelay(), "Timer should report correct retry delay")
+
+	select {
+	case tickTime := <-timer.ReceiveTick():
+		assert.WithinDuration(tickTime, callTime, time.Duration(2.5*float64(testDelay)),
+			"Tick time and call time should be within expected delay of each other (with a small margin)")
+	case <-time.After(1 * time.Second):
+		assert.Fail("Received no tick within 500ms")
+	}
+
+	// Third schedule (numRetries == 2 but error is SpecialError)
+	callTime = time.Now()
+	timer.ScheduleRetry(&SpecialError{})
+	assert.Equal(100*time.Millisecond, timer.CurrentDelay(), "Timer should report correct retry delay")
+
+	select {
+	case tickTime := <-timer.ReceiveTick():
+		assert.WithinDuration(tickTime, callTime, time.Duration(200*time.Millisecond),
+			"Tick time and call time should be within expected delay of each other (with a small margin)")
+	case <-time.After(1 * time.Second):
+		assert.Fail("Received no tick within 500ms")
+	}
+
+	timer.Close()
+}
+
+func TestCustomTimer_StopNotTicked(t *testing.T) {
+	assert := assert.New(t)
+
+	testDelay := 100 * time.Millisecond
+
+	timer := NewCustomTimer(func(_ int, _ error) time.Duration { return testDelay })
+
+	timer.ScheduleRetry(nil)
+	timer.Stop()
+
+	select {
+	case <-timer.ReceiveTick():
+		assert.Fail("Shouldn't have received tick because timer was stopped")
+	case <-time.After(2 * testDelay):
+		assert.True(true, "Should end without receiving anything")
+	}
+
+	assert.Equal(1, timer.NumRetries(), "Stopping the timer should not have reset it")
+	assert.Equal(testDelay, timer.CurrentDelay(), "Stopping the timer should not have reset it")
+
+	timer.Close()
+}
+
+func TestCustomTimer_Reset(t *testing.T) {
+	assert := assert.New(t)
+
+	testDelay := 100 * time.Millisecond
+
+	timer := NewCustomTimer(func(_ int, _ error) time.Duration { return testDelay })
+
+	timer.ScheduleRetry(nil)
+	timer.Reset()
+
+	select {
+	case <-timer.ReceiveTick():
+		assert.Fail("Shouldn't have received tick because resetting a timer should also stop it")
+	case <-time.After(2 * testDelay):
+		assert.True(true, "Should end without receiving anything")
+	}
+
+	assert.Equal(0, timer.NumRetries(), "Timer should have been reset")
+	assert.Equal(0*time.Millisecond, timer.CurrentDelay(), "Timer should have been reset")
+
+	timer.Close()
+}

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -1,0 +1,62 @@
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// ExponentialConfig holds the parameters used by the ExponentialTimer.
+type ExponentialConfig struct {
+	MaxDuration time.Duration
+	GrowthBase  int
+	Base        time.Duration
+	Random      *rand.Rand
+}
+
+// DefaultExponentialConfig creates an ExponentialConfig with default values.
+func DefaultExponentialConfig() ExponentialConfig {
+	return ExponentialConfig{
+		MaxDuration: 120 * time.Second,
+		GrowthBase:  2,
+		Base:        time.Second,
+		Random:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// DefaultExponentialDelayProvider creates a new instance of an ExponentialDelayProvider using the default config.
+func DefaultExponentialDelayProvider() DelayProvider {
+	return ExponentialDelayProvider(DefaultExponentialConfig())
+}
+
+// ExponentialDelayProvider creates a new instance of an ExponentialDelayProvider using the provided config.
+func ExponentialDelayProvider(conf ExponentialConfig) DelayProvider {
+	return func(numRetries int, _ error) time.Duration {
+		newExpDuration := time.Duration(int64(math.Pow(float64(conf.GrowthBase), float64(numRetries))) *
+			int64(conf.Base))
+
+		if newExpDuration > conf.MaxDuration {
+			newExpDuration = conf.MaxDuration
+		}
+
+		return time.Duration(conf.Random.Int63n(int64(newExpDuration)))
+	}
+}
+
+// ExponentialTimer performs an exponential backoff following the FullJitter implementation described in
+// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+type ExponentialTimer struct {
+	CustomTimer
+}
+
+// NewExponentialTimer creates an exponential backoff timer using the default configuration.
+func NewExponentialTimer() *ExponentialTimer {
+	return NewCustomExponentialTimer(DefaultExponentialConfig())
+}
+
+// NewCustomExponentialTimer creates an exponential backoff timer using the provided configuration.
+func NewCustomExponentialTimer(conf ExponentialConfig) *ExponentialTimer {
+	return &ExponentialTimer{
+		CustomTimer: *NewCustomTimer(ExponentialDelayProvider(conf)),
+	}
+}

--- a/backoff/exponential_test.go
+++ b/backoff/exponential_test.go
@@ -1,0 +1,80 @@
+package backoff
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errBogus = fmt.Errorf("bogus error")
+
+func TestDefaultRandomSeed(t *testing.T) {
+	assert := assert.New(t)
+
+	delayProvider1 := DefaultExponentialDelayProvider()
+	delayProvider2 := DefaultExponentialDelayProvider()
+
+	// Ensure different timers are not synchronized in their backoffing (use different seeds)
+	assert.NotEqual(delayProvider1(0, nil), delayProvider2(0, nil))
+}
+
+func TestExponentialDelay(t *testing.T) {
+	assert := assert.New(t)
+
+	conf := ExponentialConfig{
+		// Use nanoseconds to reduce universe from which randoms are chosen. Seconds should be the same, just scaled.
+		MaxDuration: 120 * time.Nanosecond,
+		GrowthBase:  2,
+		Base:        time.Nanosecond,
+		// Use fixed random to prevent flakiness in case the CI has very bad luck
+		Random: rand.New(rand.NewSource(1234)),
+	}
+
+	delayProvider := ExponentialDelayProvider(conf)
+
+	prevMax := int64(0)
+
+	// Try successive calls to delayProvider with increasing numRetries (from 0 to 19).
+	for i := 0; i < 20; i++ {
+		expectedMax := int64(math.Pow(2, float64(i)))
+
+		if expectedMax > int64(conf.MaxDuration) {
+			expectedMax = int64(conf.MaxDuration)
+		}
+
+		// For each value of numRetries, get min and max value we saw over 500 calls
+		min, max := minMaxForSample(delayProvider, 500, i)
+
+		assert.True(max <= expectedMax, "Max should be lower or equal to expected max. Max: %d, expected: %d", max,
+			expectedMax)
+		assert.True(max >= prevMax, "Max should grow because this is exp. backoff. Current: %d, prev: %d",
+			max, prevMax)
+		assert.True(min <= max/2, "Minimum should be 'far' from max since this should be jittery. Min: %d, max: %d",
+			min, max)
+
+		prevMax = max
+	}
+}
+
+func minMaxForSample(delayProvider DelayProvider, n int, numTries int) (min, max int64) {
+	max = 0
+	min = math.MaxInt64
+
+	for i := 0; i < n; i++ {
+		delay := int64(delayProvider(numTries, nil))
+
+		if delay > max {
+			max = delay
+		}
+
+		if delay < min {
+			min = delay
+		}
+	}
+
+	return
+}

--- a/backoff/exponential_test.go
+++ b/backoff/exponential_test.go
@@ -60,6 +60,19 @@ func TestExponentialDelay(t *testing.T) {
 	}
 }
 
+func TestExponentialOverflow(t *testing.T) {
+	assert := assert.New(t)
+
+	delayProvider := DefaultExponentialDelayProvider()
+
+	assert.NotPanics(func() {
+		min, max := minMaxForSample(delayProvider, 300, 1024)
+
+		assert.True(min >= 0, "Min should be greater or equal to 0")
+		assert.True(max <= int64(DefaultExponentialConfig().MaxDuration), "Min should be greater or equal to 0")
+	})
+}
+
 func minMaxForSample(delayProvider DelayProvider, n int, numTries int) (min, max int64) {
 	max = 0
 	min = math.MaxInt64

--- a/backoff/fixtures.go
+++ b/backoff/fixtures.go
@@ -1,0 +1,59 @@
+package backoff
+
+import "time"
+
+// TestBackoffTimer is a backoff timer that ticks on-demand.
+type TestBackoffTimer struct {
+	tickChannel chan time.Time
+}
+
+// NewTestBackoffTimer creates a new instance of a TestBackoffTimer.
+func NewTestBackoffTimer() *TestBackoffTimer {
+	return &TestBackoffTimer{
+		// tick channel without buffer allows us to sync with the sender during the tests by sending ticks
+		tickChannel: make(chan time.Time),
+	}
+}
+
+// ScheduleRetry on a TestBackoffTimer is a no-op.
+func (t *TestBackoffTimer) ScheduleRetry(err error) (int, time.Duration) {
+	// Do nothing, we'll trigger whenever we want
+	return 0, 0
+}
+
+// CurrentDelay in a TestBackoffTimer always returns 0.
+func (t *TestBackoffTimer) CurrentDelay() time.Duration {
+	// This timer doesn't have delays, it's triggered on-demand
+	return 0
+}
+
+// NumRetries in a TestBackoffTimer always returns 0.
+func (t *TestBackoffTimer) NumRetries() int {
+	// This timer doesn't keep track of num retries
+	return 0
+}
+
+// ReceiveTick returns the channel where ticks are sent.
+func (t *TestBackoffTimer) ReceiveTick() <-chan time.Time {
+	return t.tickChannel
+}
+
+// TriggerTick immediately sends a tick with the current timestamp through the ticking channel.
+func (t *TestBackoffTimer) TriggerTick() {
+	t.tickChannel <- time.Now()
+}
+
+// Reset in a TestBackoffTimer is a no-op.
+func (t *TestBackoffTimer) Reset() {
+	// Nothing to reset
+}
+
+// Stop in a TestBackoffTimer is a no-op.
+func (t *TestBackoffTimer) Stop() {
+	// Nothing to stop
+}
+
+// Close closes the ticking channel of this backoff timer.
+func (t *TestBackoffTimer) Close() {
+	close(t.tickChannel)
+}

--- a/fixtures/random.go
+++ b/fixtures/random.go
@@ -1,0 +1,31 @@
+package fixtures
+
+import (
+	"bytes"
+	"math/rand"
+	"strconv"
+)
+
+// RandomSizedBytes creates a random byte slice with the specified size.
+func RandomSizedBytes(size int) []byte {
+	buffer := bytes.Buffer{}
+
+	for i := 0; i < size; i++ {
+		buffer.WriteByte(byte(rand.Int()))
+	}
+
+	return buffer.Bytes()
+}
+
+// RandomStringMap creates a random map with string keys and values.
+func RandomStringMap() map[string]string {
+	length := rand.Intn(32)
+
+	m := map[string]string{}
+
+	for i := 0; i < length; i++ {
+		m[strconv.Itoa(rand.Int())] = strconv.Itoa(rand.Int())
+	}
+
+	return m
+}

--- a/fixtures/trace.go
+++ b/fixtures/trace.go
@@ -69,7 +69,7 @@ func RandomTrace(maxLevels, maxSpans int) model.Trace {
 	t := model.Trace{RandomSpan()}
 
 	prevLevel := t
-	maxDepth := rand.Intn(maxLevels)
+	maxDepth := 1 + rand.Intn(maxLevels)
 
 	for i := 0; i < maxDepth; i++ {
 		if len(prevLevel) > 0 {

--- a/info/writer.go
+++ b/info/writer.go
@@ -4,7 +4,9 @@ package info
 type TraceWriterInfo struct {
 	Payloads int64
 	Traces   int64
+	Spans    int64
 	Errors   int64
+	Retries  int64
 	Bytes    int64
 }
 
@@ -13,6 +15,7 @@ type ServiceWriterInfo struct {
 	Payloads int64
 	Services int64
 	Errors   int64
+	Retries  int64
 	Bytes    int64
 }
 
@@ -21,6 +24,7 @@ type StatsWriterInfo struct {
 	Payloads     int64
 	StatsBuckets int64
 	Errors       int64
+	Retries      int64
 	Bytes        int64
 }
 

--- a/statsd/fixtures.go
+++ b/statsd/fixtures.go
@@ -1,0 +1,125 @@
+package statsd
+
+import (
+	"math"
+	"sync"
+)
+
+// StatsClientGaugeArgs represents arguments to a StatsClient Gauge method call.
+type StatsClientGaugeArgs struct {
+	Name  string
+	Value float64
+	Tags  []string
+	Rate  float64
+}
+
+// StatsClientCountArgs represents arguments to a StatsClient Count method call.
+type StatsClientCountArgs struct {
+	Name  string
+	Value int64
+	Tags  []string
+	Rate  float64
+}
+
+// StatsClientHistogramArgs represents arguments to a StatsClient Histogram method call.
+type StatsClientHistogramArgs struct {
+	Name  string
+	Value float64
+	Tags  []string
+	Rate  float64
+}
+
+// CountSummary contains a summary of all Count method calls to a particular StatsClient for a particular key.
+type CountSummary struct {
+	Calls []StatsClientCountArgs
+	Sum   int64
+}
+
+// GaugeSummary contains a summary of all Gauge method calls to a particular StatsClient for a particular key.
+type GaugeSummary struct {
+	Calls []StatsClientGaugeArgs
+	Last  float64
+	Max   float64
+}
+
+// TestStatsClient is a mocked StatsClient that records all calls and replies with configurable error return values.
+type TestStatsClient struct {
+	GaugeErr       error
+	GaugeCalls     []StatsClientGaugeArgs
+	gaugeLock      sync.Mutex
+	CountErr       error
+	CountCalls     []StatsClientCountArgs
+	countLock      sync.Mutex
+	HistogramErr   error
+	HistogramCalls []StatsClientHistogramArgs
+	histogramLock  sync.Mutex
+}
+
+// Gauge records a call to a Gauge operation and replies with GaugeErr
+func (c *TestStatsClient) Gauge(name string, value float64, tags []string, rate float64) error {
+	c.gaugeLock.Lock()
+	defer c.gaugeLock.Unlock()
+	c.GaugeCalls = append(c.GaugeCalls, StatsClientGaugeArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	return c.GaugeErr
+}
+
+// Count records a call to a Count operation and replies with CountErr
+func (c *TestStatsClient) Count(name string, value int64, tags []string, rate float64) error {
+	c.countLock.Lock()
+	defer c.countLock.Unlock()
+	c.CountCalls = append(c.CountCalls, StatsClientCountArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	return c.CountErr
+}
+
+// Histogram records a call to a Histogram operation and replies with HistogramErr
+func (c *TestStatsClient) Histogram(name string, value float64, tags []string, rate float64) error {
+	c.histogramLock.Lock()
+	defer c.histogramLock.Unlock()
+	c.HistogramCalls = append(c.HistogramCalls, StatsClientHistogramArgs{Name: name, Value: value, Tags: tags, Rate: rate})
+	return c.HistogramErr
+}
+
+// GetCountSummaries computes summaries for all names supplied as parameters to Count calls.
+func (c *TestStatsClient) GetCountSummaries() map[string]*CountSummary {
+	result := map[string]*CountSummary{}
+
+	for _, countCall := range c.CountCalls {
+		name := countCall.Name
+		summary, ok := result[name]
+
+		if !ok {
+			summary = &CountSummary{}
+			result[name] = summary
+		}
+
+		summary.Calls = append(summary.Calls, countCall)
+		summary.Sum += countCall.Value
+	}
+
+	return result
+}
+
+// GetGaugeSummaries computes summaries for all names supplied as parameters to Gauge calls.
+func (c *TestStatsClient) GetGaugeSummaries() map[string]*GaugeSummary {
+	result := map[string]*GaugeSummary{}
+
+	for _, gaugeCall := range c.GaugeCalls {
+		name := gaugeCall.Name
+		summary, ok := result[name]
+
+		if !ok {
+			summary = &GaugeSummary{}
+			summary.Max = math.MinInt64
+			result[name] = summary
+		}
+
+		summary.Calls = append(summary.Calls, gaugeCall)
+		summary.Last = gaugeCall.Value
+
+		if gaugeCall.Value > summary.Max {
+			summary.Max = gaugeCall.Value
+		}
+	}
+
+	return result
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -7,9 +7,16 @@ import (
 	"github.com/DataDog/datadog-trace-agent/config"
 )
 
+// StatsClient represents a client capable of sending stats to some stat endpoint.
+type StatsClient interface {
+	Gauge(name string, value float64, tags []string, rate float64) error
+	Count(name string, value int64, tags []string, rate float64) error
+	Histogram(name string, value float64, tags []string, rate float64) error
+}
+
 // Client is a global Statsd client. When a client is configured via Configure,
 // that becomes the new global Statsd client in the package.
-var Client *statsd.Client
+var Client StatsClient = (*statsd.Client)(nil)
 
 // Configure creates a statsd client from a dogweb.ini style config file and set it to the global Statsd.
 func Configure(conf *config.AgentConfig) error {

--- a/writer/datadog_endpoint.go
+++ b/writer/datadog_endpoint.go
@@ -32,10 +32,10 @@ func NewDatadogEndpoint(client *http.Client, url, path, apiKey string) *DatadogE
 }
 
 // Write will send the serialized traces payload to the Datadog traces endpoint.
-func (e *DatadogEndpoint) Write(payload []byte, headers map[string]string) error {
+func (e *DatadogEndpoint) Write(payload *Payload) error {
 	// Create the request to be sent to the API
 	url := e.url + e.path
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload.Bytes))
 
 	if err != nil {
 		return err
@@ -44,21 +44,38 @@ func (e *DatadogEndpoint) Write(payload []byte, headers map[string]string) error
 	// Set API key in the header and issue the request
 	req.Header.Set(apiHTTPHeaderKey, e.apiKey)
 
-	SetExtraHeaders(req.Header, headers)
+	SetExtraHeaders(req.Header, payload.Headers)
 
 	resp, err := e.client.Do(req)
 
 	if err != nil {
-		return err
+		return &RetriableError{
+			err:      err,
+			endpoint: e,
+		}
 	}
 	defer resp.Body.Close()
 
 	// We check the status code to see if the request has succeeded.
 	// TODO: define all legit status code and behave accordingly.
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("request to %s responded with %s", url, resp.Status)
+		err := fmt.Errorf("request to %s responded with %s", url, resp.Status)
+		if resp.StatusCode/100 == 5 {
+			// 5xx errors are retriable
+			return &RetriableError{
+				err:      err,
+				endpoint: e,
+			}
+		}
+
+		// All others aren't
+		return err
 	}
 
 	// Everything went fine
 	return nil
+}
+
+func (e *DatadogEndpoint) String() string {
+	return fmt.Sprintf("DD endpoint(url=%s, path=%s)", e.url, e.path)
 }

--- a/writer/endpoint.go
+++ b/writer/endpoint.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"fmt"
 	"net/http"
 
 	log "github.com/cihub/seelog"
@@ -10,15 +11,15 @@ const languageHeaderKey = "X-Datadog-Reported-Languages"
 
 // Endpoint is an interface where we send the data from the Agent.
 type Endpoint interface {
-	Write(payload []byte, headers map[string]string) error
+	Write(payload *Payload) error
 }
 
 // NullEndpoint is a void endpoint dropping data.
 type NullEndpoint struct{}
 
 // Write of NullEndpoint just drops the payload and log its size.
-func (ne *NullEndpoint) Write(payload []byte, headers map[string]string) error {
-	log.Debug("null endpoint: dropping payload, size: %d", len(payload))
+func (ne *NullEndpoint) Write(payload *Payload) error {
+	log.Debug("null endpoint: dropping payload, size: %d", len(payload.Bytes))
 	return nil
 }
 
@@ -27,4 +28,15 @@ func SetExtraHeaders(h http.Header, extras map[string]string) {
 	for key, value := range extras {
 		h.Set(key, value)
 	}
+}
+
+// RetriableError is an endpoint error that signifies that the associated operation can be retried at a later point.
+type RetriableError struct {
+	err      error
+	endpoint Endpoint
+}
+
+// Error returns the error string.
+func (re *RetriableError) Error() string {
+	return fmt.Sprintf("%s: %v", re.endpoint, re.err)
 }

--- a/writer/fixtures.go
+++ b/writer/fixtures.go
@@ -1,0 +1,197 @@
+package writer
+
+import (
+	"math/rand"
+	"sync"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+)
+
+// PayloadConstructedHandlerArgs encodes the arguments passed to a PayloadConstructedHandler call.
+type PayloadConstructedHandlerArgs struct {
+	payload *Payload
+	stats   interface{}
+}
+
+// TestEndpoint represents a mocked endpoint that replies with a configurable error and records successful and failed
+// payloads.
+type TestEndpoint struct {
+	Err             error
+	SuccessPayloads []Payload
+	ErrorPayloads   []Payload
+}
+
+// Write mocks the writing of a payload to a remote endpoint, recording it and replying with the configured error (or
+// success in its absence).
+func (e *TestEndpoint) Write(payload *Payload) error {
+	if e.Err != nil {
+		e.ErrorPayloads = append(e.ErrorPayloads, *payload)
+	} else {
+		e.SuccessPayloads = append(e.SuccessPayloads, *payload)
+	}
+
+	return e.Err
+}
+
+func (e *TestEndpoint) String() string {
+	return "TestEndpoint"
+}
+
+// RandomPayload creates a new payload instance using random data and up to 32 bytes.
+func RandomPayload() *Payload {
+	return RandomSizedPayload(rand.Intn(32))
+}
+
+// RandomSizedPayload creates a new payload instance using random data with the specified size.
+func RandomSizedPayload(size int) *Payload {
+	return NewPayload(fixtures.RandomSizedBytes(size), fixtures.RandomStringMap())
+}
+
+// TestPayloadSender is a PayloadSender that is connected to a TestEndpoint, used for testing.
+type TestPayloadSender struct {
+	testEndpoint *TestEndpoint
+	BasePayloadSender
+}
+
+// NewTestPayloadSender creates a new instance of a TestPayloadSender.
+func NewTestPayloadSender() *TestPayloadSender {
+	testEndpoint := &TestEndpoint{}
+	return &TestPayloadSender{
+		testEndpoint:      testEndpoint,
+		BasePayloadSender: *NewBasePayloadSender(testEndpoint),
+	}
+}
+
+// Start asynchronously starts this payload sender.
+func (c *TestPayloadSender) Start() {
+	go c.Run()
+}
+
+// Run executes the core loop of this sender.
+func (c *TestPayloadSender) Run() {
+	c.exitWG.Add(1)
+	defer c.exitWG.Done()
+
+	for {
+		select {
+		case payload := <-c.in:
+			stats, err := c.send(payload)
+
+			if err != nil {
+				c.notifyError(payload, err, stats)
+			} else {
+				c.notifySuccess(payload, stats)
+			}
+		case <-c.exit:
+			return
+		}
+	}
+}
+
+// Payloads allows access to all payloads recorded as being successfully sent by this sender.
+func (c *TestPayloadSender) Payloads() []Payload {
+	return c.testEndpoint.SuccessPayloads
+}
+
+// Endpoint allows access to the underlying TestEndpoint.
+func (c *TestPayloadSender) Endpoint() *TestEndpoint {
+	return c.testEndpoint
+}
+
+func (c *TestPayloadSender) setEndpoint(endpoint Endpoint) {
+	c.testEndpoint = endpoint.(*TestEndpoint)
+}
+
+// TestPayloadSenderMonitor monitors a PayloadSender and stores all events
+type TestPayloadSenderMonitor struct {
+	SuccessEvents []SenderSuccessEvent
+	FailureEvents []SenderFailureEvent
+	RetryEvents   []SenderRetryEvent
+
+	sender PayloadSender
+
+	exit   chan struct{}
+	exitWG sync.WaitGroup
+}
+
+// NewTestPayloadSenderMonitor creates a new TestPayloadSenderMonitor monitoring the specified sender.
+func NewTestPayloadSenderMonitor(sender PayloadSender) *TestPayloadSenderMonitor {
+	return &TestPayloadSenderMonitor{
+		sender: sender,
+		exit:   make(chan struct{}),
+	}
+}
+
+// Start asynchronously starts this payload monitor.
+func (m *TestPayloadSenderMonitor) Start() {
+	go m.Run()
+}
+
+// Run executes the core loop of this monitor.
+func (m *TestPayloadSenderMonitor) Run() {
+	m.exitWG.Add(1)
+	defer m.exitWG.Done()
+
+	for {
+		select {
+		case event := <-m.sender.Monitor():
+			if event == nil {
+				continue
+			}
+
+			switch event := event.(type) {
+			case SenderSuccessEvent:
+				m.SuccessEvents = append(m.SuccessEvents, event)
+			case SenderFailureEvent:
+				m.FailureEvents = append(m.FailureEvents, event)
+			case SenderRetryEvent:
+				m.RetryEvents = append(m.RetryEvents, event)
+			default:
+				log.Errorf("Unknown event of type %T", event)
+			}
+		case <-m.exit:
+			return
+		}
+	}
+}
+
+// Stop stops this payload monitor and waits for it to stop.
+func (m *TestPayloadSenderMonitor) Stop() {
+	close(m.exit)
+	m.exitWG.Wait()
+}
+
+// SuccessPayloads returns a slice containing all successful payloads.
+func (m *TestPayloadSenderMonitor) SuccessPayloads() []Payload {
+	result := make([]Payload, len(m.SuccessEvents))
+
+	for i, successEvent := range m.SuccessEvents {
+		result[i] = *successEvent.Payload
+	}
+
+	return result
+}
+
+// FailurePayloads returns a slice containing all failed payloads.
+func (m *TestPayloadSenderMonitor) FailurePayloads() []Payload {
+	result := make([]Payload, len(m.FailureEvents))
+
+	for i, successEvent := range m.FailureEvents {
+		result[i] = *successEvent.Payload
+	}
+
+	return result
+}
+
+// RetryPayloads returns a slice containing all failed payloads.
+func (m *TestPayloadSenderMonitor) RetryPayloads() []Payload {
+	result := make([]Payload, len(m.RetryEvents))
+
+	for i, successEvent := range m.RetryEvents {
+		result[i] = *successEvent.Payload
+	}
+
+	return result
+}

--- a/writer/payload.go
+++ b/writer/payload.go
@@ -1,0 +1,390 @@
+package writer
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-trace-agent/backoff"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
+)
+
+// Payload represents a data payload to be sent to some endpoint
+type Payload struct {
+	CreationDate time.Time
+	Bytes        []byte
+	Headers      map[string]string
+}
+
+// NewPayload constructs a new payload object with the provided data and with CreationDate initialized to the current
+// time.
+func NewPayload(bytes []byte, headers map[string]string) *Payload {
+	return &Payload{
+		CreationDate: time.Now(),
+		Bytes:        bytes,
+		Headers:      headers,
+	}
+}
+
+// SendStats represents basic stats related to the sending of a payload.
+type SendStats struct {
+	SendTime time.Duration
+}
+
+// SenderSuccessEvent encodes information related to the successful sending of a payload.
+type SenderSuccessEvent struct {
+	Payload   *Payload
+	SendStats SendStats
+}
+
+// SenderFailureEvent encodes information related to the failed sending of a payload without subsequent retry.
+type SenderFailureEvent struct {
+	Payload   *Payload
+	SendStats SendStats
+	Error     error
+}
+
+// SenderRetryEvent encodes information related to the failed sending of a payload that triggered an automatic retry.
+type SenderRetryEvent struct {
+	Payload    *Payload
+	SendTime   time.Duration
+	Error      error
+	RetryDelay time.Duration
+	RetryNum   int
+}
+
+// PayloadSender represents an object capable of asynchronously sending payloads to some endpoint.
+type PayloadSender interface {
+	Start()
+	Run()
+	Stop()
+	Send(payload *Payload)
+	setEndpoint(endpoint Endpoint)
+	Monitor() <-chan interface{}
+}
+
+// BasePayloadSender encodes structures and behaviours common to most PayloadSenders.
+type BasePayloadSender struct {
+	in       chan *Payload
+	monitor  chan interface{}
+	endpoint Endpoint
+
+	exit   chan struct{}
+	exitWG sync.WaitGroup
+}
+
+// NewBasePayloadSender creates a new instance of a BasePayloadSender using the provided endpoint.
+func NewBasePayloadSender(endpoint Endpoint) *BasePayloadSender {
+	return &BasePayloadSender{
+		in:       make(chan *Payload),
+		monitor:  make(chan interface{}),
+		endpoint: endpoint,
+		exit:     make(chan struct{}),
+	}
+}
+
+// Send sends a single isolated payload through this sender.
+func (s *BasePayloadSender) Send(payload *Payload) {
+	s.in <- payload
+}
+
+// Stop asks this sender to stop and waits until it correctly stops.
+func (s *BasePayloadSender) Stop() {
+	close(s.exit)
+	s.exitWG.Wait()
+	close(s.in)
+	close(s.monitor)
+}
+
+func (s *BasePayloadSender) setEndpoint(endpoint Endpoint) {
+	s.endpoint = endpoint
+}
+
+// Monitor allows an external entity to monitor events of this sender by receiving Sender*Event structs.
+func (s *BasePayloadSender) Monitor() <-chan interface{} {
+	return s.monitor
+}
+
+// send will send the provided payload without any checks.
+func (s *BasePayloadSender) send(payload *Payload) (SendStats, error) {
+	if payload == nil {
+		return SendStats{}, nil
+	}
+
+	startFlush := time.Now()
+	err := s.endpoint.Write(payload)
+
+	sendStats := SendStats{
+		SendTime: time.Since(startFlush),
+	}
+
+	return sendStats, err
+}
+
+func (s *BasePayloadSender) notifySuccess(payload *Payload, sendStats SendStats) {
+	s.monitor <- SenderSuccessEvent{
+		Payload:   payload,
+		SendStats: sendStats,
+	}
+}
+
+func (s *BasePayloadSender) notifyError(payload *Payload, err error, sendStats SendStats) {
+	s.monitor <- SenderFailureEvent{
+		Payload:   payload,
+		SendStats: sendStats,
+		Error:     err,
+	}
+}
+
+func (s *BasePayloadSender) notifyRetry(payload *Payload, err error, delay time.Duration, retryNum int) {
+	s.monitor <- SenderRetryEvent{
+		Payload:    payload,
+		Error:      err,
+		RetryDelay: delay,
+		RetryNum:   retryNum,
+	}
+}
+
+// QueuablePayloadSenderConf contains the configuration needed by a QueuablePayloadSender to operate.
+type QueuablePayloadSenderConf struct {
+	MaxAge            time.Duration
+	MaxQueuedBytes    int64
+	MaxQueuedPayloads int
+	BackoffTimer      backoff.Timer
+}
+
+// DefaultQueuablePayloadSenderConf constructs a QueuablePayloadSenderConf with default sane options.
+func DefaultQueuablePayloadSenderConf() QueuablePayloadSenderConf {
+	return QueuablePayloadSenderConf{
+		MaxAge:            20 * time.Minute,
+		MaxQueuedBytes:    256 * 1024 * 1024, // 256 MB
+		MaxQueuedPayloads: -1,                // Unlimited
+		BackoffTimer:      backoff.NewExponentialTimer(),
+	}
+}
+
+// QueuablePayloadSender is a specific implementation of a PayloadSender that will queue new payloads on error and
+// retry sending them according to some configurable BackoffTimer.
+type QueuablePayloadSender struct {
+	conf              QueuablePayloadSenderConf
+	queuedPayloads    *list.List
+	queuing           bool
+	currentQueuedSize int64
+
+	// Test helper
+	syncBarrier <-chan interface{}
+
+	BasePayloadSender
+}
+
+// NewQueuablePayloadSender constructs a new QueuablePayloadSender with default configuration to send payloads to the
+// provided endpoint.
+func NewQueuablePayloadSender(endpoint Endpoint) *QueuablePayloadSender {
+	return NewCustomQueuablePayloadSender(endpoint, DefaultQueuablePayloadSenderConf())
+}
+
+// NewCustomQueuablePayloadSender constructs a new QueuablePayloadSender with custom configuration to send payloads to
+// the provided endpoint.
+func NewCustomQueuablePayloadSender(endpoint Endpoint, conf QueuablePayloadSenderConf) *QueuablePayloadSender {
+	return &QueuablePayloadSender{
+		conf:              conf,
+		queuedPayloads:    list.New(),
+		BasePayloadSender: *NewBasePayloadSender(endpoint),
+	}
+}
+
+// Start asynchronously starts this QueueablePayloadSender.
+func (s *QueuablePayloadSender) Start() {
+	go func() {
+		defer watchdog.LogOnPanic()
+		s.Run()
+	}()
+}
+
+// Run executes the QueuablePayloadSender main logic synchronously.
+func (s *QueuablePayloadSender) Run() {
+	s.exitWG.Add(1)
+	defer s.exitWG.Done()
+
+	for {
+		select {
+		case payload := <-s.in:
+			if stats, err := s.sendOrQueue(payload); err != nil {
+				log.Errorf("Error while sending or queueing payload. err=%v", err)
+				s.notifyError(payload, err, stats)
+			}
+		case <-s.conf.BackoffTimer.ReceiveTick():
+			s.flushQueue()
+		case <-s.syncBarrier:
+			// TODO: Is there a way of avoiding this? I want Promises in Go :(((
+			// This serves as a barrier (assuming syncBarrier is an unbuffered channel). Used for testing
+			continue
+		case <-s.exit:
+			log.Info("exiting payload sender, try flushing whatever is left")
+			s.flushQueue()
+			return
+		}
+	}
+}
+
+// NumQueuedPayloads returns the number of payloads currently waiting in the queue for a retry
+func (s *QueuablePayloadSender) NumQueuedPayloads() int {
+	return s.queuedPayloads.Len()
+}
+
+// sendOrQueue sends the provided payload or queues it if this sender is currently queueing payloads.
+func (s *QueuablePayloadSender) sendOrQueue(payload *Payload) (SendStats, error) {
+	stats := SendStats{}
+
+	if payload == nil {
+		return stats, nil
+	}
+
+	var err error
+
+	if !s.queuing {
+		if stats, err = s.send(payload); err != nil {
+			if _, ok := err.(*RetriableError); ok {
+				// If error is retriable, start a queue and schedule a retry
+				retryNum, delay := s.conf.BackoffTimer.ScheduleRetry(err)
+				log.Debugf("Got retriable error. Starting a queue. delay=%s, err=%v", delay, err)
+				s.notifyRetry(payload, err, delay, retryNum)
+				return stats, s.enqueue(payload)
+			}
+		} else {
+			// If success, notify
+			log.Tracef("Successfully sent direct payload: %v", payload)
+			s.notifySuccess(payload, stats)
+		}
+	} else {
+		return stats, s.enqueue(payload)
+	}
+
+	return stats, err
+}
+
+func (s *QueuablePayloadSender) enqueue(payload *Payload) error {
+	if !s.queuing {
+		s.queuing = true
+	}
+
+	for s.conf.MaxQueuedPayloads > 0 && s.queuedPayloads.Len() >= s.conf.MaxQueuedPayloads {
+		log.Debugf("Dropping existing payload because max queued payloads reached: %d", s.conf.MaxQueuedPayloads)
+		if _, err := s.dropOldestPayload("max queued payloads reached"); err != nil {
+			panic(fmt.Errorf("unable to respect max queued payloads value of %d", s.conf.MaxQueuedPayloads))
+		}
+	}
+
+	newPayloadSize := int64(len(payload.Bytes))
+
+	if newPayloadSize > s.conf.MaxQueuedBytes {
+		log.Debugf("Payload bigger than max size: size=%d, max size=%d", newPayloadSize, s.conf.MaxQueuedBytes)
+		return fmt.Errorf("unable to queue payload bigger than max size: payload size=%d, max size=%d",
+			newPayloadSize, s.conf.MaxQueuedBytes)
+	}
+
+	for s.conf.MaxQueuedBytes > 0 && s.currentQueuedSize+newPayloadSize > s.conf.MaxQueuedBytes {
+		if _, err := s.dropOldestPayload("max queued bytes reached"); err != nil {
+			// Should never happen because we know we can fit it in
+			panic(fmt.Errorf("unable to find space for queueing payload of size %d: %v", newPayloadSize, err))
+		}
+	}
+
+	log.Tracef("Queuing new payload: %v", payload)
+	s.queuedPayloads.PushBack(payload)
+	s.currentQueuedSize += newPayloadSize
+
+	return nil
+}
+
+func (s *QueuablePayloadSender) flushQueue() error {
+	if s.NumQueuedPayloads() == 0 {
+		return nil
+	}
+
+	log.Debugf("Attempting to flush queue with %d payloads", s.NumQueuedPayloads())
+
+	var next *list.Element
+	for e := s.queuedPayloads.Front(); e != nil; e = next {
+		payload := e.Value.(*Payload)
+
+		var err error
+		var stats SendStats
+
+		if stats, err = s.send(payload); err != nil {
+			if _, ok := err.(*RetriableError); ok {
+				// If send failed due to a retriable error, retry flush later
+				retryNum, delay := s.conf.BackoffTimer.ScheduleRetry(err)
+				log.Errorf("Got retriable error. Retrying flush later: retry=%d, delay=%s, err=%v",
+					retryNum, delay, err)
+				s.discardOldPayloads()
+				s.notifyRetry(payload, err, delay, retryNum)
+				// Don't try to send following. We'll flush all later.
+				return err
+			}
+
+			// If send failed due to non-retriable error, notify error and drop it
+			log.Errorf("Dropping payload due to non-retriable error: err=%v, payload=%v", err, payload)
+			s.notifyError(payload, err, stats)
+			next = s.removeQueuedPayload(e)
+			// Try sending next ones
+			continue
+		}
+
+		// If successful, remove payload from queue
+		log.Tracef("Successfully sent a queued payload: %v", payload)
+		s.notifySuccess(payload, stats)
+		next = s.removeQueuedPayload(e)
+	}
+
+	s.queuing = false
+	s.conf.BackoffTimer.Reset()
+
+	return nil
+}
+
+func (s *QueuablePayloadSender) removeQueuedPayload(e *list.Element) *list.Element {
+	next := e.Next()
+	payload := e.Value.(*Payload)
+	s.currentQueuedSize -= int64(len(payload.Bytes))
+	s.queuedPayloads.Remove(e)
+	return next
+}
+
+// Discard those payloads that are older than max age.
+func (s *QueuablePayloadSender) discardOldPayloads() {
+	var next *list.Element
+
+	for e := s.queuedPayloads.Front(); e != nil; e = next {
+		payload := e.Value.(*Payload)
+
+		age := time.Since(payload.CreationDate)
+
+		// Payloads are kept in order so as soon as we find one that isn't, we can break out
+		if age < s.conf.MaxAge {
+			break
+		}
+
+		err := fmt.Errorf("payload is older than max age: age=%v, max age=%v", age, s.conf.MaxAge)
+		log.Tracef("Discarding payload: err=%v, payload=%v", err, payload)
+		s.notifyError(payload, err, SendStats{})
+		next = s.removeQueuedPayload(e)
+	}
+}
+
+// Payloads are kept in order so dropping the one at the front guarantees we're dropping the oldest
+func (s *QueuablePayloadSender) dropOldestPayload(reason string) (*Payload, error) {
+	if s.queuedPayloads.Len() == 0 {
+		return nil, fmt.Errorf("no queued payloads")
+	}
+
+	err := fmt.Errorf("payload dropped: %s", reason)
+	droppedPayload := s.queuedPayloads.Front().Value.(*Payload)
+	s.removeQueuedPayload(s.queuedPayloads.Front())
+	s.notifyError(droppedPayload, err, SendStats{})
+
+	return droppedPayload, nil
+}

--- a/writer/payload_test.go
+++ b/writer/payload_test.go
@@ -1,0 +1,469 @@
+package writer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/backoff"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPayloadSetsCreationDate(t *testing.T) {
+	assert := assert.New(t)
+
+	newPayload := NewPayload(nil, nil)
+
+	assert.WithinDuration(time.Now(), newPayload.CreationDate, 1*time.Second)
+}
+
+func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that doesn't fail
+	workingEndpoint := &TestEndpoint{}
+
+	// And a queuable sender using that endpoint
+	queuableSender := NewQueuablePayloadSender(workingEndpoint)
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	// When we start the sender
+	monitor.Start()
+	queuableSender.Start()
+
+	// And send some payloads
+	payload1 := RandomPayload()
+	queuableSender.Send(payload1)
+	payload2 := RandomPayload()
+	queuableSender.Send(payload2)
+	payload3 := RandomPayload()
+	queuableSender.Send(payload3)
+	payload4 := RandomPayload()
+	queuableSender.Send(payload4)
+	payload5 := RandomPayload()
+	queuableSender.Send(payload5)
+
+	// And stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then we expect all sent payloads to have been successfully sent
+	successPayloads := monitor.SuccessPayloads()
+	errorPayloads := monitor.FailurePayloads()
+	assert.Equal([]Payload{*payload1, *payload2, *payload3, *payload4, *payload5}, successPayloads,
+		"Expect all sent payloads to have been successful")
+	assert.Equal(successPayloads, workingEndpoint.SuccessPayloads, "Expect sender and endpoint to match on successful payloads")
+	assert.Len(errorPayloads, 0, "No payloads should have errored out on send")
+	assert.Len(workingEndpoint.ErrorPayloads, 0, "No payloads should have errored out on send")
+}
+
+func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that initially works ok
+	flakyEndpoint := &TestEndpoint{}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// With a working endpoint
+	// We send some payloads
+	payload1 := RandomPayload()
+	queuableSender.Send(payload1)
+	payload2 := RandomPayload()
+	queuableSender.Send(payload2)
+
+	// Make sure sender processed both payloads
+	syncBarrier <- nil
+
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+
+	// With a failing endpoint with a retriable error
+	flakyEndpoint.Err = &RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint}
+	// We send some payloads
+	payload3 := RandomPayload()
+	queuableSender.Send(payload3)
+	payload4 := RandomPayload()
+	queuableSender.Send(payload4)
+	// And retry once
+	testBackoffTimer.TriggerTick()
+	// And retry twice
+	testBackoffTimer.TriggerTick()
+
+	// Make sure sender processed both ticks
+	syncBarrier <- nil
+
+	assert.Equal(2, queuableSender.NumQueuedPayloads(), "Expect 2 queued payloads")
+
+	// With the previously failing endpoint working again
+	flakyEndpoint.Err = nil
+	// We retry for the third time
+	testBackoffTimer.TriggerTick()
+
+	// Make sure sender processed previous tick
+	syncBarrier <- nil
+
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+
+	// Finally, with a failing endpoint with a non-retriable error
+	flakyEndpoint.Err = fmt.Errorf("non retriable bleh")
+	// We send some payloads
+	payload5 := RandomPayload()
+	queuableSender.Send(payload5)
+	payload6 := RandomPayload()
+	queuableSender.Send(payload6)
+
+	// Make sure sender processed previous payloads
+	syncBarrier <- nil
+
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "Expect no queued payloads")
+
+	// With the previously failing endpoint working again
+	flakyEndpoint.Err = nil
+	// We retry just in case there's something in the queue
+	testBackoffTimer.TriggerTick()
+
+	// And stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then we expect payloads sent during working endpoint or those that were retried due to retriable errors to have
+	// been sent eventually (and in order). Those that failed because of non-retriable errors should have been discarded
+	// even after a retry.
+	successPayloads := monitor.SuccessPayloads()
+	errorPayloads := monitor.FailurePayloads()
+	retryPayloads := monitor.RetryPayloads()
+	assert.Equal([]Payload{*payload1, *payload2, *payload3, *payload4}, successPayloads,
+		"Expect all sent payloads to have been successful")
+	assert.Equal(successPayloads, flakyEndpoint.SuccessPayloads, "Expect sender and endpoint to match on successful payloads")
+	// Expect 3 retry events for payload 3 (one because of first send, two others because of the two retries)
+	assert.Equal([]Payload{*payload3, *payload3, *payload3}, retryPayloads, "Expect payload 3 to have been retries 3 times")
+	// We expect payloads 5 and 6 to appear in error payloads as they failed for non-retriable errors.
+	assert.Equal([]Payload{*payload5, *payload6}, errorPayloads, "Expect errored payloads to have been discarded as expected")
+}
+
+func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that continuously throws out retriable errors
+	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint.Err = &RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer and with a meager max queued payloads value of 1
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.MaxQueuedPayloads = 1
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// When sending a first payload
+	payload1 := RandomPayload()
+	queuableSender.Send(payload1)
+
+	// Followed by another one
+	payload2 := RandomPayload()
+	queuableSender.Send(payload2)
+
+	// Followed by a third
+	payload3 := RandomPayload()
+	queuableSender.Send(payload3)
+
+	// Ensure previous payloads were processed
+	syncBarrier <- nil
+
+	// Then, when the endpoint finally works
+	flakyEndpoint.Err = nil
+
+	// And we trigger a retry
+	testBackoffTimer.TriggerTick()
+
+	// Ensure tick was processed
+	syncBarrier <- nil
+
+	// Then we should have no queued payloads
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+
+	// When we stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then endpoint should have received only payload3. Other should have been discarded because max queued payloads
+	// is 1
+	assert.Equal([]Payload{*payload3}, flakyEndpoint.SuccessPayloads, "Endpoint should have received only payload 3")
+
+	// Monitor should agree on previous fact
+	assert.Equal([]Payload{*payload3}, monitor.SuccessPayloads(),
+		"Monitor should agree with endpoint on succesful payloads")
+	assert.Equal([]Payload{*payload1, *payload2}, monitor.FailurePayloads(),
+		"Monitor should agree with endpoint on failed payloads")
+	assert.Contains(monitor.FailureEvents[0].Error.Error(), "max queued payloads",
+		"Monitor failure event should mention correct reason for error")
+	assert.Contains(monitor.FailureEvents[1].Error.Error(), "max queued payloads",
+		"Monitor failure event should mention correct reason for error")
+}
+
+func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that continuously throws out retriable errors
+	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint.Err = &RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.MaxQueuedBytes = 10
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// When sending a first payload of 4 bytes
+	payload1 := RandomSizedPayload(4)
+	queuableSender.Send(payload1)
+
+	// Followed by another one of 2 bytes
+	payload2 := RandomSizedPayload(2)
+	queuableSender.Send(payload2)
+
+	// Followed by a third of 8 bytes
+	payload3 := RandomSizedPayload(8)
+	queuableSender.Send(payload3)
+
+	// Ensure previous payloads were processed
+	syncBarrier <- nil
+
+	// Then, when the endpoint finally works
+	flakyEndpoint.Err = nil
+
+	// And we trigger a retry
+	testBackoffTimer.TriggerTick()
+
+	// Ensure tick was processed
+	syncBarrier <- nil
+
+	// Then we should have no queued payloads
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+
+	// When we stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then endpoint should have received payload2 and payload3. Payload1 should have been discarded because keeping all
+	// 3 would have put us over the max size of sender
+	assert.Equal([]Payload{*payload2, *payload3}, flakyEndpoint.SuccessPayloads,
+		"Endpoint should have received only payload 2 and 3 (in that order)")
+
+	// Monitor should agree on previous fact
+	assert.Equal([]Payload{*payload2, *payload3}, monitor.SuccessPayloads(),
+		"Monitor should agree with endpoint on succesful payloads")
+	assert.Equal([]Payload{*payload1}, monitor.FailurePayloads(),
+		"Monitor should agree with endpoint on failed payloads")
+	assert.Contains(monitor.FailureEvents[0].Error.Error(), "max queued bytes",
+		"Monitor failure event should mention correct reason for error")
+}
+
+func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that continuously throws out retriable errors
+	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint.Err = &RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.MaxQueuedBytes = 10
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// When sending a payload of 12 bytes
+	payload1 := RandomSizedPayload(12)
+	queuableSender.Send(payload1)
+
+	// Ensure previous payloads were processed
+	syncBarrier <- nil
+
+	// Then, when the endpoint finally works
+	flakyEndpoint.Err = nil
+
+	// And we trigger a retry
+	testBackoffTimer.TriggerTick()
+
+	// Ensure tick was processed
+	syncBarrier <- nil
+
+	// Then we should have no queued payloads
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+
+	// When we stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then endpoint should have received no payloads because payload1 was too big to store in queue.
+	assert.Len(flakyEndpoint.SuccessPayloads, 0, "Endpoint should have received no payloads")
+
+	// And monitor should have received failed event for payload1 with correct reason
+	assert.Equal([]Payload{*payload1}, monitor.FailurePayloads(),
+		"Monitor should agree with endpoint on failed payloads")
+	assert.Contains(monitor.FailureEvents[0].Error.Error(), "bigger than max size",
+		"Monitor failure event should mention correct reason for error")
+}
+
+func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that works
+	workingEndpoint := &TestEndpoint{}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.MaxQueuedBytes = 10
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(workingEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// When sending a payload of 12 bytes
+	payload1 := RandomSizedPayload(12)
+	queuableSender.Send(payload1)
+
+	// Ensure previous payloads were processed
+	syncBarrier <- nil
+
+	// Then we should have no queued payloads
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+
+	// When we stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then endpoint should have received payload1 because although it was big, it didn't get queued.
+	assert.Equal([]Payload{*payload1}, workingEndpoint.SuccessPayloads, "Endpoint should have received payload1")
+
+	// And monitor should have received success event for payload1
+	assert.Equal([]Payload{*payload1}, monitor.SuccessPayloads(),
+		"Monitor should agree with endpoint on success payloads")
+}
+
+func TestQueuablePayloadSender_MaxAge(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given an endpoint that continuously throws out retriable errors
+	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint.Err = &RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint}
+
+	// And a test backoff timer that can be triggered on-demand
+	testBackoffTimer := backoff.NewTestBackoffTimer()
+
+	// And a queuable sender using said endpoint and timer and with a meager max age of 100ms
+	conf := DefaultQueuablePayloadSenderConf()
+	conf.MaxAge = 100 * time.Millisecond
+	conf.BackoffTimer = testBackoffTimer
+	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	syncBarrier := make(chan interface{})
+	queuableSender.syncBarrier = syncBarrier
+
+	// And a test monitor for that sender
+	monitor := NewTestPayloadSenderMonitor(queuableSender)
+
+	monitor.Start()
+	queuableSender.Start()
+
+	// When sending two payloads one after the other
+	payload1 := RandomPayload()
+	queuableSender.Send(payload1)
+	payload2 := RandomPayload()
+	queuableSender.Send(payload2)
+
+	// And then sleeping for 500ms
+	time.Sleep(500 * time.Millisecond)
+
+	// And then sending a third payload
+	payload3 := RandomPayload()
+	queuableSender.Send(payload3)
+
+	// And then triggering a retry
+	testBackoffTimer.TriggerTick()
+
+	// Ensure tick was processed
+	syncBarrier <- nil
+
+	// Then, when the endpoint finally works
+	flakyEndpoint.Err = nil
+
+	// And we trigger a retry
+	testBackoffTimer.TriggerTick()
+
+	// Ensure tick was processed
+	syncBarrier <- nil
+
+	// Then we should have no queued payloads
+	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
+
+	// When we stop the sender
+	queuableSender.Stop()
+	monitor.Stop()
+
+	// Then endpoint should have received only payload3. Because payload1 and payload2 were too old after the failed
+	// retry (first TriggerTick).
+	assert.Equal([]Payload{*payload3}, flakyEndpoint.SuccessPayloads, "Endpoint should have received only payload 3")
+
+	// And monitor should have received failed events for payload1 and payload2 with correct reason
+	assert.Equal([]Payload{*payload1, *payload2}, monitor.FailurePayloads(),
+		"Monitor should agree with endpoint on failed payloads")
+	assert.Contains(monitor.FailureEvents[0].Error.Error(), "older than max age",
+		"Monitor failure event should mention correct reason for error")
+}

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -1,0 +1,202 @@
+package writer
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/info"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/statsd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceWriter_SenderMaxPayloads(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a service writer
+	serviceWriter, _, _, _ := testServiceWriter()
+
+	// When checking its default sender configuration
+	queuableSender := serviceWriter.BaseWriter.payloadSender.(*QueuablePayloadSender)
+
+	// Then the MaxQueuedPayloads setting should be 1
+	assert.Equal(1, queuableSender.conf.MaxQueuedPayloads)
+}
+
+func TestServiceWriter_ServiceHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a service writer, its incoming channel and the endpoint that receives the payloads
+	serviceWriter, serviceChannel, testEndpoint, _ := testServiceWriter()
+	serviceWriter.conf.FlushPeriod = 100 * time.Millisecond
+
+	serviceWriter.Start()
+
+	// Given a set of service metadata
+	metadata1 := fixtures.RandomServices(10, 10)
+
+	// When sending it
+	serviceChannel <- metadata1
+
+	// And then waiting for more than flush period
+	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
+
+	// And then sending another set of service metadata
+	metadata2 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata2
+
+	// And stopping service writer before flush ticker ticks (should still flush on exit though)
+	close(serviceChannel)
+	serviceWriter.Stop()
+
+	// Then the endpoint should have received 2 payloads, containing all sent metadata
+	expectedHeaders := map[string]string{
+		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+		"Content-Type":                 "application/json",
+	}
+
+	mergedMetadata := mergeMetadataInOrder(metadata1, metadata2)
+
+	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
+	assertMetadata(assert, expectedHeaders, metadata1, testEndpoint.SuccessPayloads[0])
+	assertMetadata(assert, expectedHeaders, mergedMetadata, testEndpoint.SuccessPayloads[1])
+}
+
+func TestServiceWriter_UpdateInfoHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a service writer, its incoming channel and the endpoint that receives the payloads
+	serviceWriter, serviceChannel, testEndpoint, statsClient := testServiceWriter()
+	serviceWriter.conf.FlushPeriod = 100 * time.Millisecond
+	serviceWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
+
+	serviceWriter.Start()
+
+	expectedNumPayloads := int64(0)
+	expectedNumServices := int64(0)
+	expectedNumBytes := int64(0)
+	expectedMinNumRetries := int64(0)
+	expectedNumErrors := int64(0)
+
+	// When sending a set of metadata
+	expectedNumPayloads++
+	metadata1 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata1
+	mergedMetadata := metadata1
+	expectedNumBytes += calculateMetadataPayloadSize(mergedMetadata)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
+
+	// And then sending a second set of metadata
+	expectedNumPayloads++
+	metadata2 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata2
+	mergedMetadata = mergeMetadataInOrder(mergedMetadata, metadata2)
+	expectedNumBytes += calculateMetadataPayloadSize(mergedMetadata)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
+
+	// And then sending a third payload with other 3 traces with an errored out endpoint with no retry
+	testEndpoint.Err = fmt.Errorf("non retriable error")
+	expectedNumErrors++
+	metadata3 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata3
+	mergedMetadata = mergeMetadataInOrder(mergedMetadata, metadata3)
+	expectedNumBytes += calculateMetadataPayloadSize(mergedMetadata)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
+
+	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
+	testEndpoint.Err = &RetriableError{
+		err:      fmt.Errorf("retriable error"),
+		endpoint: testEndpoint,
+	}
+	expectedMinNumRetries++
+	metadata4 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata4
+	mergedMetadata = mergeMetadataInOrder(mergedMetadata, metadata4)
+	expectedNumBytes += calculateMetadataPayloadSize(mergedMetadata)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
+
+	close(serviceChannel)
+	serviceWriter.Stop()
+
+	// Then we expect some counts and gauges to have been sent to the stats client for each update tick (there should
+	// have been at least 3 ticks)
+	countSummaries := statsClient.GetCountSummaries()
+	gaugeSummaries := statsClient.GetGaugeSummaries()
+
+	// Payload counts
+	payloadSummary := countSummaries["datadog.trace_agent.service_writer.payloads"]
+	assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
+	assert.Equal(expectedNumPayloads, payloadSummary.Sum)
+
+	// Services gauge
+	expectedNumServices = int64(len(mergedMetadata))
+	servicesSummary := gaugeSummaries["datadog.trace_agent.service_writer.services"]
+	assert.True(len(servicesSummary.Calls) >= 3, "There should have been multiple services gauge calls")
+	assert.EqualValues(expectedNumServices, servicesSummary.Max)
+
+	// Bytes counts
+	bytesSummary := countSummaries["datadog.trace_agent.service_writer.bytes"]
+	assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
+	assert.Equal(expectedNumBytes, bytesSummary.Sum)
+
+	// Retry counts
+	retriesSummary := countSummaries["datadog.trace_agent.service_writer.retries"]
+	assert.True(len(retriesSummary.Calls) >= 3, "There should have been multiple retries count calls")
+	assert.True(retriesSummary.Sum >= expectedMinNumRetries)
+
+	// Error counts
+	errorsSummary := countSummaries["datadog.trace_agent.service_writer.errors"]
+	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
+	assert.Equal(expectedNumErrors, errorsSummary.Sum)
+}
+
+func mergeMetadataInOrder(metadatas ...model.ServicesMetadata) model.ServicesMetadata {
+	result := model.ServicesMetadata{}
+
+	for _, metadata := range metadatas {
+		for serviceName, serviceMetadata := range metadata {
+			result[serviceName] = serviceMetadata
+		}
+	}
+
+	return result
+}
+
+func calculateMetadataPayloadSize(metadata model.ServicesMetadata) int64 {
+	data, _ := model.EncodeServicesPayload(metadata)
+	return int64(len(data))
+}
+
+func assertMetadata(assert *assert.Assertions, expectedHeaders map[string]string,
+	expectedMetadata model.ServicesMetadata, payload Payload) {
+	servicesMetadata := model.ServicesMetadata{}
+
+	assert.NoError(json.Unmarshal(payload.Bytes, &servicesMetadata), "Stats payload should unmarshal correctly")
+
+	assert.Equal(expectedHeaders, payload.Headers, "Headers should match expectation")
+	assert.Equal(expectedMetadata, servicesMetadata, "Service metadata should match expectation")
+}
+
+func testServiceWriter() (*ServiceWriter, chan model.ServicesMetadata, *TestEndpoint, *statsd.TestStatsClient) {
+	serviceChannel := make(chan model.ServicesMetadata)
+	serviceWriter := NewServiceWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, serviceChannel)
+	testEndpoint := &TestEndpoint{}
+	serviceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
+	testStatsClient := &statsd.TestStatsClient{}
+	serviceWriter.conf.StatsClient = testStatsClient
+
+	return serviceWriter, serviceChannel, testEndpoint, testStatsClient
+}

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -1,0 +1,210 @@
+package writer
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/info"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/statsd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatsWriter_StatHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a stats writer, its incoming channel and the endpoint that receives the payloads
+	statsWriter, statsChannel, testEndpoint, _ := testStatsWriter()
+
+	statsWriter.Start()
+
+	// Given 2 slices of 3 test buckets
+	testStats1 := []model.StatsBucket{
+		fixtures.RandomStatsBucket(3),
+		fixtures.RandomStatsBucket(3),
+		fixtures.RandomStatsBucket(3),
+	}
+	testStats2 := []model.StatsBucket{
+		fixtures.RandomStatsBucket(3),
+		fixtures.RandomStatsBucket(3),
+		fixtures.RandomStatsBucket(3),
+	}
+
+	// When sending those slices
+	statsChannel <- testStats1
+	statsChannel <- testStats2
+
+	// And stopping stats writer
+	close(statsChannel)
+	statsWriter.Stop()
+
+	// Then the endpoint should have received 2 payloads, containing all stat buckets
+	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
+
+	payloads := testEndpoint.SuccessPayloads
+	payload1 := payloads[0]
+	payload2 := payloads[1]
+
+	expectedHeaders := map[string]string{
+		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+		"Content-Type":                 "application/json",
+		"Content-Encoding":             "gzip",
+	}
+
+	assertStatsPayload(assert, expectedHeaders, testStats1, &payload1)
+	assertStatsPayload(assert, expectedHeaders, testStats2, &payload2)
+}
+
+func TestStatsWriter_UpdateInfoHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a stats writer, its incoming channel and the endpoint that receives the payloads
+	statsWriter, statsChannel, testEndpoint, statsClient := testStatsWriter()
+	statsWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
+
+	statsWriter.Start()
+
+	expectedNumPayloads := int64(0)
+	expectedNumBuckets := int64(0)
+	expectedNumBytes := int64(0)
+	expectedMinNumRetries := int64(0)
+	expectedNumErrors := int64(0)
+
+	// When sending 1 payload with 3 buckets
+	expectedNumPayloads++
+	payload1Buckets := []model.StatsBucket{
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+	}
+	statsChannel <- payload1Buckets
+	expectedNumBuckets += 3
+	expectedNumBytes += calculateStatPayloadSize(payload1Buckets)
+
+	// And another one with another 3 buckets
+	expectedNumPayloads++
+	payload2Buckets := []model.StatsBucket{
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+	}
+	statsChannel <- payload2Buckets
+	expectedNumBuckets += 3
+	expectedNumBytes += calculateStatPayloadSize(payload2Buckets)
+
+	// Wait for previous payloads to be sent
+	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
+
+	// And then sending a third payload with other 3 buckets with an errored out endpoint
+	testEndpoint.Err = fmt.Errorf("non retriable error")
+	expectedNumErrors++
+	payload3Buckets := []model.StatsBucket{
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+	}
+	statsChannel <- payload3Buckets
+	expectedNumBuckets += 3
+	expectedNumBytes += calculateStatPayloadSize(payload3Buckets)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
+
+	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
+	testEndpoint.Err = &RetriableError{
+		err:      fmt.Errorf("non retriable error"),
+		endpoint: testEndpoint,
+	}
+	expectedMinNumRetries++
+	payload4Buckets := []model.StatsBucket{
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+		fixtures.RandomStatsBucket(5),
+	}
+	statsChannel <- payload4Buckets
+	expectedNumBuckets += 3
+	expectedNumBytes += calculateStatPayloadSize(payload4Buckets)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
+
+	close(statsChannel)
+	statsWriter.Stop()
+
+	// Then we expect some counts to have been sent to the stats client for each update tick (there should have been
+	// at least 3 ticks)
+	countSummaries := statsClient.GetCountSummaries()
+
+	// Payload counts
+	payloadSummary := countSummaries["datadog.trace_agent.stats_writer.payloads"]
+	assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
+	assert.Equal(expectedNumPayloads, payloadSummary.Sum)
+
+	// Traces counts
+	bucketsSummary := countSummaries["datadog.trace_agent.stats_writer.stats_buckets"]
+	assert.True(len(bucketsSummary.Calls) >= 3, "There should have been multiple stats_buckets count calls")
+	assert.Equal(expectedNumBuckets, bucketsSummary.Sum)
+
+	// Bytes counts
+	bytesSummary := countSummaries["datadog.trace_agent.stats_writer.bytes"]
+	assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
+	assert.Equal(expectedNumBytes, bytesSummary.Sum)
+
+	// Retry counts
+	retriesSummary := countSummaries["datadog.trace_agent.stats_writer.retries"]
+	assert.True(len(retriesSummary.Calls) >= 3, "There should have been multiple retries count calls")
+	assert.True(retriesSummary.Sum >= expectedMinNumRetries)
+
+	// Error counts
+	errorsSummary := countSummaries["datadog.trace_agent.stats_writer.errors"]
+	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
+	assert.Equal(expectedNumErrors, errorsSummary.Sum)
+}
+
+func calculateStatPayloadSize(buckets []model.StatsBucket) int64 {
+	statsPayload := &model.StatsPayload{
+		HostName: testHostName,
+		Env:      testEnv,
+		Stats:    buckets,
+	}
+
+	data, _ := model.EncodeStatsPayload(statsPayload)
+	return int64(len(data))
+}
+
+func assertStatsPayload(assert *assert.Assertions, headers map[string]string, buckets []model.StatsBucket,
+	payload *Payload) {
+	statsPayload := model.StatsPayload{}
+
+	reader := bytes.NewBuffer(payload.Bytes)
+	gzipReader, err := gzip.NewReader(reader)
+
+	assert.NoError(err, "Gzip reader should work correctly")
+
+	jsonDecoder := json.NewDecoder(gzipReader)
+
+	assert.NoError(jsonDecoder.Decode(&statsPayload), "Stats payload should unmarshal correctly")
+
+	assert.Equal(headers, payload.Headers, "Headers should match expectation")
+	assert.Equal(testHostName, statsPayload.HostName, "Hostname should match expectation")
+	assert.Equal(testEnv, statsPayload.Env, "Env should match expectation")
+	assert.Equal(buckets, statsPayload.Stats, "Stat buckets should match expectation")
+}
+
+func testStatsWriter() (*StatsWriter, chan []model.StatsBucket, *TestEndpoint, *statsd.TestStatsClient) {
+	statsChannel := make(chan []model.StatsBucket)
+	statsWriter := NewStatsWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, statsChannel)
+	testEndpoint := &TestEndpoint{}
+	statsWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
+	testStatsClient := &statsd.TestStatsClient{}
+	statsWriter.conf.StatsClient = testStatsClient
+
+	return statsWriter, statsChannel, testEndpoint, testStatsClient
+}

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -2,7 +2,6 @@ package writer
 
 import (
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -16,85 +15,119 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
-// TraceWriter ingests sampled traces and flush them to the API.
-type TraceWriter struct {
-	endpoint Endpoint
-
-	InTraces <-chan *model.Trace
-
-	traceBuffer []*model.APITrace
-
-	stats info.TraceWriterInfo
-
-	exit   chan struct{}
-	exitWG *sync.WaitGroup
-
-	conf *config.AgentConfig
+// TraceWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
+type TraceWriterConfig struct {
+	MaxSpansPerPayload int
+	FlushPeriod        time.Duration
+	UpdateInfoPeriod   time.Duration
+	StatsClient        statsd.StatsClient
 }
 
-// NewTraceWriter returns a new writer for traces.
-func NewTraceWriter(conf *config.AgentConfig, InTraces <-chan *model.Trace) *TraceWriter {
-	var endpoint Endpoint
-
-	if conf.APIEnabled {
-		client := NewClient(conf)
-		endpoint = NewDatadogEndpoint(client, conf.APIEndpoint, "/api/v0.2/traces", conf.APIKey)
-	} else {
-		log.Info("API interface is disabled, flushing to /dev/null instead")
-		endpoint = &NullEndpoint{}
+// DefaultTraceWriterConfig creates a new instance of a TraceWriterConfig using default values.
+func DefaultTraceWriterConfig() TraceWriterConfig {
+	return TraceWriterConfig{
+		MaxSpansPerPayload: 1000,
+		FlushPeriod:        5 * time.Second,
+		UpdateInfoPeriod:   1 * time.Minute,
+		StatsClient:        statsd.Client,
 	}
+}
 
+// TraceWriter ingests sampled traces and flushes them to the API.
+type TraceWriter struct {
+	hostName string
+	env      string
+	conf     TraceWriterConfig
+	InTraces <-chan *model.Trace
+	stats    info.TraceWriterInfo
+
+	traces        []*model.APITrace
+	spansInBuffer int
+
+	BaseWriter
+}
+
+// NewTraceWriter returns a new writer for traces following the provided agent configuration and using the provided
+// input trace channel.
+func NewTraceWriter(conf *config.AgentConfig, InTraces <-chan *model.Trace) *TraceWriter {
 	return &TraceWriter{
-		endpoint: endpoint,
-
-		traceBuffer: []*model.APITrace{},
-
-		exit:   make(chan struct{}),
-		exitWG: &sync.WaitGroup{},
-
-		InTraces: InTraces,
-
-		conf: conf,
+		hostName:   conf.HostName,
+		env:        conf.DefaultEnv,
+		conf:       DefaultTraceWriterConfig(),
+		InTraces:   InTraces,
+		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/traces"),
 	}
 }
 
 // Start starts the writer.
 func (w *TraceWriter) Start() {
+	w.BaseWriter.Start()
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
 	}()
 }
 
-// Run runs the main loop of the writer goroutine. If buffers payloads and
-// services read from input chans and flushes them when necessary.
+// Run runs the main loop of the writer goroutine. It sends traces to the payload constructor, flushing it periodically
+// and collects stats which are also reported periodically.
 func (w *TraceWriter) Run() {
 	w.exitWG.Add(1)
 	defer w.exitWG.Done()
 
 	// for now, simply flush every x seconds
-	flushTicker := time.NewTicker(5 * time.Second)
+	flushTicker := time.NewTicker(w.conf.FlushPeriod)
 	defer flushTicker.Stop()
 
-	updateInfoTicker := time.NewTicker(1 * time.Minute)
+	updateInfoTicker := time.NewTicker(w.conf.UpdateInfoPeriod)
 	defer updateInfoTicker.Stop()
+
+	// Monitor sender for events
+	go func() {
+		for event := range w.payloadSender.Monitor() {
+			if event == nil {
+				continue
+			}
+
+			switch event := event.(type) {
+			case SenderSuccessEvent:
+				log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", event.SendStats.SendTime,
+					len(event.Payload.Bytes))
+				w.conf.StatsClient.Gauge("datadog.trace_agent.trace_writer.flush_duration",
+					event.SendStats.SendTime.Seconds(), nil, 1)
+				atomic.AddInt64(&w.stats.Payloads, 1)
+			case SenderFailureEvent:
+				log.Errorf("failed to flush trace payload, time:%s, size:%d bytes, error: %s",
+					event.SendStats.SendTime, len(event.Payload.Bytes), event.Error)
+				atomic.AddInt64(&w.stats.Errors, 1)
+			case SenderRetryEvent:
+				log.Errorf("retrying flush trace payload, retryNum: %d, delay:%s, error: %s",
+					event.RetryNum, event.RetryDelay, event.Error)
+				atomic.AddInt64(&w.stats.Retries, 1)
+			default:
+				log.Debugf("don't know how to handle event with type %T", event)
+			}
+		}
+	}()
 
 	log.Debug("starting trace writer")
 
 	for {
 		select {
 		case trace := <-w.InTraces:
-			// no need for lock for now as flush is sequential
-			// TODO: async flush/retry
-			apiTrace := trace.APITrace()
-			w.traceBuffer = append(w.traceBuffer, apiTrace)
+			if trace == nil {
+				continue
+			}
+			w.handleTrace(trace)
 		case <-flushTicker.C:
-			w.Flush()
+			log.Debug("Flushing current traces")
+			w.flush()
 		case <-updateInfoTicker.C:
+			log.Debug("Updating info")
 			go w.updateInfo()
 		case <-w.exit:
 			log.Info("exiting trace writer, flushing all remaining traces")
-			w.Flush()
+			w.flush()
+			log.Info("Flushed. Exiting")
 			return
 		}
 	}
@@ -104,27 +137,72 @@ func (w *TraceWriter) Run() {
 func (w *TraceWriter) Stop() {
 	close(w.exit)
 	w.exitWG.Wait()
+	w.BaseWriter.Stop()
 }
 
-// Flush flushes traces the data in the API
-func (w *TraceWriter) Flush() {
-	traces := w.traceBuffer
-
-	if len(traces) == 0 {
-		log.Debugf("no trace to flush")
+func (w *TraceWriter) handleTrace(trace *model.Trace) {
+	if len(*trace) == 0 {
+		log.Debugf("Ignoring 0-length trace")
 		return
 	}
-	log.Debugf("going to flush %d traces", len(traces))
-	atomic.AddInt64(&w.stats.Traces, int64(len(traces)))
 
-	// Make the new buffer of the size of the previous one.
-	// that's a fair estimation and it should reduce allocations without using too much memory.
-	w.traceBuffer = make([]*model.APITrace, 0, len(traces))
+	log.Tracef("Handling new trace with %d spans: %v", len(*trace), trace)
+
+	spanOverflow := w.spansInBuffer + len(*trace) - w.conf.MaxSpansPerPayload
+
+	var splitTrace model.Trace
+
+	// If we overflow max spans per payload split last trace
+	// (necessarily the one that went over the limit otherwise we'd have split earlier)
+	if spanOverflow > 0 {
+		log.Debugf("Detected span overflow. Splitting trace: MaxSpansPerPayload=%d, len(trace)=%d, spanOverflow=%d",
+			w.conf.MaxSpansPerPayload, len(*trace), spanOverflow)
+		// Find the split index
+		splitIndex := len(*trace) - spanOverflow
+		log.Debugf("Splitting trace at index %d", splitIndex)
+		// Set the spans of the split trace to the ones over the split index
+		splitTrace = (*trace)[splitIndex:]
+		// Set the spans of the original to the ones below the split index so it ends up with a non-overflowing amount
+		// of traces
+		truncatedTrace := (*trace)[:splitIndex]
+		trace = &truncatedTrace
+	}
+
+	w.traces = append(w.traces, trace.APITrace())
+	w.spansInBuffer += len(*trace)
+	log.Debugf("Added new trace to buffer. spansInBuffer=%d, len(w.traces)=%d", w.spansInBuffer, len(w.traces))
+
+	if w.spansInBuffer == w.conf.MaxSpansPerPayload {
+		log.Debugf("Flushing because we reached max per payload")
+		// If current number of spans in buffer reached the limit, flush
+		w.flush()
+	} else if w.spansInBuffer > w.conf.MaxSpansPerPayload {
+		// Should never happen due to overflow detection above but just in case
+		panic("Number of spans in buffer went over the limit")
+	}
+
+	// Handle the split trace if it exists (this allows a single trace to be split multiple times)
+	if len(splitTrace) > 0 {
+		log.Debugf("Found split trace, handling it")
+		w.handleTrace(&splitTrace)
+	}
+}
+
+func (w *TraceWriter) flush() {
+	numTraces := len(w.traces)
+
+	// If no traces, we can't construct anything
+	if numTraces == 0 {
+		return
+	}
+
+	atomic.AddInt64(&w.stats.Traces, int64(numTraces))
+	atomic.AddInt64(&w.stats.Spans, int64(w.spansInBuffer))
 
 	tracePayload := model.TracePayload{
-		HostName: w.conf.HostName,
-		Env:      w.conf.DefaultEnv,
-		Traces:   traces,
+		HostName: w.hostName,
+		Env:      w.env,
+		Traces:   w.traces,
 	}
 
 	serialized, err := proto.Marshal(&tracePayload)
@@ -132,6 +210,7 @@ func (w *TraceWriter) Flush() {
 		log.Errorf("failed to serialize trace payload, data got dropped, err: %s", err)
 		return
 	}
+
 	atomic.AddInt64(&w.stats.Bytes, int64(len(serialized)))
 
 	// TODO: benchmark and pick the right encoding
@@ -142,24 +221,13 @@ func (w *TraceWriter) Flush() {
 		"Content-Encoding": "identity",
 	}
 
-	startFlush := time.Now()
+	payload := NewPayload(serialized, headers)
 
-	// Send the payload to the endpoint
-	err = w.endpoint.Write(serialized, headers)
+	w.payloadSender.Send(payload)
 
-	flushTime := time.Since(startFlush)
-
-	// TODO: if error, depending on why, replay later.
-	if err != nil {
-		atomic.AddInt64(&w.stats.Errors, 1)
-		log.Errorf("failed to flush trace payload, time:%s, size:%d bytes, error: %s", flushTime, len(serialized), err)
-		return
-	}
-
-	log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", flushTime, len(serialized))
-	statsd.Client.Gauge("datadog.trace_agent.trace_writer.flush_duration", flushTime.Seconds(), nil, 1)
-	atomic.AddInt64(&w.stats.Payloads, 1)
-
+	// Reset traces
+	w.traces = w.traces[:0]
+	w.spansInBuffer = 0
 }
 
 func (w *TraceWriter) updateInfo() {
@@ -168,13 +236,17 @@ func (w *TraceWriter) updateInfo() {
 	// Load counters and reset them for the next flush
 	twInfo.Payloads = atomic.SwapInt64(&w.stats.Payloads, 0)
 	twInfo.Traces = atomic.SwapInt64(&w.stats.Traces, 0)
+	twInfo.Spans = atomic.SwapInt64(&w.stats.Spans, 0)
 	twInfo.Bytes = atomic.SwapInt64(&w.stats.Bytes, 0)
-	twInfo.Errors = atomic.SwapInt64(&w.stats.Traces, 0)
+	twInfo.Retries = atomic.SwapInt64(&w.stats.Retries, 0)
+	twInfo.Errors = atomic.SwapInt64(&w.stats.Errors, 0)
 
-	statsd.Client.Count("datadog.trace_agent.trace_writer.payloads", int64(twInfo.Payloads), nil, 1)
-	statsd.Client.Count("datadog.trace_agent.trace_writer.traces", int64(twInfo.Traces), nil, 1)
-	statsd.Client.Count("datadog.trace_agent.trace_writer.bytes", int64(twInfo.Bytes), nil, 1)
-	statsd.Client.Count("datadog.trace_agent.trace_writer.errors", int64(twInfo.Errors), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.payloads", int64(twInfo.Payloads), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.traces", int64(twInfo.Traces), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.spans", int64(twInfo.Spans), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.bytes", int64(twInfo.Bytes), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.retries", int64(twInfo.Retries), nil, 1)
+	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.errors", int64(twInfo.Errors), nil, 1)
 
 	info.UpdateTraceWriterInfo(twInfo)
 }

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -1,0 +1,325 @@
+package writer
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/fixtures"
+	"github.com/DataDog/datadog-trace-agent/info"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/statsd"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+var testHostName = "testhost"
+var testEnv = "testenv"
+
+func TestTraceWriter_TraceHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
+	traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
+	traceWriter.conf.FlushPeriod = 100 * time.Millisecond
+
+	traceWriter.Start()
+
+	// Given a set of 6 test traces
+	testTraces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(3, 5),
+		fixtures.RandomTrace(3, 1),
+	}
+
+	// When sending those 6 traces
+	for _, trace := range testTraces {
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+
+	// And then waiting for more than flush period
+	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+
+	// And then sending another trace
+	afterTrace := fixtures.RandomTrace(2, 2)
+	testTraces = append(testTraces, afterTrace)
+	traceChannel <- &afterTrace
+
+	// And stopping trace writer before flush ticker ticks (should still flush on exit though)
+	close(traceChannel)
+	traceWriter.Stop()
+
+	// Then the endpoint should have received 2 payloads, containing all sent traces
+	expectedHeaders := map[string]string{
+		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+		"Content-Type":                 "application/x-protobuf",
+		"Content-Encoding":             "identity",
+	}
+
+	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
+	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads)
+}
+
+func TestTraceWriter_BigTraceHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
+	traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
+	traceWriter.conf.MaxSpansPerPayload = 3
+
+	traceWriter.Start()
+
+	// Given a set of 6 test traces
+	testTraces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(3, 5),
+		fixtures.RandomTrace(3, 1),
+	}
+
+	// When sending those 6 traces
+	for _, trace := range testTraces {
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+
+	// And stopping trace writer
+	close(traceChannel)
+	traceWriter.Stop()
+
+	// Then the endpoint should have received several payloads, containing all sent traces but not going over
+	// the span limit.
+	expectedHeaders := map[string]string{
+		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+		"Content-Type":                 "application/x-protobuf",
+		"Content-Encoding":             "identity",
+	}
+
+	numSpans := 0
+
+	for _, trace := range testTraces {
+		numSpans += len(trace)
+	}
+
+	expectedNumPayloads := int(math.Ceil(float64(numSpans) / float64(traceWriter.conf.MaxSpansPerPayload)))
+	assert.Len(testEndpoint.SuccessPayloads, expectedNumPayloads, "There should be more than 1 payload")
+	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads)
+}
+
+func TestTraceWriter_UpdateInfoHandling(t *testing.T) {
+	assert := assert.New(t)
+
+	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
+	traceWriter, traceChannel, testEndpoint, statsClient := testTraceWriter()
+	traceWriter.conf.FlushPeriod = 100 * time.Millisecond
+	traceWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
+
+	traceWriter.Start()
+
+	expectedNumPayloads := int64(0)
+	expectedNumSpans := int64(0)
+	expectedNumTraces := int64(0)
+	expectedNumBytes := int64(0)
+	expectedNumErrors := int64(0)
+	expectedMinNumRetries := int64(0)
+
+	// When sending 1 payload with 3 traces
+	expectedNumPayloads++
+	payload1Traces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+	}
+	for _, trace := range payload1Traces {
+		expectedNumTraces++
+		expectedNumSpans += int64(len(trace))
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+	expectedNumBytes += calculateTracePayloadSize(payload1Traces)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+
+	// And then sending a second payload with other 3 traces
+	expectedNumPayloads++
+	payload2Traces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+	}
+	for _, trace := range payload2Traces {
+		expectedNumTraces++
+		expectedNumSpans += int64(len(trace))
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+	expectedNumBytes += calculateTracePayloadSize(payload2Traces)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+
+	// And then sending a third payload with other 3 traces with an errored out endpoint
+	testEndpoint.Err = fmt.Errorf("non retriable error")
+	expectedNumErrors++
+	payload3Traces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+	}
+	for _, trace := range payload3Traces {
+		expectedNumTraces++
+		expectedNumSpans += int64(len(trace))
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+	expectedNumBytes += calculateTracePayloadSize(payload3Traces)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+
+	// And then sending a fourth payload with other 3 traces with an errored out endpoint but retriable
+	testEndpoint.Err = &RetriableError{
+		err:      fmt.Errorf("non retriable error"),
+		endpoint: testEndpoint,
+	}
+	expectedMinNumRetries++
+	payload4Traces := []model.Trace{
+		fixtures.RandomTrace(3, 1),
+		fixtures.RandomTrace(1, 3),
+		fixtures.RandomTrace(9, 3),
+	}
+	for _, trace := range payload4Traces {
+		expectedNumTraces++
+		expectedNumSpans += int64(len(trace))
+		traceCopy := trace
+		traceChannel <- &traceCopy
+	}
+	expectedNumBytes += calculateTracePayloadSize(payload4Traces)
+
+	// And waiting for twice the flush period to trigger payload sending and info updating
+	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+
+	close(traceChannel)
+	traceWriter.Stop()
+
+	// Then we expect some counts to have been sent to the stats client for each update tick (there should have been
+	// at least 3 ticks)
+	countSummaries := statsClient.GetCountSummaries()
+
+	// Payload counts
+	payloadSummary := countSummaries["datadog.trace_agent.trace_writer.payloads"]
+	assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
+	assert.Equal(expectedNumPayloads, payloadSummary.Sum)
+
+	// Traces counts
+	tracesSummary := countSummaries["datadog.trace_agent.trace_writer.traces"]
+	assert.True(len(tracesSummary.Calls) >= 3, "There should have been multiple traces count calls")
+	assert.Equal(expectedNumTraces, tracesSummary.Sum)
+
+	// Spans counts
+	spansSummary := countSummaries["datadog.trace_agent.trace_writer.spans"]
+	assert.True(len(spansSummary.Calls) >= 3, "There should have been multiple spans count calls")
+	assert.Equal(expectedNumSpans, spansSummary.Sum)
+
+	// Bytes counts
+	bytesSummary := countSummaries["datadog.trace_agent.trace_writer.bytes"]
+	assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
+	assert.Equal(expectedNumBytes, bytesSummary.Sum)
+
+	// Retry counts
+	retriesSummary := countSummaries["datadog.trace_agent.trace_writer.retries"]
+	assert.True(len(retriesSummary.Calls) >= 3, "There should have been multiple retries count calls")
+	assert.True(retriesSummary.Sum >= expectedMinNumRetries)
+
+	// Error counts
+	errorsSummary := countSummaries["datadog.trace_agent.trace_writer.errors"]
+	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
+	assert.Equal(expectedNumErrors, errorsSummary.Sum)
+}
+
+func calculateTracePayloadSize(traces []model.Trace) int64 {
+	apiTraces := make([]*model.APITrace, len(traces))
+
+	for i, trace := range traces {
+		apiTraces[i] = trace.APITrace()
+	}
+
+	tracePayload := model.TracePayload{
+		HostName: testHostName,
+		Env:      testEnv,
+		Traces:   apiTraces,
+	}
+
+	serialized, _ := proto.Marshal(&tracePayload)
+
+	return int64(len(serialized))
+}
+
+func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expectedHeaders map[string]string,
+	expectedTraces []model.Trace, payloads []Payload) {
+
+	seenAPITraces := []*model.APITrace(nil)
+	for _, payload := range payloads {
+		assert.Equal(expectedHeaders, payload.Headers, "Payload headers should match expectation")
+
+		var tracePayload model.TracePayload
+		assert.NoError(proto.Unmarshal(payload.Bytes, &tracePayload), "Unmarshalling should work correctly")
+
+		assert.Equal(testEnv, tracePayload.Env, "Envs should match")
+		assert.Equal(testHostName, tracePayload.HostName, "Hostnames should match")
+
+		numSpans := 0
+
+		for _, seenAPITrace := range tracePayload.Traces {
+			numSpans += len(seenAPITrace.Spans)
+			seenAPITraces = append(seenAPITraces, seenAPITrace)
+		}
+
+		assert.True(numSpans <= traceWriter.conf.MaxSpansPerPayload)
+	}
+
+	traceCount := 0
+
+	for _, trace := range expectedTraces {
+		for len(trace) > 0 {
+			seenAPITrace := seenAPITraces[traceCount]
+			seenAPITraceNumSpans := len(seenAPITrace.Spans)
+
+			expectedTrace := trace[:seenAPITraceNumSpans]
+
+			if seenAPITraceNumSpans < len(trace) {
+				trace = trace[seenAPITraceNumSpans:]
+			} else {
+				trace = nil
+			}
+
+			expectedTraceAPI := expectedTrace.APITrace()
+
+			assert.True(proto.Equal(expectedTraceAPI, seenAPITraces[traceCount]),
+				"Unmarshalled trace payload should match expectation at index %d", traceCount)
+			traceCount++
+		}
+	}
+
+}
+
+func testTraceWriter() (*TraceWriter, chan *model.Trace, *TestEndpoint, *statsd.TestStatsClient) {
+	traceChannel := make(chan *model.Trace)
+	traceWriter := NewTraceWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, traceChannel)
+	testEndpoint := &TestEndpoint{}
+	traceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
+	testStatsClient := &statsd.TestStatsClient{}
+	traceWriter.conf.StatsClient = testStatsClient
+
+	return traceWriter, traceChannel, testEndpoint, testStatsClient
+}

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,0 +1,57 @@
+package writer
+
+import (
+	"sync"
+
+	log "github.com/cihub/seelog"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+)
+
+// BaseWriter encodes the base components and behaviour of a typical Writer.
+type BaseWriter struct {
+	payloadSender PayloadSender
+
+	exit   chan struct{}
+	exitWG *sync.WaitGroup
+
+	conf *config.AgentConfig
+}
+
+// NewBaseWriter creates a new instance of a BaseWriter.
+func NewBaseWriter(conf *config.AgentConfig, path string) *BaseWriter {
+	return NewCustomSenderBaseWriter(conf, path, func(endpoint Endpoint) PayloadSender {
+		return NewQueuablePayloadSender(endpoint)
+	})
+}
+
+// NewCustomSenderBaseWriter creates a new instance of a BaseWriter with a custom sender.
+func NewCustomSenderBaseWriter(conf *config.AgentConfig, path string,
+	senderFactory func(Endpoint) PayloadSender) *BaseWriter {
+
+	var endpoint Endpoint
+
+	if conf.APIEnabled {
+		client := NewClient(conf)
+		endpoint = NewDatadogEndpoint(client, conf.APIEndpoint, path, conf.APIKey)
+	} else {
+		log.Info("API interface is disabled, flushing to /dev/null instead")
+		endpoint = &NullEndpoint{}
+	}
+
+	return &BaseWriter{
+		payloadSender: senderFactory(endpoint),
+		exit:          make(chan struct{}),
+		exitWG:        &sync.WaitGroup{},
+	}
+}
+
+// Start starts the necessary components of a BaseWriter.
+func (w *BaseWriter) Start() {
+	w.payloadSender.Start()
+}
+
+// Stop stops any the stoppable components of a BaseWriter.
+func (w *BaseWriter) Stop() {
+	w.payloadSender.Stop()
+}


### PR DESCRIPTION
Includes:
* More modular structure for extra code reuse and cleaner testing.
* Readdition of retriable errors.
* Async flushing of payloads handled by a PayloadSender.
* Addition of exponential jittery backoff timer used by default by the new PayloadSender.

Working on top of: https://github.com/DataDog/datadog-trace-agent/pull/343