### PR TITLE
Make Backend a MemoryBackend of a Backend interface

### DIFF
--- a/sampler/backend.go
+++ b/sampler/backend.go
@@ -1,159 +1,28 @@
 package sampler
 
-import (
-	"sync"
-	"time"
-)
+// Backend stores and count traces and signatures ingested by a sampler
+type Backend interface {
+	// Run runs the blocking execution of the backend main loop
+	Run()
+	// Stop stops the backend main loop
+	Stop()
 
-// Backend storing any state required to run the sampling algorithms.
-//
-// Current implementation is only based on counters with polynomial decay.
-// Its bias with steady counts is 1 * decayFactor.
-// The stored scores represent approximation of the real count values (with a countScaleFactor factor).
-type Backend struct {
-	// Score per signature
-	scores map[Signature]float64
-	// Score of all traces (equals the sum of all signature scores)
-	totalScore float64
-	// Score of sampled traces
-	sampledScore float64
-	mu           sync.RWMutex
+	// CountSample counts that 1 trace is going through the sampler
+	CountSample()
+	// CountSignature counts that 1 signature is going through the sampler
+	CountSignature(signature Signature)
 
-	// Every decayPeriod, decay the score
-	// Lower value is more reactive, but forgets quicker
-	decayPeriod time.Duration
-	// At every decay tick, how much we reduce/divide the score
-	// Lower value is more reactive, but forgets quicker
-	decayFactor float64
-	// Factor to apply to move from the score to the representing number of traces per second.
-	// By definition of the decay formula: countScaleFactor = (decayFactor / (decayFactor - 1)) * decayPeriod
-	// It also represents by how much a spike is smoothed: if we instantly receive N times the same signature,
-	// its immediate count will be increased by N / countScaleFactor.
-	countScaleFactor float64
+	// GetTotalScore returns the TPS of all traces ingested
+	GetTotalScore() float64
+	// GetSampledScore returns the TPS of all traces sampled
+	GetSampledScore() float64
+	// GetUpperSampledScore is similar to GetSampledScore, but with the upper approximation
+	GetUpperSampledScore() float64
+	// GetSignatureScore returns the TPS of traces ingested of a given signature
+	GetSignatureScore(signature Signature) float64
+	// GetAllSignatureScores returns the TPS of traces ingested for all signatures
+	GetAllSignatureScores() map[Signature]float64
 
-	exit chan struct{}
-}
-
-// NewBackend returns an initialized Backend
-func NewBackend(decayPeriod time.Duration) *Backend {
-	// With this factor, any past trace counts for less than 50% after 6*decayPeriod and >1% after 39*decayPeriod
-	// We can keep it hardcoded, but having `decayPeriod` configurable should be enough?
-	decayFactor := 1.125 // 9/8
-
-	return &Backend{
-		scores:           make(map[Signature]float64),
-		sampledScore:     0,
-		decayPeriod:      decayPeriod,
-		decayFactor:      decayFactor,
-		countScaleFactor: (decayFactor / (decayFactor - 1)) * decayPeriod.Seconds(),
-		exit:             make(chan struct{}),
-	}
-}
-
-// Run runs and block on the Sampler main loop
-func (b *Backend) Run() {
-	t := time.NewTicker(b.decayPeriod)
-	defer t.Stop()
-
-	for {
-		select {
-		case <-t.C:
-			b.DecayScore()
-		case <-b.exit:
-			return
-		}
-	}
-}
-
-// Stop stops the main Run loop
-func (b *Backend) Stop() {
-	close(b.exit)
-}
-
-// CountSignature counts an incoming signature
-func (b *Backend) CountSignature(signature Signature) {
-	b.mu.Lock()
-	b.scores[signature]++
-	b.totalScore++
-	b.mu.Unlock()
-}
-
-// CountSample counts a trace sampled by the sampler
-func (b *Backend) CountSample() {
-	b.mu.Lock()
-	b.sampledScore++
-	b.mu.Unlock()
-}
-
-// GetSignatureScore returns the score of a signature.
-// It is normalized to represent a number of signatures per second.
-func (b *Backend) GetSignatureScore(signature Signature) float64 {
-	b.mu.RLock()
-	score := b.scores[signature] / b.countScaleFactor
-	b.mu.RUnlock()
-
-	return score
-}
-
-// GetAllSignatureScores returns the scores for all signatures.
-// It is normalized to represent a number of signatures per second.
-func (b *Backend) GetAllSignatureScores() map[Signature]float64 {
-	b.mu.RLock()
-	scores := make(map[Signature]float64, len(b.scores))
-	for signature, score := range b.scores {
-		scores[signature] = score / b.countScaleFactor
-	}
-	b.mu.RUnlock()
-
-	return scores
-}
-
-// GetSampledScore returns the global score of all sampled traces.
-func (b *Backend) GetSampledScore() float64 {
-	b.mu.RLock()
-	score := b.sampledScore / b.countScaleFactor
-	b.mu.RUnlock()
-
-	return score
-}
-
-// GetTotalScore returns the global score of all sampled traces.
-func (b *Backend) GetTotalScore() float64 {
-	b.mu.RLock()
-	score := b.totalScore / b.countScaleFactor
-	b.mu.RUnlock()
-
-	return score
-}
-
-// GetUpperSampledScore returns a certain upper bound of the global count of all sampled traces.
-func (b *Backend) GetUpperSampledScore() float64 {
-	// Overestimate the real score with the high limit of the backend bias.
-	return b.GetSampledScore() * b.decayFactor
-}
-
-// GetCardinality returns the number of different signatures seen recently.
-func (b *Backend) GetCardinality() int64 {
-	b.mu.Lock()
-	cardinality := int64(len(b.scores))
-	b.mu.Unlock()
-
-	return cardinality
-}
-
-// DecayScore applies the decay to the rolling counters
-func (b *Backend) DecayScore() {
-	b.mu.Lock()
-	for sig := range b.scores {
-		score := b.scores[sig]
-		if score > b.decayFactor*minSignatureScoreOffset {
-			b.scores[sig] /= b.decayFactor
-		} else {
-			// When the score is too small, we can optimize by simply dropping the entry
-			delete(b.scores, sig)
-		}
-	}
-	b.totalScore /= b.decayFactor
-	b.sampledScore /= b.decayFactor
-	b.mu.Unlock()
+	// get the number of different signatures seen
+	GetCardinality() int64
 }

--- a/sampler/backend.go
+++ b/sampler/backend.go
@@ -1,28 +1,34 @@
 package sampler
 
-// Backend stores and count traces and signatures ingested by a sampler
+// Backend stores and counts traces and signatures ingested by a sampler.
 type Backend interface {
-	// Run runs the blocking execution of the backend main loop
+	// Run runs the blocking execution of the backend main loop.
 	Run()
-	// Stop stops the backend main loop
+
+	// Stop stops the backend main loop.
 	Stop()
 
-	// CountSample counts that 1 trace is going through the sampler
+	// CountSample counts that 1 trace is going through the sampler.
 	CountSample()
-	// CountSignature counts that 1 signature is going through the sampler
+
+	// CountSignature counts that 1 signature is going through the sampler.
 	CountSignature(signature Signature)
 
-	// GetTotalScore returns the TPS of all traces ingested
+	// GetTotalScore returns the TPS (Traces Per Second) of all traces ingested.
 	GetTotalScore() float64
-	// GetSampledScore returns the TPS of all traces sampled
-	GetSampledScore() float64
-	// GetUpperSampledScore is similar to GetSampledScore, but with the upper approximation
-	GetUpperSampledScore() float64
-	// GetSignatureScore returns the TPS of traces ingested of a given signature
-	GetSignatureScore(signature Signature) float64
-	// GetAllSignatureScores returns the TPS of traces ingested for all signatures
-	GetAllSignatureScores() map[Signature]float64
 
-	// get the number of different signatures seen
+	// GetSampledScore returns the TPS of all traces sampled.
+	GetSampledScore() float64
+
+	// GetUpperSampledScore is similar to GetSampledScore, but with the upper approximation.
+	GetUpperSampledScore() float64
+
+	// GetSignatureScore returns the TPS of traces ingested of a given signature.
+	GetSignatureScore(signature Signature) float64
+
+	// GetSignatureScores returns the TPS of traces ingested for all signatures.
+	GetSignatureScores() map[Signature]float64
+
+	// GetCardinality returns the number of different signatures seen.
 	GetCardinality() int64
 }

--- a/sampler/memory_backend.go
+++ b/sampler/memory_backend.go
@@ -11,34 +11,43 @@ import (
 // Its bias with steady counts is 1 * decayFactor.
 // The stored scores represent approximation of the real count values (with a countScaleFactor factor).
 type MemoryBackend struct {
-	// Score per signature
+	// scores maps signatures to scores.
 	scores map[Signature]float64
-	// Score of all traces (equals the sum of all signature scores)
-	totalScore float64
-	// Score of sampled traces
-	sampledScore float64
-	mu           sync.RWMutex
 
-	// Every decayPeriod, decay the score
-	// Lower value is more reactive, but forgets quicker
+	// totalScore holds the score sum of all traces (equals the sum of all signature scores).
+	totalScore float64
+
+	// sampledScore is the score of all sampled traces.
+	sampledScore float64
+
+	// mu is a lock protecting all the scores.
+	mu sync.RWMutex
+
+	// decayPeriod is the time period between each score decay.
+	// A lower value is more reactive, but forgets quicker.
 	decayPeriod time.Duration
-	// At every decay tick, how much we reduce/divide the score
-	// Lower value is more reactive, but forgets quicker
+
+	// decayFactor is how much we reduce/divide the score at every decay run.
+	// A lower value is more reactive, but forgets quicker.
 	decayFactor float64
-	// Factor to apply to move from the score to the representing number of traces per second.
-	// By definition of the decay formula: countScaleFactor = (decayFactor / (decayFactor - 1)) * decayPeriod
-	// It also represents by how much a spike is smoothed: if we instantly receive N times the same signature,
-	// its immediate count will be increased by N / countScaleFactor.
+
+	// countScaleFactor is the factor to apply to move from the score
+	// to the representing number of traces per second.
+	// By definition of the decay formula is:
+	// countScaleFactor = (decayFactor / (decayFactor - 1)) * decayPeriod
+	// It also represents by how much a spike is smoothed: if we instantly
+	// receive N times the same signature, its immediate count will be
+	// increased by N / countScaleFactor.
 	countScaleFactor float64
 
+	// exit is the channel to close to stop the run loop.
 	exit chan struct{}
 }
 
-// NewMemoryBackend returns an initialized Backend
+// NewMemoryBackend returns an initialized Backend.
 func NewMemoryBackend(decayPeriod time.Duration, decayFactor float64) *MemoryBackend {
 	return &MemoryBackend{
 		scores:           make(map[Signature]float64),
-		sampledScore:     0,
 		decayPeriod:      decayPeriod,
 		decayFactor:      decayFactor,
 		countScaleFactor: (decayFactor / (decayFactor - 1)) * decayPeriod.Seconds(),
@@ -46,7 +55,7 @@ func NewMemoryBackend(decayPeriod time.Duration, decayFactor float64) *MemoryBac
 	}
 }
 
-// Run runs and block on the Sampler main loop
+// Run runs and block on the Sampler main loop.
 func (b *MemoryBackend) Run() {
 	t := time.NewTicker(b.decayPeriod)
 	defer t.Stop()
@@ -61,12 +70,12 @@ func (b *MemoryBackend) Run() {
 	}
 }
 
-// Stop stops the main Run loop
+// Stop stops the main Run loop.
 func (b *MemoryBackend) Stop() {
 	close(b.exit)
 }
 
-// CountSignature counts an incoming signature
+// CountSignature counts an incoming signature.
 func (b *MemoryBackend) CountSignature(signature Signature) {
 	b.mu.Lock()
 	b.scores[signature]++
@@ -74,7 +83,7 @@ func (b *MemoryBackend) CountSignature(signature Signature) {
 	b.mu.Unlock()
 }
 
-// CountSample counts a trace sampled by the sampler
+// CountSample counts a trace sampled by the sampler.
 func (b *MemoryBackend) CountSample() {
 	b.mu.Lock()
 	b.sampledScore++
@@ -91,9 +100,9 @@ func (b *MemoryBackend) GetSignatureScore(signature Signature) float64 {
 	return score
 }
 
-// GetAllSignatureScores returns the scores for all signatures.
+// GetSignatureScores returns the scores for all signatures.
 // It is normalized to represent a number of signatures per second.
-func (b *MemoryBackend) GetAllSignatureScores() map[Signature]float64 {
+func (b *MemoryBackend) GetSignatureScores() map[Signature]float64 {
 	b.mu.RLock()
 	scores := make(map[Signature]float64, len(b.scores))
 	for signature, score := range b.scores {
@@ -130,22 +139,21 @@ func (b *MemoryBackend) GetUpperSampledScore() float64 {
 
 // GetCardinality returns the number of different signatures seen recently.
 func (b *MemoryBackend) GetCardinality() int64 {
-	b.mu.Lock()
+	b.mu.RLock()
 	cardinality := int64(len(b.scores))
-	b.mu.Unlock()
+	b.mu.RUnlock()
 
 	return cardinality
 }
 
-// decayScore applies the decay to the rolling counters
+// decayScore applies the decay to the rolling counters.
 func (b *MemoryBackend) decayScore() {
 	b.mu.Lock()
 	for sig := range b.scores {
-		score := b.scores[sig]
-		if score > b.decayFactor*minSignatureScoreOffset {
+		if b.scores[sig] > b.decayFactor*minSignatureScoreOffset {
 			b.scores[sig] /= b.decayFactor
 		} else {
-			// When the score is too small, we can optimize by simply dropping the entry
+			// When the score is too small, we can optimize by simply dropping the entry.
 			delete(b.scores, sig)
 		}
 	}

--- a/sampler/memory_backend.go
+++ b/sampler/memory_backend.go
@@ -1,0 +1,155 @@
+package sampler
+
+import (
+	"sync"
+	"time"
+)
+
+// MemoryBackend storing any state required to run the sampling algorithms.
+//
+// Current implementation is only based on counters with polynomial decay.
+// Its bias with steady counts is 1 * decayFactor.
+// The stored scores represent approximation of the real count values (with a countScaleFactor factor).
+type MemoryBackend struct {
+	// Score per signature
+	scores map[Signature]float64
+	// Score of all traces (equals the sum of all signature scores)
+	totalScore float64
+	// Score of sampled traces
+	sampledScore float64
+	mu           sync.RWMutex
+
+	// Every decayPeriod, decay the score
+	// Lower value is more reactive, but forgets quicker
+	decayPeriod time.Duration
+	// At every decay tick, how much we reduce/divide the score
+	// Lower value is more reactive, but forgets quicker
+	decayFactor float64
+	// Factor to apply to move from the score to the representing number of traces per second.
+	// By definition of the decay formula: countScaleFactor = (decayFactor / (decayFactor - 1)) * decayPeriod
+	// It also represents by how much a spike is smoothed: if we instantly receive N times the same signature,
+	// its immediate count will be increased by N / countScaleFactor.
+	countScaleFactor float64
+
+	exit chan struct{}
+}
+
+// NewMemoryBackend returns an initialized Backend
+func NewMemoryBackend(decayPeriod time.Duration, decayFactor float64) *MemoryBackend {
+	return &MemoryBackend{
+		scores:           make(map[Signature]float64),
+		sampledScore:     0,
+		decayPeriod:      decayPeriod,
+		decayFactor:      decayFactor,
+		countScaleFactor: (decayFactor / (decayFactor - 1)) * decayPeriod.Seconds(),
+		exit:             make(chan struct{}),
+	}
+}
+
+// Run runs and block on the Sampler main loop
+func (b *MemoryBackend) Run() {
+	t := time.NewTicker(b.decayPeriod)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			b.decayScore()
+		case <-b.exit:
+			return
+		}
+	}
+}
+
+// Stop stops the main Run loop
+func (b *MemoryBackend) Stop() {
+	close(b.exit)
+}
+
+// CountSignature counts an incoming signature
+func (b *MemoryBackend) CountSignature(signature Signature) {
+	b.mu.Lock()
+	b.scores[signature]++
+	b.totalScore++
+	b.mu.Unlock()
+}
+
+// CountSample counts a trace sampled by the sampler
+func (b *MemoryBackend) CountSample() {
+	b.mu.Lock()
+	b.sampledScore++
+	b.mu.Unlock()
+}
+
+// GetSignatureScore returns the score of a signature.
+// It is normalized to represent a number of signatures per second.
+func (b *MemoryBackend) GetSignatureScore(signature Signature) float64 {
+	b.mu.RLock()
+	score := b.scores[signature] / b.countScaleFactor
+	b.mu.RUnlock()
+
+	return score
+}
+
+// GetAllSignatureScores returns the scores for all signatures.
+// It is normalized to represent a number of signatures per second.
+func (b *MemoryBackend) GetAllSignatureScores() map[Signature]float64 {
+	b.mu.RLock()
+	scores := make(map[Signature]float64, len(b.scores))
+	for signature, score := range b.scores {
+		scores[signature] = score / b.countScaleFactor
+	}
+	b.mu.RUnlock()
+
+	return scores
+}
+
+// GetSampledScore returns the global score of all sampled traces.
+func (b *MemoryBackend) GetSampledScore() float64 {
+	b.mu.RLock()
+	score := b.sampledScore / b.countScaleFactor
+	b.mu.RUnlock()
+
+	return score
+}
+
+// GetTotalScore returns the global score of all sampled traces.
+func (b *MemoryBackend) GetTotalScore() float64 {
+	b.mu.RLock()
+	score := b.totalScore / b.countScaleFactor
+	b.mu.RUnlock()
+
+	return score
+}
+
+// GetUpperSampledScore returns a certain upper bound of the global count of all sampled traces.
+func (b *MemoryBackend) GetUpperSampledScore() float64 {
+	// Overestimate the real score with the high limit of the backend bias.
+	return b.GetSampledScore() * b.decayFactor
+}
+
+// GetCardinality returns the number of different signatures seen recently.
+func (b *MemoryBackend) GetCardinality() int64 {
+	b.mu.Lock()
+	cardinality := int64(len(b.scores))
+	b.mu.Unlock()
+
+	return cardinality
+}
+
+// decayScore applies the decay to the rolling counters
+func (b *MemoryBackend) decayScore() {
+	b.mu.Lock()
+	for sig := range b.scores {
+		score := b.scores[sig]
+		if score > b.decayFactor*minSignatureScoreOffset {
+			b.scores[sig] /= b.decayFactor
+		} else {
+			// When the score is too small, we can optimize by simply dropping the entry
+			delete(b.scores, sig)
+		}
+	}
+	b.totalScore /= b.decayFactor
+	b.sampledScore /= b.decayFactor
+	b.mu.Unlock()
+}

--- a/sampler/memory_backend_test.go
+++ b/sampler/memory_backend_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getTestBackend() *Backend {
+func getTestBackend() *MemoryBackend {
 	decayPeriod := 5 * time.Second
 
-	return NewBackend(decayPeriod)
+	return NewMemoryBackend(decayPeriod, defaultDecayFactor)
 }
 
 func randomSignature() Signature {
@@ -42,7 +42,7 @@ func TestCountScoreConvergence(t *testing.T) {
 	period := backend.decayPeriod
 
 	for period := 0; period < periods; period++ {
-		backend.DecayScore()
+		backend.decayScore()
 		for i := 0; i < tracesPerPeriod; i++ {
 			backend.CountSignature(sign)
 			backend.CountSample()
@@ -65,7 +65,7 @@ func TestCountScoreOblivion(t *testing.T) {
 	ticks := 50
 
 	for period := 0; period < ticks; period++ {
-		backend.DecayScore()
+		backend.decayScore()
 		for i := 0; i < tracesPerPeriod; i++ {
 			backend.CountSignature(sign)
 		}
@@ -79,13 +79,13 @@ func TestCountScoreOblivion(t *testing.T) {
 	oblivionPeriods := 40
 
 	for period := 0; period < halfLifePeriods; period++ {
-		backend.DecayScore()
+		backend.decayScore()
 	}
 
 	assert.True(backend.GetSignatureScore(sign) < 0.5*float64(tracesPerPeriod))
 
 	for period := 0; period < oblivionPeriods-halfLifePeriods; period++ {
-		backend.DecayScore()
+		backend.decayScore()
 	}
 
 	assert.True(backend.GetSignatureScore(sign) < 0.01*float64(tracesPerPeriod))

--- a/sampler/presampler.go
+++ b/sampler/presampler.go
@@ -67,7 +67,7 @@ func (ps *PreSampler) Run() {
 	for {
 		select {
 		case <-t.C:
-			ps.DecayScore()
+			ps.decayScore()
 		case <-ps.exit:
 			return
 		}
@@ -179,8 +179,8 @@ func (ps *PreSampler) Sample(req *http.Request) bool {
 	return ps.sampleWithCount(traceCount)
 }
 
-// DecayScore applies the decay to the rolling counters
-func (ps *PreSampler) DecayScore() {
+// decayScore applies the decay to the rolling counters
+func (ps *PreSampler) decayScore() {
 	ps.mu.Lock()
 
 	ps.stats.RecentPayloadsSeen /= ps.decayFactor

--- a/sampler/presampler_test.go
+++ b/sampler/presampler_test.go
@@ -119,7 +119,7 @@ func TestPreSamplerRace(t *testing.T) {
 	}()
 	go func() {
 		for i := 0; i < N; i++ {
-			ps.DecayScore()
+			ps.decayScore()
 			time.Sleep(time.Microsecond)
 		}
 		wg.Done()
@@ -134,22 +134,22 @@ func TestPreSamplerSampleWithCount(t *testing.T) {
 	ps.SetRate(0.2)
 	assert.Equal(0.2, ps.RealRate(), "by default, RealRate returns wished rate")
 	assert.True(ps.sampleWithCount(100), "always accept first payload")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.False(ps.sampleWithCount(10), "refuse as this accepting this would make 100%")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.Equal(0.898876404494382, ps.RealRate())
 	assert.False(ps.sampleWithCount(290), "still refuse")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.False(ps.sampleWithCount(99), "just below the limit")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.True(ps.sampleWithCount(1), "should there be no decay, this one would be dropped, but with decay, the rate decreased as the recently dropped gain importance over the old initially accepted")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.Equal(0.16365162139216005, ps.RealRate(), "well below 20%, again, decay speaks")
 	assert.True(ps.sampleWithCount(1000000), "accepting payload with many traces")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.Equal(0.9997119577953764, ps.RealRate(), "real rate is almost 1, as we accepted a hudge payload")
 	assert.False(ps.sampleWithCount(100000), "rejecting, real rate is too high now")
-	ps.DecayScore()
+	ps.decayScore()
 	assert.Equal(0.8986487877795845, ps.RealRate(), "real rate should be now around 90%")
 	assert.Equal(PreSamplerStats{
 		Rate:                0.2,

--- a/sampler/score.go
+++ b/sampler/score.go
@@ -65,7 +65,7 @@ func (s *Sampler) GetCountScore(signature Signature) float64 {
 // The score value can be seeing as the sample rate if the count were the only factor
 // Since other factors can intervene (such as extra global sampling), its value can be larger than 1
 func (s *Sampler) GetAllCountScores() map[Signature]float64 {
-	m := s.Backend.GetAllSignatureScores()
+	m := s.Backend.GetSignatureScores()
 	for k, v := range m {
 		m[k] = s.backendScoreToSamplerScore(v)
 	}

--- a/sampler/scoresampler_test.go
+++ b/sampler/scoresampler_test.go
@@ -65,7 +65,7 @@ func TestMaxTPS(t *testing.T) {
 	periods := 50
 
 	s.Sampler.maxTPS = maxTPS
-	periodSeconds := s.Sampler.Backend.decayPeriod.Seconds()
+	periodSeconds := defaultDecayPeriod.Seconds()
 	tracesPerPeriod := tps * periodSeconds
 	// Set signature score offset high enough not to kick in during the test.
 	s.Sampler.signatureScoreOffset = 2 * tps
@@ -74,7 +74,7 @@ func TestMaxTPS(t *testing.T) {
 	sampledCount := 0
 
 	for period := 0; period < initPeriods+periods; period++ {
-		s.Sampler.Backend.DecayScore()
+		s.Sampler.Backend.(*MemoryBackend).decayScore()
 		for i := 0; i < int(tracesPerPeriod); i++ {
 			trace, root := getTestTrace()
 			sampled := s.Sample(trace, root, defaultEnv)
@@ -95,7 +95,7 @@ func TestMaxTPS(t *testing.T) {
 	// Check for 1% epsilon, but the precision also depends on the backend imprecision (error factor = decayFactor).
 	// Combine error rates with L1-norm instead of L2-norm by laziness, still good enough for tests.
 	assert.InEpsilon(s.Sampler.maxTPS, float64(sampledCount)/(float64(periods)*periodSeconds),
-		0.01+s.Sampler.Backend.decayFactor-1)
+		0.01+defaultDecayFactor-1)
 }
 
 func TestSamplerChainedSampling(t *testing.T) {


### PR DESCRIPTION
Make `Backend` an interface.
It should make the code more explicit about what it exposes, and will allow a better reusability/flexibility.