### PR TITLE
writer: ensure 64bit alignment on 32bit systems

### DIFF
--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -16,9 +16,9 @@ import (
 
 // ServiceWriter ingests service metadata and flush them to the API.
 type ServiceWriter struct {
+	stats      info.ServiceWriterInfo
 	conf       writerconfig.ServiceWriterConfig
 	InServices <-chan model.ServicesMetadata
-	stats      info.ServiceWriterInfo
 
 	serviceBuffer model.ServicesMetadata
 

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -16,11 +16,11 @@ import (
 
 // StatsWriter ingests stats buckets and flushes their aggregation to the API.
 type StatsWriter struct {
+	stats    info.StatsWriterInfo
 	hostName string
 	env      string
 	conf     writerconfig.StatsWriterConfig
 	InStats  <-chan []model.StatsBucket
-	stats    info.StatsWriterInfo
 
 	BaseWriter
 }

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -19,12 +19,12 @@ import (
 
 // TraceWriter ingests sampled traces and flushes them to the API.
 type TraceWriter struct {
+	stats          info.TraceWriterInfo
 	hostName       string
 	env            string
 	conf           writerconfig.TraceWriterConfig
 	InTraces       <-chan *model.Trace
 	InTransactions <-chan *model.Span
-	stats          info.TraceWriterInfo
 
 	traces        []*model.APITrace
 	transactions  []*model.Span


### PR DESCRIPTION
While letting the trace-agent run on an ARMv7 system (32bit), I encounter some segmentation faults with atomic operations. This is a familiar issue in go, please see https://golang.org/pkg/sync/atomic/#pkg-note-BUG

To fix this, I moved the structs containing the values to be written atomically to the top of the parent struct to ensure that they are 64bit aligned. See link above
> The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.