### PR TITLE
Fix race condition on dual sampling

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -259,13 +259,12 @@ func (a *Agent) Process(t model.Trace) {
 		a.Concentrator.Add(pt)
 
 	}()
-	for _, s := range samplers {
-		sampler := s
-		go func() {
-			defer watchdog.LogOnPanic()
-			sampler.Add(pt)
-		}()
-	}
+	go func() {
+		defer watchdog.LogOnPanic()
+		for _, s := range samplers {
+			s.Add(pt)
+		}
+	}()
 	if a.TransactionSampler.Enabled() {
 		go func() {
 			defer watchdog.LogOnPanic()


### PR DESCRIPTION
Both signature and priority sampler can access the `span.Metrics` map (to access either `samplingPriorityKey` or `SpanSampleRateMetricKey`) at the same time when dealing with traces with a priority. It can result in a race condition.

```
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | fatal error: concurrent map read and map write
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | goroutine 3024 [running]:
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | runtime.throw(0x9fea58, 0x21)
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/.gimme/versions/go1.8.linux.amd64/src/runtime/panic.go:596 +0x95 fp=0xc4204cada0 sp=0xc4204cad80
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | runtime.mapaccess1_faststr(0x94da40, 0xc4201b8c60, 0x9f6643, 0x15, 0x16)
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/.gimme/versions/go1.8.linux.amd64/src/runtime/hashmap_fast.go:217 +0x4cf fp=0xc4204cae00 sp=0xc4204cada0
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | github.com/DataDog/datadog-trace-agent/sampler.(*PriorityEngine).Sample(0xc4201f5170, 0xc4200be360, 0x11, 0x11, 0xc4205be080, 0x9e9d75, 0x4, 0xc4204caf08)
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/workspace/raclette-prod/src/github.com/DataDog/datadog-trace-agent/sampler/prioritysampler.go:94 +0x76 fp=0xc4204caea0 sp=0xc4204cae00
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | main.(*Sampler).Add(0xc4201f9640, 0xc4200be360, 0x11, 0x11, 0xc420467b00, 0x11, 0x11, 0xc4205be080, 0x9e9d75, 0x4, ...)
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/workspace/raclette-prod/src/github.com/DataDog/datadog-trace-agent/agent/sampler.go:63 +0xbd fp=0xc4204caf00 sp=0xc4204caea0
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | main.(*Agent).Process.func3(0xc4201f9640, 0xc4200be360, 0x11, 0x11, 0xc420467b00, 0x11, 0x11, 0xc4205be080, 0x9e9d75, 0x4, ...)
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/workspace/raclette-prod/src/github.com/DataDog/datadog-trace-agent/agent/agent.go:266 +0x67 fp=0xc4204caf78 sp=0xc4204caf00
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | runtime.goexit()
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/.gimme/versions/go1.8.linux.amd64/src/runtime/asm_amd64.s:2197 +0x1 fp=0xc4204caf80 sp=0xc4204caf78
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) | created by main.(*Agent).Process
2018-02-15 12:52:34 UTC | ERROR | (apm.go:95 in func2) |        /home/jenkins/workspace/raclette-prod/src/github.com/DataDog/datadog-trace-agent/agent/agent.go:267 +0x71e
```

This is a quick fix consisting running both samplers serially.

If this happen to fix the issue, we can work on deeper work to make this part of the code nicer (and to avoid a single trace to be sampled twice).