### PR TITLE
 {cmd,statsd,writer}: fix race conditions in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2
 jobs:
      build:
           working_directory: /go/src/github.com/DataDog/datadog-trace-agent
+          resource_class: large
 
           docker:
                - image: circleci/golang:1.8

--- a/cmd/trace-agent/service_mapper.go
+++ b/cmd/trace-agent/service_mapper.go
@@ -12,12 +12,10 @@ import (
 // ServiceMapper provides a cache layer over model.ServicesMetadata pipeline
 // Used in conjunction with ServiceWriter: in-> ServiceMapper out-> ServiceWriter
 type ServiceMapper struct {
-	in   <-chan model.ServicesMetadata
-	out  chan<- model.ServicesMetadata
-	exit chan bool
-	done sync.WaitGroup
-
-	mu    sync.RWMutex // guards cache
+	in    <-chan model.ServicesMetadata
+	out   chan<- model.ServicesMetadata
+	exit  chan bool
+	done  sync.WaitGroup
 	cache model.ServicesMetadata
 }
 
@@ -58,9 +56,7 @@ func (s *ServiceMapper) Run() {
 		case metadata := <-s.in:
 			s.update(metadata)
 		case <-telemetryTicker.C:
-			s.mu.RLock()
 			log.Infof("total number of tracked services: %d", len(s.cache))
-			s.mu.RUnlock()
 		case <-s.exit:
 			return
 		}
@@ -89,21 +85,11 @@ func (s *ServiceMapper) update(metadata model.ServicesMetadata) {
 	}
 
 	s.out <- changes
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.cache.Merge(changes)
 }
 
-func (s *ServiceMapper) cacheSize() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.cache)
-}
-
 func (s *ServiceMapper) shouldAdd(service string, metadata model.ServicesMetadata) bool {
-	s.mu.RLock()
 	cacheEntry, ok := s.cache[service]
-	s.mu.RUnlock()
 
 	// No cache entry?
 	if !ok {

--- a/cmd/trace-agent/service_mapper_test.go
+++ b/cmd/trace-agent/service_mapper_test.go
@@ -14,9 +14,6 @@ func TestServiceMapper(t *testing.T) {
 	mapper.Start()
 	defer mapper.Stop()
 
-	// Let's ensure we have a proper context
-	assert.Equal(0, mapper.cacheSize())
-
 	input := model.ServicesMetadata{"service-a": {"app_type": "type-a"}}
 	in <- input
 	output := <-out
@@ -24,7 +21,6 @@ func TestServiceMapper(t *testing.T) {
 	// When the service is ingested for the first time, we simply propagate it
 	// to the output channel and add an entry to the cache map
 	assert.Equal(input, output)
-	assert.Equal(1, mapper.cacheSize())
 
 	// This entry will result in a cache-hit and therefore will be filtered out
 	in <- model.ServicesMetadata{"service-a": {"app_type": "SOMETHING_DIFFERENT"}}
@@ -35,7 +31,6 @@ func TestServiceMapper(t *testing.T) {
 	output = <-out
 
 	assert.Equal(newService, output)
-	assert.Equal(2, mapper.cacheSize())
 }
 
 func TestCachePolicy(t *testing.T) {

--- a/cmd/trace-agent/service_mapper_test.go
+++ b/cmd/trace-agent/service_mapper_test.go
@@ -15,7 +15,7 @@ func TestServiceMapper(t *testing.T) {
 	defer mapper.Stop()
 
 	// Let's ensure we have a proper context
-	assert.Len(mapper.cache, 0)
+	assert.Equal(0, mapper.cacheSize())
 
 	input := model.ServicesMetadata{"service-a": {"app_type": "type-a"}}
 	in <- input
@@ -24,7 +24,7 @@ func TestServiceMapper(t *testing.T) {
 	// When the service is ingested for the first time, we simply propagate it
 	// to the output channel and add an entry to the cache map
 	assert.Equal(input, output)
-	assert.Len(mapper.cache, 1)
+	assert.Equal(1, mapper.cacheSize())
 
 	// This entry will result in a cache-hit and therefore will be filtered out
 	in <- model.ServicesMetadata{"service-a": {"app_type": "SOMETHING_DIFFERENT"}}
@@ -35,7 +35,7 @@ func TestServiceMapper(t *testing.T) {
 	output = <-out
 
 	assert.Equal(newService, output)
-	assert.Len(mapper.cache, 2)
+	assert.Equal(2, mapper.cacheSize())
 }
 
 func TestCachePolicy(t *testing.T) {

--- a/gorake.rb
+++ b/gorake.rb
@@ -65,7 +65,7 @@ def go_vet(path)
 end
 
 def go_test(path, opts = {})
-  cmd = 'go test'
+  cmd = 'go test -race'
   filter = ''
   if opts[:coverage_file]
     cmd += " -coverprofile=#{opts[:coverage_file]} -coverpkg=./..."

--- a/statsd/fixtures.go
+++ b/statsd/fixtures.go
@@ -44,12 +44,14 @@ type GaugeSummary struct {
 
 // TestStatsClient is a mocked StatsClient that records all calls and replies with configurable error return values.
 type TestStatsClient struct {
-	GaugeErr       error
-	GaugeCalls     []StatsClientGaugeArgs
-	gaugeLock      sync.Mutex
-	CountErr       error
-	CountCalls     []StatsClientCountArgs
-	countLock      sync.Mutex
+	gaugeLock  sync.Mutex
+	GaugeErr   error
+	GaugeCalls []StatsClientGaugeArgs
+
+	countLock  sync.RWMutex
+	CountErr   error
+	CountCalls []StatsClientCountArgs
+
 	HistogramErr   error
 	HistogramCalls []StatsClientHistogramArgs
 	histogramLock  sync.Mutex
@@ -83,6 +85,8 @@ func (c *TestStatsClient) Histogram(name string, value float64, tags []string, r
 func (c *TestStatsClient) GetCountSummaries() map[string]*CountSummary {
 	result := map[string]*CountSummary{}
 
+	c.countLock.RLock()
+	defer c.countLock.RUnlock()
 	for _, countCall := range c.CountCalls {
 		name := countCall.Name
 		summary, ok := result[name]

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -62,10 +62,11 @@ func TestServiceWriter_ServiceHandling(t *testing.T) {
 	}
 
 	mergedMetadata := mergeMetadataInOrder(metadata1, metadata2)
+	successPayloads := testEndpoint.SuccessPayloads()
 
-	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
-	assertMetadata(assert, expectedHeaders, metadata1, testEndpoint.SuccessPayloads[0])
-	assertMetadata(assert, expectedHeaders, mergedMetadata, testEndpoint.SuccessPayloads[1])
+	assert.Len(successPayloads, 2, "There should be 2 payloads")
+	assertMetadata(assert, expectedHeaders, metadata1, successPayloads[0])
+	assertMetadata(assert, expectedHeaders, mergedMetadata, successPayloads[1])
 }
 
 func TestServiceWriter_UpdateInfoHandling(t *testing.T) {
@@ -105,7 +106,7 @@ func TestServiceWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint with no retry
-	testEndpoint.Err = fmt.Errorf("non retriable error")
+	testEndpoint.SetError(fmt.Errorf("non retriable error"))
 	expectedNumErrors++
 	metadata3 := fixtures.RandomServices(10, 10)
 	serviceChannel <- metadata3
@@ -116,10 +117,10 @@ func TestServiceWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
-	testEndpoint.Err = &RetriableError{
+	testEndpoint.SetError(&RetriableError{
 		err:      fmt.Errorf("retriable error"),
 		endpoint: testEndpoint,
-	}
+	})
 	expectedMinNumRetries++
 	metadata4 := fixtures.RandomServices(10, 10)
 	serviceChannel <- metadata4

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -46,10 +46,11 @@ func TestStatsWriter_StatHandling(t *testing.T) {
 	close(statsChannel)
 	statsWriter.Stop()
 
-	// Then the endpoint should have received 2 payloads, containing all stat buckets
-	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
+	payloads := testEndpoint.SuccessPayloads()
 
-	payloads := testEndpoint.SuccessPayloads
+	// Then the endpoint should have received 2 payloads, containing all stat buckets
+	assert.Len(payloads, 2, "There should be 2 payloads")
+
 	payload1 := payloads[0]
 	payload2 := payloads[1]
 
@@ -104,7 +105,7 @@ func TestStatsWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
 
 	// And then sending a third payload with other 3 buckets with an errored out endpoint
-	testEndpoint.Err = fmt.Errorf("non retriable error")
+	testEndpoint.SetError(fmt.Errorf("non retriable error"))
 	expectedNumErrors++
 	payload3Buckets := []model.StatsBucket{
 		fixtures.RandomStatsBucket(5),
@@ -119,10 +120,10 @@ func TestStatsWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
-	testEndpoint.Err = &RetriableError{
+	testEndpoint.SetError(&RetriableError{
 		err:      fmt.Errorf("non retriable error"),
 		endpoint: testEndpoint,
-	}
+	})
 	expectedMinNumRetries++
 	payload4Buckets := []model.StatsBucket{
 		fixtures.RandomStatsBucket(5),

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -66,8 +66,8 @@ func TestTraceWriter_TraceHandling(t *testing.T) {
 		"Content-Encoding":             "gzip",
 	}
 
-	assert.Len(testEndpoint.SuccessPayloads, 2, "There should be 2 payloads")
-	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads)
+	assert.Len(testEndpoint.SuccessPayloads(), 2, "There should be 2 payloads")
+	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads())
 }
 
 func TestTraceWriter_BigTraceHandling(t *testing.T) {
@@ -114,8 +114,8 @@ func TestTraceWriter_BigTraceHandling(t *testing.T) {
 	}
 
 	expectedNumPayloads := int(math.Ceil(float64(numSpans) / float64(traceWriter.conf.MaxSpansPerPayload)))
-	assert.Len(testEndpoint.SuccessPayloads, expectedNumPayloads, "There should be more than 1 payload")
-	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads)
+	assert.Len(testEndpoint.SuccessPayloads(), expectedNumPayloads, "There should be more than 1 payload")
+	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads())
 }
 
 func TestTraceWriter_UpdateInfoHandling(t *testing.T) {
@@ -172,7 +172,7 @@ func TestTraceWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * traceWriter.conf.FlushPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint
-	testEndpoint.Err = fmt.Errorf("non retriable error")
+	testEndpoint.SetError(fmt.Errorf("non retriable error"))
 	expectedNumErrors++
 	payload3Traces := []model.Trace{
 		fixtures.RandomTrace(3, 1),
@@ -191,10 +191,10 @@ func TestTraceWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * traceWriter.conf.FlushPeriod)
 
 	// And then sending a fourth payload with other 3 traces with an errored out endpoint but retriable
-	testEndpoint.Err = &RetriableError{
+	testEndpoint.SetError(&RetriableError{
 		err:      fmt.Errorf("non retriable error"),
 		endpoint: testEndpoint,
-	}
+	})
 	expectedMinNumRetries++
 	payload4Traces := []model.Trace{
 		fixtures.RandomTrace(3, 1),


### PR DESCRIPTION
Running the tests with `go test -race /....` reveals several race conditions. This PR fixes them and enables the flag. It slows CI down a bit but adds more thread-safety.