### PR TITLE
Allow configuration of trace, stats and service writers.

### DIFF
--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -71,3 +71,86 @@ oldest_span_cutoff_seconds=30
 receiver_port=8126
 # how many unique connections to allow during one 30 second lease period
 connection_limit=2000
+
+###################################################
+# Trace writer - combines traces into payloads
+# that are sent to Datadog servers
+###################################################
+[trace.writer.traces]
+# Information about different traces is batched together for performance reasons. This setting controls the maximum
+# amount of spans inside one of these batches. Bigger values lead to fewer but bigger payloads.
+max_spans_per_payload=1000
+# Period with which the agent forces flushes of payloads. In case the previous limit is not reached within this
+# period, a payload with less than max_spans_per_payload will be sent.
+flush_period_seconds=5
+# Period with which the agent will send updated trace writer statistics to DD servers.
+update_info_period_seconds=60
+# For how many seconds should we keep traces queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: 20 minutes
+queue_max_age_seconds=1200
+# Maximum amount of trace data we can have queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: 256MB
+queue_max_bytes=268435456
+# Maximum amount of trace payloads we can have queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: Unlimited
+queue_max_payloads=-1
+# When we are unable to send traces to DD servers, retries will be attempted with various delays. Each retry delay
+# is determined by a full-jitter exponential backoff that performs the following computation:
+# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
+# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
+# MaxDuration and will also be desynchronized with retrial processes of other agents.
+# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
+exp_backoff_max_duration_seconds=120
+exp_backoff_base_milliseconds=200
+exp_backoff_growth_base=2
+
+###################################################
+# Service writer - extracts service info from
+# traces and sends it to Datadog servers.
+###################################################
+[trace.writer.services]
+# Period with which the agent flushes service info to DD servers.
+flush_period_seconds=5
+# Period with which the agent will send updated service writer statistics to DD servers.
+update_info_period_seconds=60
+# When we are unable to send service info to DD servers, retries will be attempted with various delays. Each retry delay
+# is determined by a full-jitter exponential backoff that performs the following computation:
+# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
+# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
+# MaxDuration and will also be desynchronized with retrial processes of other agents.
+# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
+exp_backoff_max_duration_seconds=120
+exp_backoff_base_milliseconds=200
+exp_backoff_growth_base=2
+
+###################################################
+# Stat writer - aggregates stats about traces
+# and sends them to Datadog servers
+###################################################
+[trace.writer.stats]
+# Period with which the agent will send updated stat writer statistics to DD servers.
+update_info_period_seconds=60
+# For how many seconds should we keep stats payloads queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: 20 minutes
+queue_max_age_seconds=1200
+# Maximum amount of stats data we can have queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: 256MB
+queue_max_bytes=268435456
+# Maximum amount of stats payloads we can have queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: Unlimited
+queue_max_payloads=-1
+# When we are unable to send stats to DD servers, retries will be attempted with various delays. Each retry delay
+# is determined by a full-jitter exponential backoff that performs the following computation:
+# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
+# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
+# MaxDuration and will also be desynchronized with retrial processes of other agents.
+# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
+exp_backoff_max_duration_seconds=120
+exp_backoff_base_milliseconds=200
+exp_backoff_growth_base=2

--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -83,8 +83,6 @@ max_spans_per_payload=1000
 # Period with which the agent forces flushes of payloads. In case the previous limit is not reached within this
 # period, a payload with less than max_spans_per_payload will be sent.
 flush_period_seconds=5
-# Period with which the agent will send updated trace writer statistics to DD servers.
-update_info_period_seconds=60
 # For how many seconds should we keep traces queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
 # Default: 20 minutes
@@ -97,15 +95,6 @@ queue_max_bytes=268435456
 # A value <= 0 disables this limit
 # Default: Unlimited
 queue_max_payloads=-1
-# When we are unable to send traces to DD servers, retries will be attempted with various delays. Each retry delay
-# is determined by a full-jitter exponential backoff that performs the following computation:
-# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
-# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
-# MaxDuration and will also be desynchronized with retrial processes of other agents.
-# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
-exp_backoff_max_duration_seconds=120
-exp_backoff_base_milliseconds=200
-exp_backoff_growth_base=2
 
 ###################################################
 # Service writer - extracts service info from
@@ -114,25 +103,12 @@ exp_backoff_growth_base=2
 [trace.writer.services]
 # Period with which the agent flushes service info to DD servers.
 flush_period_seconds=5
-# Period with which the agent will send updated service writer statistics to DD servers.
-update_info_period_seconds=60
-# When we are unable to send service info to DD servers, retries will be attempted with various delays. Each retry delay
-# is determined by a full-jitter exponential backoff that performs the following computation:
-# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
-# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
-# MaxDuration and will also be desynchronized with retrial processes of other agents.
-# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
-exp_backoff_max_duration_seconds=120
-exp_backoff_base_milliseconds=200
-exp_backoff_growth_base=2
 
 ###################################################
 # Stat writer - aggregates stats about traces
 # and sends them to Datadog servers
 ###################################################
 [trace.writer.stats]
-# Period with which the agent will send updated stat writer statistics to DD servers.
-update_info_period_seconds=60
 # For how many seconds should we keep stats payloads queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
 # Default: 20 minutes
@@ -145,12 +121,3 @@ queue_max_bytes=268435456
 # A value <= 0 disables this limit
 # Default: Unlimited
 queue_max_payloads=-1
-# When we are unable to send stats to DD servers, retries will be attempted with various delays. Each retry delay
-# is determined by a full-jitter exponential backoff that performs the following computation:
-# delay = Random(0, Min(MaxDuration, (GrowthBase ^ NumRetries) * Base))
-# The idea is that each consecutive retry for the same payload will, on average, take longer and longer until reaching
-# MaxDuration and will also be desynchronized with retrial processes of other agents.
-# The following parameters enable you to configure MaxDuration, Base and GrowthBase, respectively.
-exp_backoff_max_duration_seconds=120
-exp_backoff_base_milliseconds=200
-exp_backoff_growth_base=2

--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -83,18 +83,10 @@ max_spans_per_payload=1000
 # Period with which the agent forces flushes of payloads. In case the previous limit is not reached within this
 # period, a payload with less than max_spans_per_payload will be sent.
 flush_period_seconds=5
-# For how many seconds should we keep traces queued up in case we are unable to send them to DD servers.
-# A value <= 0 disables this limit
-# Default: 20 minutes
-queue_max_age_seconds=1200
 # Maximum amount of trace data we can have queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
 # Default: 256MB
 queue_max_bytes=268435456
-# Maximum amount of trace payloads we can have queued up in case we are unable to send them to DD servers.
-# A value <= 0 disables this limit
-# Default: Unlimited
-queue_max_payloads=-1
 
 ###################################################
 # Service writer - extracts service info from
@@ -109,15 +101,7 @@ flush_period_seconds=5
 # and sends them to Datadog servers
 ###################################################
 [trace.writer.stats]
-# For how many seconds should we keep stats payloads queued up in case we are unable to send them to DD servers.
-# A value <= 0 disables this limit
-# Default: 20 minutes
-queue_max_age_seconds=1200
 # Maximum amount of stats data we can have queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
 # Default: 256MB
 queue_max_bytes=268435456
-# Maximum amount of stats payloads we can have queued up in case we are unable to send them to DD servers.
-# A value <= 0 disables this limit
-# Default: Unlimited
-queue_max_payloads=-1

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -29,12 +29,12 @@ func DefaultExponentialDelayProvider() DelayProvider {
 
 // ExponentialDelayProvider creates a new instance of an ExponentialDelayProvider using the provided config.
 func ExponentialDelayProvider(conf ExponentialConfig) DelayProvider {
-	return ExponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(time.Now().UnixNano())))
+	return exponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(time.Now().UnixNano())))
 }
 
-// ExponentialDelayProviderCustomRandom creates a new instance of ExponentialDelayProvider using the provided config
+// exponentialDelayProviderCustomRandom creates a new instance of ExponentialDelayProvider using the provided config
 // and random number generator.
-func ExponentialDelayProviderCustomRandom(conf ExponentialConfig, rand *rand.Rand) DelayProvider {
+func exponentialDelayProviderCustomRandom(conf ExponentialConfig, rand *rand.Rand) DelayProvider {
 	return func(numRetries int, _ error) time.Duration {
 		pow := math.Pow(float64(conf.GrowthBase), float64(numRetries))
 

--- a/backoff/exponential.go
+++ b/backoff/exponential.go
@@ -11,7 +11,6 @@ type ExponentialConfig struct {
 	MaxDuration time.Duration
 	GrowthBase  int
 	Base        time.Duration
-	Random      *rand.Rand
 }
 
 // DefaultExponentialConfig creates an ExponentialConfig with default values.
@@ -19,8 +18,7 @@ func DefaultExponentialConfig() ExponentialConfig {
 	return ExponentialConfig{
 		MaxDuration: 120 * time.Second,
 		GrowthBase:  2,
-		Base:        time.Second,
-		Random:      rand.New(rand.NewSource(time.Now().UnixNano())),
+		Base:        200 * time.Millisecond,
 	}
 }
 
@@ -31,6 +29,12 @@ func DefaultExponentialDelayProvider() DelayProvider {
 
 // ExponentialDelayProvider creates a new instance of an ExponentialDelayProvider using the provided config.
 func ExponentialDelayProvider(conf ExponentialConfig) DelayProvider {
+	return ExponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(time.Now().UnixNano())))
+}
+
+// ExponentialDelayProviderCustomRandom creates a new instance of ExponentialDelayProvider using the provided config
+// and random number generator.
+func ExponentialDelayProviderCustomRandom(conf ExponentialConfig, rand *rand.Rand) DelayProvider {
 	return func(numRetries int, _ error) time.Duration {
 		pow := math.Pow(float64(conf.GrowthBase), float64(numRetries))
 
@@ -52,7 +56,7 @@ func ExponentialDelayProvider(conf ExponentialConfig) DelayProvider {
 			newExpDuration = conf.MaxDuration
 		}
 
-		return time.Duration(conf.Random.Int63n(int64(newExpDuration)))
+		return time.Duration(rand.Int63n(int64(newExpDuration)))
 	}
 }
 

--- a/backoff/exponential_test.go
+++ b/backoff/exponential_test.go
@@ -33,7 +33,7 @@ func TestExponentialDelay(t *testing.T) {
 	}
 
 	// Use fixed random to prevent flakiness in case the CI has very bad luck
-	delayProvider := ExponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(1234)))
+	delayProvider := exponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(1234)))
 
 	prevMax := int64(0)
 

--- a/backoff/exponential_test.go
+++ b/backoff/exponential_test.go
@@ -30,11 +30,10 @@ func TestExponentialDelay(t *testing.T) {
 		MaxDuration: 120 * time.Nanosecond,
 		GrowthBase:  2,
 		Base:        time.Nanosecond,
-		// Use fixed random to prevent flakiness in case the CI has very bad luck
-		Random: rand.New(rand.NewSource(1234)),
 	}
 
-	delayProvider := ExponentialDelayProvider(conf)
+	// Use fixed random to prevent flakiness in case the CI has very bad luck
+	delayProvider := ExponentialDelayProviderCustomRandom(conf, rand.New(rand.NewSource(1234)))
 
 	prevMax := int64(0)
 

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,16 @@ func (c *File) GetInt(section, name string) (int, error) {
 	return value, nil
 }
 
+// GetInt64 gets a 64-bit integer value from section/name, or an error if it is missing
+// or cannot be converted to an integer.
+func (c *File) GetInt64(section, name string) (int64, error) {
+	value, err := c.instance.Section(section).Key(name).Int64()
+	if err != nil {
+		return 0, fmt.Errorf("missing `%s` value in [%s] section", name, section)
+	}
+	return value, nil
+}
+
 // GetFloat gets an float value from section/name, or an error if it is missing
 // or cannot be converted to an float.
 func (c *File) GetFloat(section, name string) (float64, error) {

--- a/writer/config/payload.go
+++ b/writer/config/payload.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-trace-agent/backoff"
+)
+
+// QueuablePayloadSenderConf contains the configuration needed by a QueuablePayloadSender to operate.
+type QueuablePayloadSenderConf struct {
+	MaxAge             time.Duration
+	MaxQueuedBytes     int64
+	MaxQueuedPayloads  int
+	ExponentialBackoff backoff.ExponentialConfig
+}
+
+// DefaultQueuablePayloadSenderConf constructs a QueuablePayloadSenderConf with default sane options.
+func DefaultQueuablePayloadSenderConf() QueuablePayloadSenderConf {
+	return QueuablePayloadSenderConf{
+		MaxAge:             20 * time.Minute,
+		MaxQueuedBytes:     256 * 1024 * 1024, // 256 MB
+		MaxQueuedPayloads:  -1,                // Unlimited
+		ExponentialBackoff: backoff.DefaultExponentialConfig(),
+	}
+}

--- a/writer/config/service_writer.go
+++ b/writer/config/service_writer.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"time"
+)
+
+// ServiceWriterConfig contains the configuration to customize the behaviour of a ServiceWriter.
+type ServiceWriterConfig struct {
+	FlushPeriod      time.Duration
+	UpdateInfoPeriod time.Duration
+	SenderConfig     QueuablePayloadSenderConf
+}
+
+// DefaultServiceWriterConfig creates a new instance of a ServiceWriterConfig using default values.
+func DefaultServiceWriterConfig() ServiceWriterConfig {
+	return ServiceWriterConfig{
+		FlushPeriod:      5 * time.Second,
+		UpdateInfoPeriod: 1 * time.Minute,
+		SenderConfig:     DefaultQueuablePayloadSenderConf(),
+	}
+}

--- a/writer/config/stats_writer.go
+++ b/writer/config/stats_writer.go
@@ -1,0 +1,17 @@
+package config
+
+import "time"
+
+// StatsWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
+type StatsWriterConfig struct {
+	UpdateInfoPeriod time.Duration
+	SenderConfig     QueuablePayloadSenderConf
+}
+
+// DefaultStatsWriterConfig creates a new instance of a StatsWriterConfig using default values.
+func DefaultStatsWriterConfig() StatsWriterConfig {
+	return StatsWriterConfig{
+		UpdateInfoPeriod: 1 * time.Minute,
+		SenderConfig:     DefaultQueuablePayloadSenderConf(),
+	}
+}

--- a/writer/config/trace_writer.go
+++ b/writer/config/trace_writer.go
@@ -1,0 +1,21 @@
+package config
+
+import "time"
+
+// TraceWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
+type TraceWriterConfig struct {
+	MaxSpansPerPayload int
+	FlushPeriod        time.Duration
+	UpdateInfoPeriod   time.Duration
+	SenderConfig       QueuablePayloadSenderConf
+}
+
+// DefaultTraceWriterConfig creates a new instance of a TraceWriterConfig using default values.
+func DefaultTraceWriterConfig() TraceWriterConfig {
+	return TraceWriterConfig{
+		MaxSpansPerPayload: 1000,
+		FlushPeriod:        5 * time.Second,
+		UpdateInfoPeriod:   1 * time.Minute,
+		SenderConfig:       DefaultQueuablePayloadSenderConf(),
+	}
+}

--- a/writer/payload_test.go
+++ b/writer/payload_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-trace-agent/backoff"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -69,9 +70,9 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer
-	conf := DefaultQueuablePayloadSenderConf()
-	conf.BackoffTimer = testBackoffTimer
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 
@@ -168,10 +169,10 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer and with a meager max queued payloads value of 1
-	conf := DefaultQueuablePayloadSenderConf()
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedPayloads = 1
-	conf.BackoffTimer = testBackoffTimer
 	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 
@@ -238,10 +239,10 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
-	conf := DefaultQueuablePayloadSenderConf()
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	conf.BackoffTimer = testBackoffTimer
 	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 
@@ -307,10 +308,10 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
-	conf := DefaultQueuablePayloadSenderConf()
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	conf.BackoffTimer = testBackoffTimer
 	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 
@@ -363,10 +364,10 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
-	conf := DefaultQueuablePayloadSenderConf()
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	conf.BackoffTimer = testBackoffTimer
 	queuableSender := NewCustomQueuablePayloadSender(workingEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 
@@ -409,10 +410,10 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	testBackoffTimer := backoff.NewTestBackoffTimer()
 
 	// And a queuable sender using said endpoint and timer and with a meager max age of 100ms
-	conf := DefaultQueuablePayloadSenderConf()
+	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxAge = 100 * time.Millisecond
-	conf.BackoffTimer = testBackoffTimer
 	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
 

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -29,6 +29,8 @@ type ServiceWriter struct {
 // NewServiceWriter returns a new writer for services.
 func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.ServicesMetadata) *ServiceWriter {
 	writerConf := conf.ServiceWriterConfig
+	log.Infof("Service writer initializing with config: %+v", writerConf)
+
 	return &ServiceWriter{
 		conf:          writerConf,
 		InServices:    InServices,

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -10,29 +10,13 @@ import (
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 )
-
-// ServiceWriterConfig contains the configuration to customize the behaviour of a ServiceWriter.
-type ServiceWriterConfig struct {
-	FlushPeriod      time.Duration
-	UpdateInfoPeriod time.Duration
-	StatsClient      statsd.StatsClient
-}
-
-// DefaultServiceWriterConfig creates a new instance of a ServiceWriterConfig using default values.
-func DefaultServiceWriterConfig() ServiceWriterConfig {
-	return ServiceWriterConfig{
-		FlushPeriod:      5 * time.Second,
-		UpdateInfoPeriod: 1 * time.Minute,
-		StatsClient:      statsd.Client,
-	}
-}
 
 // ServiceWriter ingests service metadata and flush them to the API.
 type ServiceWriter struct {
-	conf       ServiceWriterConfig
+	conf       writerconfig.ServiceWriterConfig
 	InServices <-chan model.ServicesMetadata
 	stats      info.ServiceWriterInfo
 
@@ -44,14 +28,19 @@ type ServiceWriter struct {
 
 // NewServiceWriter returns a new writer for services.
 func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.ServicesMetadata) *ServiceWriter {
+	writerConf := conf.ServiceWriterConfig
 	return &ServiceWriter{
-		conf:          DefaultServiceWriterConfig(),
+		conf:          writerConf,
 		InServices:    InServices,
 		serviceBuffer: model.ServicesMetadata{},
-		BaseWriter: *NewCustomSenderBaseWriter(conf, "/api/v0.2/services", func(endpoint Endpoint) PayloadSender {
-			conf := DefaultQueuablePayloadSenderConf()
-			conf.MaxQueuedPayloads = 1
-			return NewCustomQueuablePayloadSender(endpoint, conf)
+		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/services", func(endpoint Endpoint) PayloadSender {
+			senderConf := writerConf.SenderConfig
+			// Hardcode service sender configuration as the latest payload supplants older ones. So we don't really
+			// need more than 1 payload in the queue.
+			senderConf.MaxQueuedPayloads = 1
+			senderConf.MaxQueuedBytes = -1
+			senderConf.MaxAge = -1
+			return NewCustomQueuablePayloadSender(endpoint, senderConf)
 		}),
 	}
 }
@@ -91,7 +80,7 @@ func (w *ServiceWriter) Run() {
 			case SenderSuccessEvent:
 				log.Infof("flushed service payload to the API, time:%s, size:%d bytes", event.SendStats.SendTime,
 					len(event.Payload.Bytes))
-				w.conf.StatsClient.Gauge("datadog.trace_agent.service_writer.flush_duration",
+				w.statsClient.Gauge("datadog.trace_agent.service_writer.flush_duration",
 					event.SendStats.SendTime.Seconds(), nil, 1)
 				atomic.AddInt64(&w.stats.Payloads, 1)
 			case SenderFailureEvent:
@@ -135,7 +124,7 @@ func (w *ServiceWriter) Stop() {
 func (w *ServiceWriter) handleServiceMetadata(metadata model.ServicesMetadata) {
 	if w.serviceBuffer.Update(metadata) {
 		w.updated = true
-		w.conf.StatsClient.Count("datadog.trace_agent.writer.services.updated", 1, nil, 1)
+		w.statsClient.Count("datadog.trace_agent.writer.services.updated", 1, nil, 1)
 	}
 }
 
@@ -178,11 +167,11 @@ func (w *ServiceWriter) updateInfo() {
 	swInfo.Errors = atomic.SwapInt64(&w.stats.Errors, 0)
 	swInfo.Retries = atomic.SwapInt64(&w.stats.Retries, 0)
 
-	w.conf.StatsClient.Count("datadog.trace_agent.service_writer.payloads", int64(swInfo.Payloads), nil, 1)
-	w.conf.StatsClient.Gauge("datadog.trace_agent.service_writer.services", float64(swInfo.Services), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.service_writer.bytes", int64(swInfo.Bytes), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.service_writer.retries", int64(swInfo.Retries), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.service_writer.errors", int64(swInfo.Errors), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.service_writer.payloads", int64(swInfo.Payloads), nil, 1)
+	w.statsClient.Gauge("datadog.trace_agent.service_writer.services", float64(swInfo.Services), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.service_writer.bytes", int64(swInfo.Bytes), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.service_writer.retries", int64(swInfo.Retries), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.service_writer.errors", int64(swInfo.Errors), nil, 1)
 
 	info.UpdateServiceWriterInfo(swInfo)
 }

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/statsd"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -192,11 +193,14 @@ func assertMetadata(assert *assert.Assertions, expectedHeaders map[string]string
 
 func testServiceWriter() (*ServiceWriter, chan model.ServicesMetadata, *TestEndpoint, *statsd.TestStatsClient) {
 	serviceChannel := make(chan model.ServicesMetadata)
-	serviceWriter := NewServiceWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, serviceChannel)
+	conf := &config.AgentConfig{
+		ServiceWriterConfig: writerconfig.DefaultServiceWriterConfig(),
+	}
+	serviceWriter := NewServiceWriter(conf, serviceChannel)
 	testEndpoint := &TestEndpoint{}
 	serviceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
 	testStatsClient := &statsd.TestStatsClient{}
-	serviceWriter.conf.StatsClient = testStatsClient
+	serviceWriter.statsClient = testStatsClient
 
 	return serviceWriter, serviceChannel, testEndpoint, testStatsClient
 }

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -10,29 +10,15 @@ import (
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 )
-
-// StatsWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
-type StatsWriterConfig struct {
-	UpdateInfoPeriod time.Duration
-	StatsClient      statsd.StatsClient
-}
-
-// DefaultStatsWriterConfig creates a new instance of a StatsWriterConfig using default values.
-func DefaultStatsWriterConfig() StatsWriterConfig {
-	return StatsWriterConfig{
-		UpdateInfoPeriod: 1 * time.Minute,
-		StatsClient:      statsd.Client,
-	}
-}
 
 // StatsWriter ingests stats buckets and flushes their aggregation to the API.
 type StatsWriter struct {
 	hostName string
 	env      string
-	conf     StatsWriterConfig
+	conf     writerconfig.StatsWriterConfig
 	InStats  <-chan []model.StatsBucket
 	stats    info.StatsWriterInfo
 
@@ -41,12 +27,16 @@ type StatsWriter struct {
 
 // NewStatsWriter returns a new writer for services.
 func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket) *StatsWriter {
+	writerConf := conf.StatsWriterConfig
+
 	return &StatsWriter{
-		hostName:   conf.HostName,
-		env:        conf.DefaultEnv,
-		conf:       DefaultStatsWriterConfig(),
-		InStats:    InStats,
-		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/stats"),
+		hostName: conf.HostName,
+		env:      conf.DefaultEnv,
+		conf:     writerConf,
+		InStats:  InStats,
+		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/stats", func(endpoint Endpoint) PayloadSender {
+			return NewCustomQueuablePayloadSender(endpoint, writerConf.SenderConfig)
+		}),
 	}
 }
 
@@ -81,7 +71,7 @@ func (w *StatsWriter) Run() {
 			case SenderSuccessEvent:
 				log.Infof("flushed stat payload to the API, time:%s, size:%d bytes", event.SendStats.SendTime,
 					len(event.Payload.Bytes))
-				w.conf.StatsClient.Gauge("datadog.trace_agent.stats_writer.flush_duration",
+				w.statsClient.Gauge("datadog.trace_agent.stats_writer.flush_duration",
 					event.SendStats.SendTime.Seconds(), nil, 1)
 				atomic.AddInt64(&w.stats.Payloads, 1)
 			case SenderFailureEvent:
@@ -163,11 +153,11 @@ func (w *StatsWriter) updateInfo() {
 	swInfo.Retries = atomic.SwapInt64(&w.stats.Retries, 0)
 	swInfo.Errors = atomic.SwapInt64(&w.stats.Errors, 0)
 
-	w.conf.StatsClient.Count("datadog.trace_agent.stats_writer.payloads", int64(swInfo.Payloads), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.stats_writer.stats_buckets", int64(swInfo.StatsBuckets), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.stats_writer.bytes", int64(swInfo.Bytes), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.stats_writer.retries", int64(swInfo.Retries), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.stats_writer.errors", int64(swInfo.Errors), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.stats_writer.payloads", int64(swInfo.Payloads), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.stats_writer.stats_buckets", int64(swInfo.StatsBuckets), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.stats_writer.bytes", int64(swInfo.Bytes), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.stats_writer.retries", int64(swInfo.Retries), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.stats_writer.errors", int64(swInfo.Errors), nil, 1)
 
 	info.UpdateStatsWriterInfo(swInfo)
 }

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -28,6 +28,7 @@ type StatsWriter struct {
 // NewStatsWriter returns a new writer for services.
 func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket) *StatsWriter {
 	writerConf := conf.StatsWriterConfig
+	log.Infof("Stats writer initializing with config: %+v", writerConf)
 
 	return &StatsWriter{
 		hostName: conf.HostName,

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/statsd"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -200,11 +201,16 @@ func assertStatsPayload(assert *assert.Assertions, headers map[string]string, bu
 
 func testStatsWriter() (*StatsWriter, chan []model.StatsBucket, *TestEndpoint, *statsd.TestStatsClient) {
 	statsChannel := make(chan []model.StatsBucket)
-	statsWriter := NewStatsWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, statsChannel)
+	conf := &config.AgentConfig{
+		HostName:          testHostName,
+		DefaultEnv:        testEnv,
+		StatsWriterConfig: writerconfig.DefaultStatsWriterConfig(),
+	}
+	statsWriter := NewStatsWriter(conf, statsChannel)
 	testEndpoint := &TestEndpoint{}
 	statsWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
 	testStatsClient := &statsd.TestStatsClient{}
-	statsWriter.conf.StatsClient = testStatsClient
+	statsWriter.statsClient = testStatsClient
 
 	return statsWriter, statsChannel, testEndpoint, testStatsClient
 }

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -6,13 +6,13 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/golang/protobuf/proto"
 
 	"github.com/DataDog/datadog-trace-agent/config"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
+	"github.com/golang/protobuf/proto"
 )
 
 // TraceWriter ingests sampled traces and flush them to the API.
@@ -20,7 +20,7 @@ import (
 type TraceWriter struct {
 	hostName       string
 	env            string
-	conf           TraceWriterConfig
+	conf           writerconfig.TraceWriterConfig
 	InTraces       <-chan *model.Trace
 	InTransactions <-chan *model.Span
 	stats          info.TraceWriterInfo
@@ -32,27 +32,12 @@ type TraceWriter struct {
 	BaseWriter
 }
 
-// TraceWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
-type TraceWriterConfig struct {
-	MaxSpansPerPayload int
-	FlushPeriod        time.Duration
-	UpdateInfoPeriod   time.Duration
-	StatsClient        statsd.StatsClient
-}
-
-// DefaultTraceWriterConfig creates a new instance of a TraceWriterConfig using default values.
-func DefaultTraceWriterConfig() TraceWriterConfig {
-	return TraceWriterConfig{
-		MaxSpansPerPayload: 1000,
-		FlushPeriod:        5 * time.Second,
-		UpdateInfoPeriod:   1 * time.Minute,
-		StatsClient:        statsd.Client,
-	}
-}
-
 // NewTraceWriter returns a new writer for traces.
 func NewTraceWriter(conf *config.AgentConfig, InTraces <-chan *model.Trace, InTransactions <-chan *model.Span) *TraceWriter {
+	writerConf := conf.TraceWriterConfig
+
 	return &TraceWriter{
+		conf:     writerConf,
 		hostName: conf.HostName,
 		env:      conf.DefaultEnv,
 
@@ -62,8 +47,9 @@ func NewTraceWriter(conf *config.AgentConfig, InTraces <-chan *model.Trace, InTr
 		InTraces:       InTraces,
 		InTransactions: InTransactions,
 
-		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/traces"),
-		conf:       DefaultTraceWriterConfig(),
+		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/traces", func(endpoint Endpoint) PayloadSender {
+			return NewCustomQueuablePayloadSender(endpoint, writerConf.SenderConfig)
+		}),
 	}
 }
 
@@ -100,7 +86,7 @@ func (w *TraceWriter) Run() {
 			case SenderSuccessEvent:
 				log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", event.SendStats.SendTime,
 					len(event.Payload.Bytes))
-				w.conf.StatsClient.Gauge("datadog.trace_agent.trace_writer.flush_duration",
+				w.statsClient.Gauge("datadog.trace_agent.trace_writer.flush_duration",
 					event.SendStats.SendTime.Seconds(), nil, 1)
 				atomic.AddInt64(&w.stats.Payloads, 1)
 			case SenderFailureEvent:
@@ -257,12 +243,12 @@ func (w *TraceWriter) updateInfo() {
 	twInfo.Retries = atomic.SwapInt64(&w.stats.Retries, 0)
 	twInfo.Errors = atomic.SwapInt64(&w.stats.Errors, 0)
 
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.payloads", int64(twInfo.Payloads), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.traces", int64(twInfo.Traces), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.spans", int64(twInfo.Spans), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.bytes", int64(twInfo.Bytes), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.retries", int64(twInfo.Retries), nil, 1)
-	w.conf.StatsClient.Count("datadog.trace_agent.trace_writer.errors", int64(twInfo.Errors), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.payloads", int64(twInfo.Payloads), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.traces", int64(twInfo.Traces), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.spans", int64(twInfo.Spans), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.bytes", int64(twInfo.Bytes), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.retries", int64(twInfo.Retries), nil, 1)
+	w.statsClient.Count("datadog.trace_agent.trace_writer.errors", int64(twInfo.Errors), nil, 1)
 
 	info.UpdateTraceWriterInfo(twInfo)
 }

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-// TraceWriter ingests sampled traces and flush them to the API.
 // TraceWriter ingests sampled traces and flushes them to the API.
 type TraceWriter struct {
 	hostName       string

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -35,6 +35,7 @@ type TraceWriter struct {
 // NewTraceWriter returns a new writer for traces.
 func NewTraceWriter(conf *config.AgentConfig, InTraces <-chan *model.Trace, InTransactions <-chan *model.Span) *TraceWriter {
 	writerConf := conf.TraceWriterConfig
+	log.Infof("Trace writer initializing with config: %+v", writerConf)
 
 	return &TraceWriter{
 		conf:     writerConf,

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
 	"github.com/DataDog/datadog-trace-agent/statsd"
+	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 )
@@ -316,11 +317,16 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 func testTraceWriter() (*TraceWriter, chan *model.Trace, *TestEndpoint, *statsd.TestStatsClient) {
 	traceChannel := make(chan *model.Trace)
 	transactionChannel := make(chan *model.Span)
-	traceWriter := NewTraceWriter(&config.AgentConfig{HostName: testHostName, DefaultEnv: testEnv}, traceChannel, transactionChannel)
+	conf := &config.AgentConfig{
+		HostName:          testHostName,
+		DefaultEnv:        testEnv,
+		TraceWriterConfig: writerconfig.DefaultTraceWriterConfig(),
+	}
+	traceWriter := NewTraceWriter(conf, traceChannel, transactionChannel)
 	testEndpoint := &TestEndpoint{}
 	traceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
 	testStatsClient := &statsd.TestStatsClient{}
-	traceWriter.conf.StatsClient = testStatsClient
+	traceWriter.statsClient = testStatsClient
 
 	return traceWriter, traceChannel, testEndpoint, testStatsClient
 }


### PR DESCRIPTION
This PR exposes most of the configurations surrounding the new senders and queues for trace, stats and service writers.

This way, these details can be tuned without need for a recompilation.