### PR TITLE
quantizer: support MySQL comments

### DIFF
--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -119,14 +119,6 @@ func TestSQLQuantizer(t *testing.T) {
 			"select * from users where id = ?",
 		},
 		{
-			"select * from users where id = 214325346 -- boom",
-			"select * from users where id = ?",
-		},
-		{
-			"select * from users where id = 214325346 # boom",
-			"select * from users where id = ?",
-		},
-		{
 			"SELECT * FROM `host` WHERE `id` IN (42, 43) /*comment with parameters,host:localhost,url:controller#home,id:FF005:00CAA*/",
 			"SELECT * FROM host WHERE id IN ( ? )",
 		},
@@ -267,6 +259,37 @@ func TestSQLQuantizer(t *testing.T) {
 		{
 			"INSERT INTO user (id, email, name) VALUES (null, ?, ?)",
 			"INSERT INTO user ( id, email, name ) VALUES ( ? )",
+		},
+		{
+			"select * from users where id = 214325346     # This comment continues to the end of line",
+			"select * from users where id = ?",
+		},
+		{
+			"select * from users where id = 214325346     -- This comment continues to the end of line",
+			"select * from users where id = ?",
+		},
+		{
+			"SELECT * FROM /* this is an in-line comment */ users;",
+			"SELECT * FROM users",
+		},
+		{
+			"SELECT /*! STRAIGHT_JOIN */ col1 FROM table1",
+			"SELECT col1 FROM table1",
+		},
+		{
+			`DELETE FROM t1
+			WHERE s11 > ANY
+			(SELECT COUNT(*) /* no hint */ FROM t2
+			WHERE NOT EXISTS
+			(SELECT * FROM t3
+			WHERE ROW(5*t2.s1,77)=
+			(SELECT 50,11*s1 FROM t4 UNION SELECT 50,77 FROM
+			(SELECT * FROM t5) AS t5)));`,
+			"DELETE FROM t1 WHERE s11 > ANY ( SELECT COUNT ( * ) FROM t2 WHERE NOT EXISTS ( SELECT * FROM t3 WHERE ROW ( ? * t2.s1, ? ) = ( SELECT ? * s1 FROM t4 UNION SELECT ? FROM ( SELECT * FROM t5 ) ) ) )",
+		},
+		{
+			"SET @g = 'POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))';",
+			"SET @g = ?",
 		},
 	}
 

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -119,6 +119,14 @@ func TestSQLQuantizer(t *testing.T) {
 			"select * from users where id = ?",
 		},
 		{
+			"select * from users where id = 214325346 -- boom",
+			"select * from users where id = ?",
+		},
+		{
+			"select * from users where id = 214325346 # boom",
+			"select * from users where id = ?",
+		},
+		{
 			"SELECT * FROM `host` WHERE `id` IN (42, 43) /*comment with parameters,host:localhost,url:controller#home,id:FF005:00CAA*/",
 			"SELECT * FROM host WHERE id IN ( ? )",
 		},

--- a/quantizer/tokenizer.go
+++ b/quantizer/tokenizer.go
@@ -83,7 +83,7 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 	tkn.skipBlank()
 
 	switch ch := tkn.lastChar; {
-	case isLetter(ch):
+	case isLeadingLetter(ch):
 		return tkn.scanIdentifier()
 	case isDigit(ch):
 		return tkn.scanNumber(false)
@@ -118,6 +118,9 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 				return tkn.scanCommentType1("--")
 			}
 			return int(ch), []byte{byte(ch)}
+		case '#':
+			tkn.next()
+			return tkn.scanCommentType1("#")
 		case '<':
 			switch tkn.lastChar {
 			case '>':
@@ -452,8 +455,12 @@ func skipNonLiteralIdentifier(ch uint16) bool {
 	return isLetter(ch) || isDigit(ch) || '.' == ch || '-' == ch
 }
 
+func isLeadingLetter(ch uint16) bool {
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' || ch == '@'
+}
+
 func isLetter(ch uint16) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' || ch == '@' || ch == '#'
+	return isLeadingLetter(ch) || ch == '#'
 }
 
 func digitVal(ch uint16) int {


### PR DESCRIPTION
### Overview

Updates a contributor PR: #320 

It adds support for MySQL comments (inline especially) that are not properly removed from the Agent quantizer:

```
--- FAIL: TestSQLQuantizer (0.00s)
        Location:       sql_test.go:307
	Error:		Not equal: "select * from users where id = ?" (expected)
			        != "select * from users where id = ? # This comment continues to the end of line" (actual)
```

This patch solves the problem.