### PR TITLE
model: use io.LimitReader

### DIFF
--- a/model/limited_reader.go
+++ b/model/limited_reader.go
@@ -1,13 +1,8 @@
 package model
 
 import (
-	"errors"
 	"io"
 )
-
-// ErrLimitedReaderLimitReached indicates that the read limit has been
-// reached.
-var ErrLimitedReaderLimitReached = errors.New("read limit reached")
 
 // LimitedReader reads from a reader up to a specific limit. When this limit
 // has been reached, any subsequent read will return
@@ -15,43 +10,14 @@ var ErrLimitedReaderLimitReached = errors.New("read limit reached")
 // The underlying reader has to implement io.ReadCloser so that it can be used
 // with http request bodies.
 type LimitedReader struct {
-	r     io.ReadCloser
-	limit int64
-	Count int64
+	io.Reader
+	io.Closer
 }
 
 // NewLimitedReader creates a new LimitedReader.
 func NewLimitedReader(r io.ReadCloser, limit int64) *LimitedReader {
 	return &LimitedReader{
-		r:     r,
-		limit: limit,
+		Reader: io.LimitReader(r, limit),
+		Closer: r,
 	}
-}
-
-// Read reads from the underlying reader.
-func (r *LimitedReader) Read(buf []byte) (n int, err error) {
-	if r.limit <= 0 {
-		return 0, ErrLimitedReaderLimitReached
-	}
-
-	if int64(len(buf)) > r.limit {
-		buf = buf[0:r.limit]
-	}
-	n, err = r.r.Read(buf)
-
-	// Some libraries (e.g. msgp) will ignore read data if err is not nil.
-	// We reset err if something was read, and the next read will return
-	// io.EOF with no data.
-	if err == io.EOF && n > 0 {
-		err = nil
-	}
-
-	r.limit -= int64(n)
-	r.Count += int64(n)
-	return
-}
-
-// Close closes the underlying reader.
-func (r *LimitedReader) Close() error {
-	return r.r.Close()
 }

--- a/model/limited_reader_test.go
+++ b/model/limited_reader_test.go
@@ -52,19 +52,16 @@ func TestLimitedReader(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, n)
 	assert.Equal(t, []byte("f"), tmp)
-	assert.Equal(t, int64(1), lr.Count)
 
 	tmp = make([]byte, 4)
 	n, err = lr.Read(tmp)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, n)
 	assert.Equal(t, []byte("oo\x00\x00"), tmp)
-	assert.Equal(t, int64(3), lr.Count)
 
 	tmp = make([]byte, 1)
 	n, err = lr.Read(tmp)
-	assert.Equal(t, ErrLimitedReaderLimitReached, err)
-	assert.Equal(t, int64(3), lr.Count)
+	assert.Equal(t, io.EOF, err)
 }
 
 func TestLimitedReaderEOFBuffer(t *testing.T) {
@@ -77,13 +74,11 @@ func TestLimitedReaderEOFBuffer(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 6, n)
 	assert.Equal(t, []byte("foobar"), tmp)
-	assert.Equal(t, int64(6), lr.Count)
 
 	tmp = make([]byte, 6)
 	n, err = lr.Read(tmp)
 	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 0, n)
-	assert.Equal(t, int64(6), lr.Count)
 }
 
 func TestLimitedReaderEOFMockFile(t *testing.T) {
@@ -92,14 +87,12 @@ func TestLimitedReaderEOFMockFile(t *testing.T) {
 
 	tmp := make([]byte, 6)
 	n, err := lr.Read(tmp)
-	assert.Nil(t, err)
+	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 6, n)
 	assert.Equal(t, []byte("foobar"), tmp)
-	assert.Equal(t, int64(6), lr.Count)
 
 	tmp = make([]byte, 6)
 	n, err = lr.Read(tmp)
 	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 0, n)
-	assert.Equal(t, int64(6), lr.Count)
 }


### PR DESCRIPTION
No need to implement our own. It is already available in the [standard library](https://golang.org/pkg/io/#LimitReader) and works more correctly by returning the appropriate error (`io.EOF`) for where it is used (in the [Receiver](https://github.com/gbbr/datadog-trace-agent/blob/b4025fcdade41d0f07df37d96b2a9d4552f2c7cc/cmd/trace-agent/receiver.go#L163)'s request body).