### PR TITLE
Refactor service metadata pipeline

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -91,7 +91,6 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 	// wire components together
 	tw.InTraces = sampledTraceChan
 	sw.InStats = statsChan
-	svcW.InServices = serviceChan
 
 	return &Agent{
 		Receiver:         r,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -247,7 +247,7 @@ func (a *Agent) Process(t model.Trace) {
 
 	go func() {
 		defer watchdog.LogOnPanic()
-		a.ServiceExtractor.Process(t)
+		a.ServiceExtractor.Process(wt)
 	}()
 
 	go func() {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -38,14 +38,15 @@ func (pt *processedTrace) weight() float64 {
 
 // Agent struct holds all the sub-routines structs and make the data flow between them
 type Agent struct {
-	Receiver        *HTTPReceiver
-	Concentrator    *Concentrator
-	Filters         []filters.Filter
-	ScoreSampler    *Sampler
-	PrioritySampler *Sampler
-	TraceWriter     *writer.TraceWriter
-	ServiceWriter   *writer.ServiceWriter
-	StatsWriter     *writer.StatsWriter
+	Receiver         *HTTPReceiver
+	Concentrator     *Concentrator
+	Filters          []filters.Filter
+	ScoreSampler     *Sampler
+	PrioritySampler  *Sampler
+	TraceWriter      *writer.TraceWriter
+	ServiceWriter    *writer.ServiceWriter
+	StatsWriter      *writer.StatsWriter
+	ServiceExtractor *TraceServiceExtractor
 
 	// config
 	conf    *config.AgentConfig
@@ -79,6 +80,7 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 
 	ss := NewScoreSampler(conf, sampledTraceChan, analyzedTransactionChan)
 	ps := NewPrioritySampler(conf, dynConf, sampledTraceChan, analyzedTransactionChan)
+	se := NewTraceServiceExtractor(serviceChan)
 	tw := writer.NewTraceWriter(conf, sampledTraceChan, analyzedTransactionChan)
 	sw := writer.NewStatsWriter(conf, statsChan)
 	svcW := writer.NewServiceWriter(conf, serviceChan)
@@ -89,18 +91,19 @@ func NewAgent(conf *config.AgentConfig, exit chan struct{}) *Agent {
 	svcW.InServices = serviceChan
 
 	return &Agent{
-		Receiver:        r,
-		Concentrator:    c,
-		Filters:         f,
-		ScoreSampler:    ss,
-		PrioritySampler: ps,
-		TraceWriter:     tw,
-		StatsWriter:     sw,
-		ServiceWriter:   svcW,
-		conf:            conf,
-		dynConf:         dynConf,
-		exit:            exit,
-		die:             die,
+		Receiver:         r,
+		Concentrator:     c,
+		Filters:          f,
+		ScoreSampler:     ss,
+		PrioritySampler:  ps,
+		TraceWriter:      tw,
+		StatsWriter:      sw,
+		ServiceWriter:    svcW,
+		ServiceExtractor: se,
+		conf:             conf,
+		dynConf:          dynConf,
+		exit:             exit,
+		die:              die,
 	}
 }
 
@@ -236,6 +239,11 @@ func (a *Agent) Process(t model.Trace) {
 	if tenv := t.GetEnv(); tenv != "" {
 		pt.Env = tenv
 	}
+
+	go func() {
+		defer watchdog.LogOnPanic()
+		a.ServiceExtractor.Process(t)
+	}()
 
 	go func() {
 		defer watchdog.LogOnPanic()

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -145,6 +145,7 @@ func (a *Agent) Run() {
 			a.Concentrator.Stop()
 			a.TraceWriter.Stop()
 			a.StatsWriter.Stop()
+			a.ServiceMapper.Stop()
 			a.ServiceWriter.Stop()
 			a.ScoreSampler.Stop()
 			a.PrioritySampler.Stop()

--- a/agent/service_mapper.go
+++ b/agent/service_mapper.go
@@ -67,7 +67,7 @@ func (s *ServiceMapper) update(metadata model.ServicesMetadata) {
 	var changes model.ServicesMetadata
 
 	for k, v := range metadata {
-		if _, ok := s.cache[k]; ok {
+		if !s.shouldAdd(k, metadata) {
 			continue
 		}
 
@@ -86,4 +86,23 @@ func (s *ServiceMapper) update(metadata model.ServicesMetadata) {
 
 	s.out <- changes
 	s.cache.Merge(changes)
+}
+
+func (s *ServiceMapper) shouldAdd(service string, metadata model.ServicesMetadata) bool {
+	cacheEntry, ok := s.cache[service]
+
+	// No cache entry?
+	if !ok {
+		return true
+	}
+
+	// Cache entry came from service API?
+	if _, ok = cacheEntry[model.ServiceApp]; ok {
+		return false
+	}
+
+	// New metadata value came from service API?
+	_, ok = metadata[service][model.ServiceApp]
+
+	return ok
 }

--- a/agent/service_mapper.go
+++ b/agent/service_mapper.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/DataDog/datadog-trace-agent/watchdog"
+	log "github.com/cihub/seelog"
+)
+
+// ServiceMapper provides a cache layer over model.ServicesMetadata pipeline
+// Used in conjunction with ServiceWriter: in-> ServiceMapper out-> ServiceWriter
+type ServiceMapper struct {
+	in    <-chan model.ServicesMetadata
+	out   chan<- model.ServicesMetadata
+	exit  chan bool
+	done  sync.WaitGroup
+	cache model.ServicesMetadata
+}
+
+// NewServiceMapper returns an instance of ServiceMapper with the provided channels
+func NewServiceMapper(in <-chan model.ServicesMetadata, out chan<- model.ServicesMetadata) *ServiceMapper {
+	return &ServiceMapper{
+		in:    in,
+		out:   out,
+		exit:  make(chan bool),
+		cache: make(model.ServicesMetadata),
+	}
+}
+
+// Start runs the event loop in a non-blocking way
+func (s *ServiceMapper) Start() {
+	s.done.Add(1)
+
+	go func() {
+		defer watchdog.LogOnPanic()
+		s.Run()
+		s.done.Done()
+	}()
+}
+
+// Stop gracefully terminates the event-loop
+func (s *ServiceMapper) Stop() {
+	close(s.exit)
+	s.done.Wait()
+}
+
+// Run triggers the event-loop that consumes model.ServicesMeta
+func (s *ServiceMapper) Run() {
+	telemetryTicker := time.NewTicker(1 * time.Minute)
+	defer telemetryTicker.Stop()
+
+	for {
+		select {
+		case metadata := <-s.in:
+			s.update(metadata)
+		case <-telemetryTicker.C:
+			log.Infof("total number of tracked services: %d", len(s.cache))
+		case <-s.exit:
+			return
+		}
+	}
+}
+
+func (s *ServiceMapper) update(metadata model.ServicesMetadata) {
+	var changes model.ServicesMetadata
+
+	for k, v := range metadata {
+		if _, ok := s.cache[k]; ok {
+			continue
+		}
+
+		// We do this inside the for loop to avoid unecessary memory allocations.
+		// After few method executions, the cache will be warmed up and this section be skipped altogether.
+		if changes == nil {
+			changes = make(model.ServicesMetadata)
+		}
+
+		changes[k] = v
+	}
+
+	if changes == nil {
+		return
+	}
+
+	s.out <- changes
+	s.cache.Merge(changes)
+}

--- a/agent/service_mapper_test.go
+++ b/agent/service_mapper_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceMapper(t *testing.T) {
+	assert := assert.New(t)
+
+	mapper, in, out := testMapper()
+	mapper.Start()
+	defer mapper.Stop()
+
+	// Let's ensure we have a proper context
+	assert.Len(mapper.cache, 0)
+
+	input := model.ServicesMetadata{"service-a": {"app_type": "type-a"}}
+	in <- input
+	output := <-out
+
+	// When the service is ingested for the first time, we simply propagate it
+	// to the output channel and add an entry to the cache map
+	assert.Equal(input, output)
+	assert.Len(mapper.cache, 1)
+
+	// This entry will result in a cache-hit and therefore will be filtered out
+	in <- model.ServicesMetadata{"service-a": {"app_type": "SOMETHING_DIFFERENT"}}
+
+	// This represents a new service and thus will be cached and propagated to the outbound channel
+	newService := model.ServicesMetadata{"service-b": {"app_type": "type-b"}}
+	in <- newService
+	output = <-out
+
+	assert.Equal(newService, output)
+	assert.Len(mapper.cache, 2)
+}
+
+func testMapper() (mapper *ServiceMapper, in, out chan model.ServicesMetadata) {
+	in = make(chan model.ServicesMetadata, 1)
+	out = make(chan model.ServicesMetadata, 1)
+	mapper = NewServiceMapper(in, out)
+
+	return mapper, in, out
+}

--- a/agent/trace_service_extractor.go
+++ b/agent/trace_service_extractor.go
@@ -15,11 +15,11 @@ func NewTraceServiceExtractor(out chan<- model.ServicesMetadata) *TraceServiceEx
 }
 
 // Process extracts service metadata from top-level spans and sends it downstream
-func (ts *TraceServiceExtractor) Process(t model.Trace) {
+func (ts *TraceServiceExtractor) Process(t model.WeightedTrace) {
 	meta := make(model.ServicesMetadata)
 
 	for _, s := range t {
-		if !s.TopLevel() {
+		if !s.TopLevel {
 			continue
 		}
 

--- a/agent/trace_service_extractor.go
+++ b/agent/trace_service_extractor.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/DataDog/datadog-trace-agent/model"
+)
+
+// TraceServiceExtractor extracts service metadata from top-level spans
+type TraceServiceExtractor struct {
+	outServices chan<- model.ServicesMetadata
+}
+
+// NewTraceServiceExtractor returns a new TraceServiceExtractor
+func NewTraceServiceExtractor(out chan<- model.ServicesMetadata) *TraceServiceExtractor {
+	return &TraceServiceExtractor{out}
+}
+
+// Process extracts service metadata from top-level spans and sends it downstream
+func (ts *TraceServiceExtractor) Process(t model.Trace) {
+	meta := make(model.ServicesMetadata)
+
+	for _, s := range t {
+		if !s.TopLevel() {
+			continue
+		}
+
+		if _, ok := meta[s.Service]; ok {
+			continue
+		}
+
+		if v := s.Type; len(v) > 0 {
+			meta[s.Service] = map[string]string{model.AppType: v}
+		}
+	}
+
+	if len(meta) > 0 {
+		ts.outServices <- meta
+	}
+}

--- a/agent/trace_service_extractor_test.go
+++ b/agent/trace_service_extractor_test.go
@@ -21,9 +21,10 @@ func TestTracerServiceExtractor(t *testing.T) {
 	}
 
 	trace.ComputeTopLevel()
+	wt := model.NewWeightedTrace(trace, trace[0])
 
 	go func() {
-		testExtractor.Process(trace)
+		testExtractor.Process(wt)
 	}()
 
 	metadata := <-testChan

--- a/agent/trace_service_extractor_test.go
+++ b/agent/trace_service_extractor_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTracerServiceExtractor(t *testing.T) {
+	assert := assert.New(t)
+
+	testChan := make(chan model.ServicesMetadata)
+	testExtractor := NewTraceServiceExtractor(testChan)
+
+	trace := model.Trace{
+		&model.Span{TraceID: 1, SpanID: 1, ParentID: 0, Service: "service-a", Type: "type-a"},
+		&model.Span{TraceID: 1, SpanID: 2, ParentID: 1, Service: "service-b", Type: "type-b"},
+		&model.Span{TraceID: 1, SpanID: 3, ParentID: 1, Service: "service-c", Type: "type-c"},
+		&model.Span{TraceID: 1, SpanID: 4, ParentID: 3, Service: "service-c", Type: "ignore"},
+	}
+
+	trace.ComputeTopLevel()
+
+	go func() {
+		testExtractor.Process(trace)
+	}()
+
+	metadata := <-testChan
+
+	// Result should only contain information derived from top-level spans
+	assert.Equal(metadata, model.ServicesMetadata{
+		"service-a": {"app_type": "type-a"},
+		"service-b": {"app_type": "type-b"},
+		"service-c": {"app_type": "type-c"},
+	})
+}

--- a/model/services.go
+++ b/model/services.go
@@ -12,6 +12,9 @@ import (
 // ServicesMetadata is a standard key/val meta map attached to each named service
 type ServicesMetadata map[string]map[string]string
 
+// AppType is one of the pieces of information embedded in ServiceMetadata
+const AppType = "app_type"
+
 // Update compares this metadata blob with the one given in the argument
 // if different, update s1 and return true. If equal, return false
 func (s1 ServicesMetadata) Update(s2 ServicesMetadata) bool {

--- a/model/services.go
+++ b/model/services.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 )
 
 //go:generate msgp -marshal=false
@@ -14,21 +13,6 @@ type ServicesMetadata map[string]map[string]string
 
 // AppType is one of the pieces of information embedded in ServiceMetadata
 const AppType = "app_type"
-
-// Update compares this metadata blob with the one given in the argument
-// if different, update s1 and return true. If equal, return false
-func (s1 ServicesMetadata) Update(s2 ServicesMetadata) bool {
-	updated := false
-
-	for s, metas := range s2 {
-		if !reflect.DeepEqual(s1[s], metas) {
-			s1[s] = metas
-			updated = true
-		}
-	}
-
-	return updated
-}
 
 // Merge adds all entries from s2 to s1
 func (s1 ServicesMetadata) Merge(s2 ServicesMetadata) {

--- a/model/services.go
+++ b/model/services.go
@@ -14,6 +14,9 @@ type ServicesMetadata map[string]map[string]string
 // AppType is one of the pieces of information embedded in ServiceMetadata
 const AppType = "app_type"
 
+// ServiceApp represents the app to which certain integration belongs to
+const ServiceApp = "app"
+
 // Merge adds all entries from s2 to s1
 func (s1 ServicesMetadata) Merge(s2 ServicesMetadata) {
 	for k, v := range s2 {

--- a/model/services.go
+++ b/model/services.go
@@ -30,6 +30,13 @@ func (s1 ServicesMetadata) Update(s2 ServicesMetadata) bool {
 	return updated
 }
 
+// Merge adds all entries from s2 to s1
+func (s1 ServicesMetadata) Merge(s2 ServicesMetadata) {
+	for k, v := range s2 {
+		s1[k] = v
+	}
+}
+
 // EncodeServicesPayload will return a slice of bytes representing the
 // services metadata, this uses the same versioned endpoint that AgentPayload
 // uses for serialization.

--- a/model/services_test.go
+++ b/model/services_test.go
@@ -6,59 +6,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestServiceMetadataNotUpdated(t *testing.T) {
-	// metadata should not change
-	metas := make(ServicesMetadata)
-	metas["web-server"] = make(map[string]string)
-	metas["web-server"]["app_type"] = "web"
-	metas["web-server"]["app"] = "pylons"
+func TestMerge(t *testing.T) {
+	assert := assert.New(t)
 
-	metas2 := make(ServicesMetadata)
-	metas2["web-server"] = make(map[string]string)
-	metas2["web-server"]["app_type"] = "web"
-	metas2["web-server"]["app"] = "pylons"
+	s1 := ServicesMetadata{
+		"web-server": {"app_type": "web"},
+		"memcached":  {"app_type": "cache"},
+	}
 
-	assert.False(t, metas.Update(metas2))
-}
+	s2 := ServicesMetadata{
+		"web-server": {"app_type": "custom"},
+		"mysql":      {"app_type": "db"},
+	}
 
-func TestServiceMetadataUpdated(t *testing.T) {
-	// metadata should be updated
-	metas := make(ServicesMetadata)
-	metas["web-server"] = make(map[string]string)
-	metas["web-server"]["app_type"] = "web"
-	metas["web-server"]["app"] = "pylons"
+	s1.Merge(s2)
 
-	metas2 := make(ServicesMetadata)
-	metas2["web-server"] = make(map[string]string)
-	metas2["web-server"]["app_type"] = "web"
-	metas2["web-server"]["app"] = "rails"
-
-	assert.True(t, metas.Update(metas2))
-	assert.Equal(t, "rails", metas["web-server"]["app"])
-}
-
-func TestServiceMetadataPartial(t *testing.T) {
-	// metadata should be updated
-	metas := make(ServicesMetadata)
-	metas["web-server"] = make(map[string]string)
-	metas["web-server"]["app_type"] = "web"
-	metas["web-server"]["app"] = "pylons"
-	metas["postgres"] = make(map[string]string)
-	metas["postgres"]["app_type"] = "db"
-	metas["postgres"]["app"] = "postgres"
-
-	metas2 := make(ServicesMetadata)
-	metas2["web-server"] = make(map[string]string)
-	metas2["web-server"]["app_type"] = "web"
-	metas2["web-server"]["app"] = "pylons"
-
-	assert.False(t, metas.Update(metas2))
-}
-
-func TestServiceMetadataEmpty(t *testing.T) {
-	// metadata should not be updated
-	metas := make(ServicesMetadata)
-	metas2 := make(ServicesMetadata)
-
-	assert.False(t, metas.Update(metas2))
+	assert.Equal(ServicesMetadata{
+		"web-server": {"app_type": "custom"},
+		"memcached":  {"app_type": "cache"},
+		"mysql":      {"app_type": "db"},
+	}, s1)
 }


### PR DESCRIPTION
This PR adds `TraceServiceExtractor` to our trace processing pipeline. The idea is extract service metadata out of all top-level spans belonging to a given trace and send them downstream (to `ServiceWriter`).

By doing this we intend to simplify instrumentation on the client side, since we no longer require service metadata to be set at the tracer level.

#### Update

Based on feedback from @LotharSee and @ufoot I've made the following changes:

* Created `ServiceMapper` which should be now the entry point for ingesting `ServicesMetadata` (either coming from HTTP requests or from metadata embedded on traces). `ServiceMapper` is just a cache layer around `ServiceWriter`;
* Removed caching functionality/`DeepEqual` logic from `ServiceWriter`;