### PR TITLE
Reduce debug log verbosity and reduce max sender memory usage

### DIFF
--- a/agent/trace-agent.ini
+++ b/agent/trace-agent.ini
@@ -85,8 +85,8 @@ max_spans_per_payload=1000
 flush_period_seconds=5
 # Maximum amount of trace data we can have queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
-# Default: 256MB
-queue_max_bytes=268435456
+# Default: 64MB
+queue_max_bytes=67108864
 
 ###################################################
 # Service writer - extracts service info from
@@ -101,8 +101,8 @@ flush_period_seconds=5
 queue_max_payloads=-1
 # Maximum amount of service data we can have queued up in case we are unable to send it to DD servers.
 # A value <= 0 disables this limit
-# Default: 256MB
-queue_max_bytes=268435456
+# Default: 64MB
+queue_max_bytes=67108864
 # Maximum amount of time for which we keep service data enqueued in case we are unable to send it to DD servers.
 # A value <= 0 disables this limit
 # Default: -1
@@ -115,5 +115,5 @@ queue_max_age_seconds=-1
 [trace.writer.stats]
 # Maximum amount of stats data we can have queued up in case we are unable to send them to DD servers.
 # A value <= 0 disables this limit
-# Default: 256MB
-queue_max_bytes=268435456
+# Default: 64MB
+queue_max_bytes=67108864

--- a/model/normalizer.go
+++ b/model/normalizer.go
@@ -76,7 +76,7 @@ func (s *Span) Normalize() error {
 	// root span's ``trace id = span id`` has been removed
 	if s.ParentID == s.TraceID && s.ParentID == s.SpanID {
 		s.ParentID = 0
-		log.Debugf("span.normalize: `ParentID`, `TraceID` and `SpanID` are the same; `ParentID` set to 0: %s", s.TraceID)
+		log.Debugf("span.normalize: `ParentID`, `TraceID` and `SpanID` are the same; `ParentID` set to 0: %d", s.TraceID)
 	}
 
 	// Start & Duration as nanoseconds timestamps

--- a/writer/config/payload.go
+++ b/writer/config/payload.go
@@ -18,8 +18,8 @@ type QueuablePayloadSenderConf struct {
 func DefaultQueuablePayloadSenderConf() QueuablePayloadSenderConf {
 	return QueuablePayloadSenderConf{
 		MaxAge:             20 * time.Minute,
-		MaxQueuedBytes:     256 * 1024 * 1024, // 256 MB
-		MaxQueuedPayloads:  -1,                // Unlimited
+		MaxQueuedBytes:     64 * 1024 * 1024, // 64 MB
+		MaxQueuedPayloads:  -1,               // Unlimited
 		ExponentialBackoff: backoff.DefaultExponentialConfig(),
 	}
 }

--- a/writer/payload.go
+++ b/writer/payload.go
@@ -199,7 +199,7 @@ func (s *QueuablePayloadSender) Run() {
 		select {
 		case payload := <-s.in:
 			if stats, err := s.sendOrQueue(payload); err != nil {
-				log.Errorf("Error while sending or queueing payload. err=%v", err)
+				log.Debugf("Error while sending or queueing payload. err=%v", err)
 				s.notifyError(payload, err, stats)
 			}
 		case <-s.backoffTimer.ReceiveTick():
@@ -304,7 +304,7 @@ func (s *QueuablePayloadSender) flushQueue() error {
 			if _, ok := err.(*RetriableError); ok {
 				// If send failed due to a retriable error, retry flush later
 				retryNum, delay := s.backoffTimer.ScheduleRetry(err)
-				log.Errorf("Got retriable error. Retrying flush later: retry=%d, delay=%s, err=%v",
+				log.Debugf("Got retriable error. Retrying flush later: retry=%d, delay=%s, err=%v",
 					retryNum, delay, err)
 				s.discardOldPayloads()
 				s.notifyRetry(payload, err, delay, retryNum)
@@ -313,7 +313,7 @@ func (s *QueuablePayloadSender) flushQueue() error {
 			}
 
 			// If send failed due to non-retriable error, notify error and drop it
-			log.Errorf("Dropping payload due to non-retriable error: err=%v, payload=%v", err, payload)
+			log.Debugf("Dropping payload due to non-retriable error: err=%v, payload=%v", err, payload)
 			s.notifyError(payload, err, stats)
 			next = s.removeQueuedPayload(e)
 			// Try sending next ones

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -120,7 +120,6 @@ func (w *TraceWriter) Run() {
 			log.Debug("Flushing current traces")
 			w.flush()
 		case <-updateInfoTicker.C:
-			log.Debug("Updating info")
 			go w.updateInfo()
 		case <-w.exit:
 			log.Info("exiting trace writer, flushing all remaining traces")
@@ -168,7 +167,7 @@ func (w *TraceWriter) handleTrace(trace *model.Trace) {
 
 	w.traces = append(w.traces, trace.APITrace())
 	w.spansInBuffer += len(*trace)
-	log.Debugf("Added new trace to buffer. spansInBuffer=%d, len(w.traces)=%d", w.spansInBuffer, len(w.traces))
+	log.Tracef("Added new trace to buffer. spansInBuffer=%d, len(w.traces)=%d", w.spansInBuffer, len(w.traces))
 
 	if w.spansInBuffer == w.conf.MaxSpansPerPayload {
 		log.Debugf("Flushing because we reached max per payload")


### PR DESCRIPTION
- Reduce `queue_max_bytes` down to 64MB. It is a safer default for customers, up to approximatively 200-250% the normal memory usage.
- Reduce log verbosity in debug mode.