### PR TITLE
writer: inherit and use "skip_ssl_validation" setting from Agent v{5,6}

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -65,7 +65,8 @@ type AgentConfig struct {
 	WatchdogInterval time.Duration // WatchdogInterval is the delay between 2 watchdog checks
 
 	// http/s proxying
-	ProxyURL *url.URL
+	ProxyURL          *url.URL
+	SkipSSLValidation bool
 
 	// filtering
 	Ignore map[string][]string

--- a/config/merge_ini.go
+++ b/config/merge_ini.go
@@ -67,6 +67,13 @@ func mergeIniConfig(c *AgentConfig, conf *File) error {
 		} else if pURL != nil {
 			c.ProxyURL = pURL
 		}
+
+		switch m.Key("skip_ssl_validation").MustString("") {
+		case "yes", "true", "1":
+			c.SkipSSLValidation = true
+		case "no", "false", "0":
+			c.SkipSSLValidation = false
+		}
 	}
 
 	// [trace.api] section

--- a/config/merge_yaml.go
+++ b/config/merge_yaml.go
@@ -18,10 +18,11 @@ import (
 // YamlAgentConfig is a structure used for marshaling the datadog.yaml configuration
 // available in Agent versions >= 6
 type YamlAgentConfig struct {
-	APIKey   string `yaml:"api_key"`
-	HostName string `yaml:"hostname"`
-	LogLevel string `yaml:"log_level"`
-	Proxy    proxy  `yaml:"proxy"`
+	APIKey            string `yaml:"api_key"`
+	HostName          string `yaml:"hostname"`
+	LogLevel          string `yaml:"log_level"`
+	Proxy             proxy  `yaml:"proxy"`
+	SkipSSLValidation *bool  `yaml:"skip_ssl_validation"`
 
 	StatsdPort int `yaml:"dogstatsd_port"`
 
@@ -141,6 +142,10 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) error {
 				log.Errorf("Failed to parse proxy URL from proxy.https configuration: %s", err)
 			}
 		}
+	}
+
+	if yc.SkipSSLValidation != nil {
+		agentConf.SkipSSLValidation = *yc.SkipSSLValidation
 	}
 
 	if yc.TraceAgent.Enabled != nil {

--- a/writer/client.go
+++ b/writer/client.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -12,20 +13,13 @@ import (
 const timeout = 10 * time.Second
 
 // NewClient returns a http.Client configured with the Agent options.
-func NewClient(conf *config.AgentConfig) (client *http.Client) {
+func NewClient(conf *config.AgentConfig) *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.SkipSSLValidation},
+	}
 	if conf.ProxyURL != nil {
 		log.Infof("configuring proxy through host %s", conf.ProxyURL.Hostname())
-		client = &http.Client{
-			Timeout: timeout,
-			Transport: &http.Transport{
-				Proxy: http.ProxyURL(conf.ProxyURL),
-			},
-		}
-	} else {
-		client = &http.Client{
-			Timeout: timeout,
-		}
+		transport.Proxy = http.ProxyURL(conf.ProxyURL)
 	}
-
-	return
+	return &http.Client{Timeout: timeout, Transport: transport}
 }


### PR DESCRIPTION
This should permit use-cases of running the agent behind a proxy such as `haproxy`, using the `skip_ssl_validation: true` setting in the config file.