### PR TITLE
writer: add transaction stream to trace writer

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,6 +64,7 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 	// inter-component channels
 	rawTraceChan := make(chan model.Trace, 5000) // about 1000 traces/sec for 5 sec, TODO: move to *model.Trace
 	sampledTraceChan := make(chan *model.Trace)
+	analyzedTransactionChan := make(chan *model.Span)
 	statsChan := make(chan []model.StatsBucket)
 	serviceChan := make(chan model.ServicesMetadata, 50)
 
@@ -76,14 +77,14 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 	)
 	f := filters.Setup(conf)
 
-	ss := NewScoreSampler(conf, sampledTraceChan)
+	ss := NewScoreSampler(conf, sampledTraceChan, analyzedTransactionChan)
 	var ps *Sampler
 	if conf.PrioritySampling {
 		// Use priority sampling for distributed tracing only if conf says so
 		// TODO: remove the option once comfortable ; as it is true by default.
-		ps = NewPrioritySampler(conf, dynConf, sampledTraceChan)
+		ps = NewPrioritySampler(conf, dynConf, sampledTraceChan, analyzedTransactionChan)
 	}
-	tw := writer.NewTraceWriter(conf, sampledTraceChan)
+	tw := writer.NewTraceWriter(conf, sampledTraceChan, analyzedTransactionChan)
 	sw := writer.NewStatsWriter(conf, statsChan)
 	svcW := writer.NewServiceWriter(conf, serviceChan)
 
@@ -111,7 +112,7 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 // Run starts routers routines and individual pieces then stop them when the exit order is received
 func (a *Agent) Run() {
 	// it's really important to use a ticker for this, and with a not too short
-	// interval, for this is our garantee that the process won't start and kill
+	// interval, for this is our guarantee that the process won't start and kill
 	// itself too fast (nightmare loop)
 	watchdogTicker := time.NewTicker(a.conf.WatchdogInterval)
 	defer watchdogTicker.Stop()

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -72,23 +72,22 @@ func (s *Sampler) Add(t processedTrace) {
 	}
 
 	// inspect the WeightedTrace so that we can identify top-level spans
-	// Only top-level spans are eligible to be analyzed
 	for _, span := range t.WeightedTrace {
-		if analyzeRate, ok := s.analyzedRateByService[span.Service]; ok {
-			s.Analyze(span, analyzeRate)
-		}
+		s.Analyze(span)
 	}
 }
 
 // Analyze queues a span for analysis, applying any sample rate specified
 // Only top-level spans are eligible to be analyzed
-func (s *Sampler) Analyze(span *model.WeightedSpan, sampleRate float64) {
+func (s *Sampler) Analyze(span *model.WeightedSpan) {
 	if !span.TopLevel {
 		return
 	}
 
-	if sampler.SampleByRate(span.TraceID, sampleRate) {
-		s.analyzed <- span.Span
+	if analyzeRate, ok := s.analyzedRateByService[span.Service]; ok {
+		if sampler.SampleByRate(span.TraceID, analyzeRate) {
+			s.analyzed <- span.Span
+		}
 	}
 }
 

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
-const SpanAnalyzedTransaction = "_analyzed_transaction"
+const spanAnalyzedTransaction = "_analyzed_transaction"
 
 // Sampler chooses wich spans to write to the API
 type Sampler struct {
@@ -69,7 +69,7 @@ func (s *Sampler) Add(t processedTrace) {
 	s.totalTraceCount++
 	if s.engine.Sample(t.Trace, t.Root, t.Env) {
 		s.keptTraceCount++
-		t.Root.Metrics[SpanAnalyzedTransaction] = 1
+		t.Root.Metrics[spanAnalyzedTransaction] = 1
 		s.sampled <- &t.Trace
 	}
 

--- a/agent/sampler.go
+++ b/agent/sampler.go
@@ -14,8 +14,6 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
-const spanAnalyzeRate = "_analyze_rate"
-
 // Sampler chooses wich spans to write to the API
 type Sampler struct {
 	sampled               chan *model.Trace

--- a/config/agent.go
+++ b/config/agent.go
@@ -72,7 +72,6 @@ type AgentConfig struct {
 
 	// transaction analytics
 	AnalyzedRateByService map[string]float64
-	AnalyzeWebServices    bool
 }
 
 // mergeEnv applies overrides from environment variables to the trace agent configuration
@@ -199,7 +198,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 
 		Ignore:                make(map[string][]string),
 		AnalyzedRateByService: make(map[string]float64),
-		AnalyzeWebServices:    true,
 	}
 
 	return ac
@@ -284,10 +282,6 @@ APM_CONF:
 
 	if v, e := conf.GetStrArray("trace.ignore", "resource", ','); e == nil {
 		c.Ignore["resource"] = v
-	}
-
-	if v := strings.ToLower(conf.GetDefault("trace.analytics", "analyze_web_transactions", "")); v == "no" || v == "false" {
-		c.AnalyzeWebServices = false
 	}
 
 	if v, e := conf.GetSection("trace.analyzed_rate_by_service"); e == nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -209,3 +209,19 @@ func TestGetHostname(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEqual(t, "", h)
 }
+
+func TestAnalyzedRateByService(t *testing.T) {
+	assert := assert.New(t)
+	config, _ := ini.Load([]byte(strings.Join([]string{
+		"[trace.analyzed_rate_by_service]",
+		"web = 0.8",
+		"intake = 0.05",
+		"bad_service = ",
+	}, "\n")))
+
+	conf := &File{instance: config, Path: "whatever"}
+	agentConfig, _ := NewAgentConfig(conf, nil)
+
+	assert.Equal(agentConfig.AnalyzedRateByService["web"], 0.8)
+	assert.Equal(agentConfig.AnalyzedRateByService["intake"], 0.05)
+}


### PR DESCRIPTION
Add a stream for "analyzed transactions" into the trace writer. This stream captures top-level spans for faceted analysis. Transactions can be sampled by rate per service, with `1.0` indicating that we should stream every root span for a service.

Configured by:

```
[trace.analyzed_rate_by_service]
web = 1.0
rpc = 0.2
```