### PR TITLE
Improvements to trace writer and payload queue behaviour.

### DIFF
--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -134,6 +134,7 @@ func (w *ServiceWriter) flush() {
 	data, err := model.EncodeServicesPayload(w.serviceBuffer)
 	if err != nil {
 		log.Errorf("error while encoding service payload: %v", err)
+		w.serviceBuffer = make(model.ServicesMetadata)
 		return
 	}
 

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -43,12 +43,16 @@ func TestServiceWriter_ServiceHandling(t *testing.T) {
 	// When sending it
 	serviceChannel <- metadata1
 
+	// And then immediately sending another set of service metadata
+	metadata2 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata2
+
 	// And then waiting for more than flush period
 	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
 
-	// And then sending another set of service metadata
-	metadata2 := fixtures.RandomServices(10, 10)
-	serviceChannel <- metadata2
+	// And then sending a third set of service metadata
+	metadata3 := fixtures.RandomServices(10, 10)
+	serviceChannel <- metadata3
 
 	// And stopping service writer before flush ticker ticks (should still flush on exit though)
 	close(serviceChannel)
@@ -64,8 +68,8 @@ func TestServiceWriter_ServiceHandling(t *testing.T) {
 	successPayloads := testEndpoint.SuccessPayloads()
 
 	assert.Len(successPayloads, 2, "There should be 2 payloads")
-	assertMetadata(assert, expectedHeaders, metadata1, successPayloads[0])
-	assertMetadata(assert, expectedHeaders, mergedMetadata, successPayloads[1])
+	assertMetadata(assert, expectedHeaders, mergedMetadata, successPayloads[0])
+	assertMetadata(assert, expectedHeaders, metadata3, successPayloads[1])
 }
 
 func TestServiceWriter_UpdateInfoHandling(t *testing.T) {

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -210,6 +210,7 @@ func (w *TraceWriter) flush() {
 	serialized, err := proto.Marshal(&tracePayload)
 	if err != nil {
 		log.Errorf("failed to serialize trace payload, data got dropped, err: %s", err)
+		w.resetBuffer()
 		return
 	}
 
@@ -244,7 +245,10 @@ func (w *TraceWriter) flush() {
 
 	log.Debugf("flushing traces=%v transactions=%v", len(w.traces), len(w.transactions))
 	w.payloadSender.Send(payload)
+	w.resetBuffer()
+}
 
+func (w *TraceWriter) resetBuffer() {
 	// Reset traces
 	w.traces = w.traces[:0]
 	w.transactions = w.transactions[:0]


### PR DESCRIPTION
* Payload queue could become stuck if queued payloads all expired due to max age before next flush (queue would become of size 0, so we'd never leave the queue state but we'd also never schedule a new retry).
* Clean old (bigger than max age) payloads when inserting new ones not just on flush.
* When we can't serialize a trace or service payload, we should reset our buffers because otherwise we'll probably end up in a serialization error loop and no progress will be made.
* Fixed a flaky test in service writer after logic changes to the buffering mechanism.