### PR TITLE
{statsd,writer}: keep fixtures private and limited to tests

### DIFF
--- a/fixtures/statsd.go
+++ b/fixtures/statsd.go
@@ -1,4 +1,4 @@
-package statsd
+package fixtures
 
 import (
 	"math"

--- a/writer/payload_test.go
+++ b/writer/payload_test.go
@@ -22,13 +22,13 @@ func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that doesn't fail
-	workingEndpoint := &TestEndpoint{}
+	workingEndpoint := &testEndpoint{}
 
 	// And a queuable sender using that endpoint
 	queuableSender := NewQueuablePayloadSender(workingEndpoint)
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	// When we start the sender
 	monitor.Start()
@@ -64,7 +64,7 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that initially works ok
-	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint := &testEndpoint{}
 
 	// And a test backoff timer that can be triggered on-demand
 	testBackoffTimer := fixtures.NewTestBackoffTimer()
@@ -77,7 +77,7 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()
@@ -162,7 +162,7 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that continuously throws out retriable errors
-	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint := &testEndpoint{}
 	flakyEndpoint.SetError(&RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 
 	// And a test backoff timer that can be triggered on-demand
@@ -177,7 +177,7 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()
@@ -232,7 +232,7 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that continuously throws out retriable errors
-	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint := &testEndpoint{}
 	flakyEndpoint.SetError(&RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 
 	// And a test backoff timer that can be triggered on-demand
@@ -247,7 +247,7 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()
@@ -301,7 +301,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that continuously throws out retriable errors
-	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint := &testEndpoint{}
 	flakyEndpoint.SetError(&RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 
 	// And a test backoff timer that can be triggered on-demand
@@ -316,7 +316,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()
@@ -358,7 +358,7 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that works
-	workingEndpoint := &TestEndpoint{}
+	workingEndpoint := &testEndpoint{}
 
 	// And a test backoff timer that can be triggered on-demand
 	testBackoffTimer := fixtures.NewTestBackoffTimer()
@@ -372,7 +372,7 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()
@@ -403,7 +403,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	assert := assert.New(t)
 
 	// Given an endpoint that continuously throws out retriable errors
-	flakyEndpoint := &TestEndpoint{}
+	flakyEndpoint := &testEndpoint{}
 	flakyEndpoint.SetError(&RetriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 
 	// And a test backoff timer that can be triggered on-demand
@@ -418,7 +418,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	queuableSender.syncBarrier = syncBarrier
 
 	// And a test monitor for that sender
-	monitor := NewTestPayloadSenderMonitor(queuableSender)
+	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
 	queuableSender.Start()

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -190,15 +189,15 @@ func assertMetadata(assert *assert.Assertions, expectedHeaders map[string]string
 	assert.Equal(expectedMetadata, servicesMetadata, "Service metadata should match expectation")
 }
 
-func testServiceWriter() (*ServiceWriter, chan model.ServicesMetadata, *TestEndpoint, *statsd.TestStatsClient) {
+func testServiceWriter() (*ServiceWriter, chan model.ServicesMetadata, *testEndpoint, *fixtures.TestStatsClient) {
 	serviceChannel := make(chan model.ServicesMetadata)
 	conf := &config.AgentConfig{
 		ServiceWriterConfig: writerconfig.DefaultServiceWriterConfig(),
 	}
 	serviceWriter := NewServiceWriter(conf, serviceChannel)
-	testEndpoint := &TestEndpoint{}
+	testEndpoint := &testEndpoint{}
 	serviceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
-	testStatsClient := &statsd.TestStatsClient{}
+	testStatsClient := &fixtures.TestStatsClient{}
 	serviceWriter.statsClient = testStatsClient
 
 	return serviceWriter, serviceChannel, testEndpoint, testStatsClient

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -200,7 +199,7 @@ func assertStatsPayload(assert *assert.Assertions, headers map[string]string, bu
 	assert.Equal(buckets, statsPayload.Stats, "Stat buckets should match expectation")
 }
 
-func testStatsWriter() (*StatsWriter, chan []model.StatsBucket, *TestEndpoint, *statsd.TestStatsClient) {
+func testStatsWriter() (*StatsWriter, chan []model.StatsBucket, *testEndpoint, *fixtures.TestStatsClient) {
 	statsChannel := make(chan []model.StatsBucket)
 	conf := &config.AgentConfig{
 		HostName:          testHostName,
@@ -208,9 +207,9 @@ func testStatsWriter() (*StatsWriter, chan []model.StatsBucket, *TestEndpoint, *
 		StatsWriterConfig: writerconfig.DefaultStatsWriterConfig(),
 	}
 	statsWriter := NewStatsWriter(conf, statsChannel)
-	testEndpoint := &TestEndpoint{}
+	testEndpoint := &testEndpoint{}
 	statsWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
-	testStatsClient := &statsd.TestStatsClient{}
+	testStatsClient := &fixtures.TestStatsClient{}
 	statsWriter.statsClient = testStatsClient
 
 	return statsWriter, statsChannel, testEndpoint, testStatsClient

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-trace-agent/fixtures"
 	"github.com/DataDog/datadog-trace-agent/info"
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -338,7 +337,7 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 
 }
 
-func testTraceWriter() (*TraceWriter, chan *model.Trace, *TestEndpoint, *statsd.TestStatsClient) {
+func testTraceWriter() (*TraceWriter, chan *model.Trace, *testEndpoint, *fixtures.TestStatsClient) {
 	traceChannel := make(chan *model.Trace)
 	transactionChannel := make(chan *model.Span)
 	conf := &config.AgentConfig{
@@ -347,9 +346,9 @@ func testTraceWriter() (*TraceWriter, chan *model.Trace, *TestEndpoint, *statsd.
 		TraceWriterConfig: writerconfig.DefaultTraceWriterConfig(),
 	}
 	traceWriter := NewTraceWriter(conf, traceChannel, transactionChannel)
-	testEndpoint := &TestEndpoint{}
+	testEndpoint := &testEndpoint{}
 	traceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
-	testStatsClient := &statsd.TestStatsClient{}
+	testStatsClient := &fixtures.TestStatsClient{}
 	traceWriter.statsClient = testStatsClient
 
 	return traceWriter, traceChannel, testEndpoint, testStatsClient


### PR DESCRIPTION
- Moves `statsd/fixtures.go` to `fixtures/statsd.go`
- Makes test functions and types meant for testing unexported in `writer/fixtures.go`