### PR TITLE
build: Makefile defaults acting up due to extra space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ VERSION_MINOR = $(shell echo $(word 2, $(SPLAT)) | sed 's/[^0-9]*//g')
 VERSION_PATCH = $(shell echo $(word 3, $(SPLAT)) | sed 's/[^0-9]*//g')
 
 # account for some defaults
-VERSION_MAJOR := $(if $(VERSION_MAJOR),$(VERSION_MAJOR), 0)
-VERSION_MINOR := $(if $(VERSION_MINOR),$(VERSION_MINOR), 0)
-VERSION_PATCH := $(if $(VERSION_PATCH),$(VERSION_PATCH), 0)
+VERSION_MAJOR := $(if $(VERSION_MAJOR),$(VERSION_MAJOR),0)
+VERSION_MINOR := $(if $(VERSION_MINOR),$(VERSION_MINOR),99)
+VERSION_PATCH := $(if $(VERSION_PATCH),$(VERSION_PATCH),0)
 
 install:
 	# prepares all dependencies by running the 'deps' task, generating


### PR DESCRIPTION
The extra space was being included in the vars messing up the calls to `windmc` and `winres` when a  `TRACE_AGENT_VERSION` that didn't match semver `maj.min.patch` was being passed (this scenario could happen from omnibus).

Also, if we typically default to `0.99.0` if nothing was set, we should also default to `0.99.0` if a weird version (ie. branch name) is passed to the agent.