### PR TITLE
Let multiple payloads to be enqueued on `ServiceWriter`

### DIFF
--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -95,6 +95,18 @@ queue_max_bytes=268435456
 [trace.writer.services]
 # Period with which the agent flushes service info to DD servers.
 flush_period_seconds=5
+# Maximum number of service data payloads we can have queued up in case we are unable to send them to DD servers.
+# A value <= 0 disables this limit
+# Default: -1
+queue_max_payloads=-1
+# Maximum amount of service data we can have queued up in case we are unable to send it to DD servers.
+# A value <= 0 disables this limit
+# Default: 256MB
+queue_max_bytes=268435456
+# Maximum amount of time for which we keep service data enqueued in case we are unable to send it to DD servers.
+# A value <= 0 disables this limit
+# Default: -1
+queue_max_age_seconds=-1
 
 ###################################################
 # Stat writer - aggregates stats about traces

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -36,11 +36,6 @@ func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.Services
 		serviceBuffer: model.ServicesMetadata{},
 		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/services", func(endpoint Endpoint) PayloadSender {
 			senderConf := writerConf.SenderConfig
-			// Hardcode service sender configuration as the latest payload supplants older ones. So we don't really
-			// need more than 1 payload in the queue.
-			senderConf.MaxQueuedPayloads = 1
-			senderConf.MaxQueuedBytes = -1
-			senderConf.MaxAge = -1
 			return NewCustomQueuablePayloadSender(endpoint, senderConf)
 		}),
 	}

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -25,8 +25,8 @@ func TestServiceWriter_SenderMaxPayloads(t *testing.T) {
 	// When checking its default sender configuration
 	queuableSender := serviceWriter.BaseWriter.payloadSender.(*QueuablePayloadSender)
 
-	// Then the MaxQueuedPayloads setting should be 1
-	assert.Equal(1, queuableSender.conf.MaxQueuedPayloads)
+	// Then the MaxQueuedPayloads setting should be -1 (unlimited)
+	assert.Equal(-1, queuableSender.conf.MaxQueuedPayloads)
 }
 
 func TestServiceWriter_ServiceHandling(t *testing.T) {


### PR DESCRIPTION
Since we only send increments as opposed to full snapshots of service metadata, we must support enqueuing multiple payloads for `ServiceWriter`.

Should we also raise the default `MaxAge` configuration param for queued payloads? A single-service payload is less than 100 bytes, and the service number tends to be small as well (in the order of dozens), so I think it should be safe to increase it.


