### PR TITLE
cmd/trace-agent: remove exit channels in favor of http.Server and context.Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ install:
 
 ci:
 	# task used by CI
+	GOOS=windows go build ./cmd/trace-agent # ensure windows builds
 	go get -u github.com/golang/lint/golint/...
 	golint ./cmd/trace-agent ./filters ./fixtures ./info ./quantile ./quantizer ./sampler ./statsd ./watchdog ./writer
 	go test ./...

--- a/cmd/trace-agent/listener.go
+++ b/cmd/trace-agent/listener.go
@@ -9,28 +9,27 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// StoppableListener wraps a regular TCPListener with an exit channel so we can exit cleanly from the Serve() loop of our HTTP server
-type StoppableListener struct {
-	exit      chan struct{}
+// RateLimitedListener wraps a regular TCPListener with rate limiting.
+type RateLimitedListener struct {
 	connLease int32 // How many connections are available for this listener before rate-limiting kicks in
 	*net.TCPListener
 }
 
-// NewStoppableListener returns a new wrapped listener, which is non-initialized
-func NewStoppableListener(l net.Listener, exit chan struct{}, conns int) (*StoppableListener, error) {
+// NewRateLimitedListener returns a new wrapped listener, which is non-initialized
+func NewRateLimitedListener(l net.Listener, conns int) (*RateLimitedListener, error) {
 	tcpL, ok := l.(*net.TCPListener)
 
 	if !ok {
 		return nil, errors.New("cannot wrap listener")
 	}
 
-	sl := &StoppableListener{exit: exit, connLease: int32(conns), TCPListener: tcpL}
+	sl := &RateLimitedListener{connLease: int32(conns), TCPListener: tcpL}
 
 	return sl, nil
 }
 
 // Refresh periodically refreshes the connection lease, and thus cancels any rate limits in place
-func (sl *StoppableListener) Refresh(conns int) {
+func (sl *RateLimitedListener) Refresh(conns int) {
 	for range time.Tick(30 * time.Second) {
 		atomic.StoreInt32(&sl.connLease, int32(conns))
 		log.Debugf("Refreshed the connection lease: %d conns available", conns)
@@ -50,8 +49,8 @@ func (e *RateLimitedError) Temporary() bool { return true }
 // Timeout tells the HTTP server loop that this error is not a timeout
 func (e *RateLimitedError) Timeout() bool { return false }
 
-// Accept reimplements the regular Accept but adds a check on the exit channel and returns if needed
-func (sl *StoppableListener) Accept() (net.Conn, error) {
+// Accept reimplements the regular Accept but adds rate limiting.
+func (sl *RateLimitedListener) Accept() (net.Conn, error) {
 	if atomic.LoadInt32(&sl.connLease) <= 0 {
 		// we've reached our cap for this lease period, reject the request
 		return nil, &RateLimitedError{}
@@ -62,16 +61,6 @@ func (sl *StoppableListener) Accept() (net.Conn, error) {
 		sl.SetDeadline(time.Now().Add(time.Second))
 
 		newConn, err := sl.TCPListener.Accept()
-
-		//Check for the channel being closed
-		select {
-		case <-sl.exit:
-			log.Debug("stopping listener")
-			sl.TCPListener.Close()
-			return nil, errors.New("listener stopped")
-		default:
-			//If the channel is still open, continue as normal
-		}
 
 		if err != nil {
 			netErr, ok := err.(net.Error)

--- a/cmd/trace-agent/main_nix.go
+++ b/cmd/trace-agent/main_nix.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	_ "net/http/pprof"
 
@@ -28,13 +29,13 @@ func init() {
 
 // main is the main application entry point
 func main() {
-	exit := make(chan struct{})
+	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	// Handle stops properly
 	go func() {
 		defer watchdog.LogOnPanic()
-		handleSignal(exit)
+		handleSignal(cancelFunc)
 	}()
 
-	runAgent(exit)
+	runAgent(ctx)
 }

--- a/cmd/trace-agent/receiver_test.go
+++ b/cmd/trace-agent/receiver_test.go
@@ -63,10 +63,7 @@ func TestReceiverRequestBodyLength(t *testing.T) {
 	go receiver.Run()
 
 	defer func() {
-		close(receiver.exit)
-		// we need to wait more than on second (time for StoppableListener.Accept
-		// to acknowledge the connection has been closed)
-		time.Sleep(2 * time.Second)
+		receiver.Stop()
 		http.DefaultServeMux = defaultMux
 	}()
 


### PR DESCRIPTION
In this change:

* Removes `exit` channel from StoppableListener and instead just uses [`(*http.Server).Shutdown`](https://golang.org/pkg/net/http/#Server.Shutdown) from the standard library (introduced in Go 1.8)
* Removes `exit` channel from the agent and instead uses the more idiomatic cancellation context.
* Adds the Windows build to CI.