### PR TITLE
Add DD_APM_NON_LOCAL_TRAFFIC env var

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -22,6 +22,7 @@ where env vars are preferrable to static files
 - `DD_API_KEY` - overrides `[Main] api_key`
 - `DD_DOGSTATSD_PORT` - overrides `[Main] dogstatsd_port`
 - `DD_BIND_HOST` - overrides `[Main] bind_host`
+- `DD_APM_NON_LOCAL_TRAFFIC` - overrides `[Main] non_local_traffic`
 - `DD_LOG_LEVEL` - overrides `[Main] log_level`
 - `DD_RECEIVER_PORT` - overrides `[trace.receiver] receiver_port`
 - `DD_IGNORE_RESOURCE` - overrides `[trace.ignore] resource`

--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -16,6 +16,12 @@ func mergeEnv(c *AgentConfig) {
 		c.Enabled = false
 	}
 
+	if v := os.Getenv("DD_APM_NON_LOCAL_TRAFFIC"); v == "true" {
+		c.ReceiverHost = "0.0.0.0"
+	} else if v == "false" {
+		c.ReceiverHost = "localhost"
+	}
+
 	if v := os.Getenv("DD_HOSTNAME"); v != "" {
 		c.HostName = v
 	}


### PR DESCRIPTION
Add support for the `DD_APM_NON_LOCAL_TRAFFIC` env variable.
`bind_host` will disappear with Datadog Agent 6 in favor of apm_non_local_traffic.
This new variable will be useful to the docker environment.