### PR TITLE
Add dedicated error sampling

### DIFF
--- a/cmd/trace-agent/sampler.go
+++ b/cmd/trace-agent/sampler.go
@@ -31,7 +31,9 @@ func NewScoreSampler(conf *config.AgentConfig) *Sampler {
 	}
 }
 
-// NewErrorsSampler creates a new empty error sampler ready to be started
+// NewErrorsSampler creates a new sampler dedicated to traces containing errors
+// to isolate them from the global max tps. It behaves exactly like the normal
+// ScoreSampler except that its statistics are reported under a different name.
 func NewErrorsSampler(conf *config.AgentConfig) *Sampler {
 	return &Sampler{
 		engine: sampler.NewErrorsEngine(conf.ExtraSampleRate, conf.MaxTPS),

--- a/info/info.go
+++ b/info/info.go
@@ -34,6 +34,7 @@ var (
 	watchdogInfo        watchdog.Info
 	samplerInfo         SamplerInfo
 	prioritySamplerInfo SamplerInfo
+	errorsSamplerInfo   SamplerInfo
 	rateByService       map[string]float64
 	preSamplerStats     sampler.PreSamplerStats
 	start               = time.Now()
@@ -155,7 +156,7 @@ func publishSamplerInfo() interface{} {
 	return samplerInfo
 }
 
-// UpdatePrioritySamplerInfo updates internal stats about priority sampking
+// UpdatePrioritySamplerInfo updates internal stats about priority sampling
 func UpdatePrioritySamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -167,6 +168,20 @@ func publishPrioritySamplerInfo() interface{} {
 	infoMu.RLock()
 	defer infoMu.RUnlock()
 	return prioritySamplerInfo
+}
+
+// UpdateErrorsSamplerInfo updates internal stats about error sampling
+func UpdateErrorsSamplerInfo(ss SamplerInfo) {
+	infoMu.Lock()
+	defer infoMu.Unlock()
+
+	errorsSamplerInfo = ss
+}
+
+func publishErrorsSamplerInfo() interface{} {
+	infoMu.RLock()
+	defer infoMu.RUnlock()
+	return errorsSamplerInfo
 }
 
 // UpdateRateByService updates the RateByService map
@@ -239,6 +254,7 @@ func InitInfo(conf *config.AgentConfig) error {
 		expvar.Publish("stats_writer", expvar.Func(publishStatsWriterInfo))
 		expvar.Publish("service_writer", expvar.Func(publishServiceWriterInfo))
 		expvar.Publish("prioritysampler", expvar.Func(publishPrioritySamplerInfo))
+		expvar.Publish("errorssampler", expvar.Func(publishErrorsSamplerInfo))
 		expvar.Publish("ratebyservice", expvar.Func(publishRateByService))
 		expvar.Publish("watchdog", expvar.Func(publishWatchdogInfo))
 		expvar.Publish("presampler", expvar.Func(publishPreSamplerStats))

--- a/info/info.go
+++ b/info/info.go
@@ -110,7 +110,7 @@ const (
 `
 )
 
-// UpdateReceiverStats updates internal stats about the receiver
+// UpdateReceiverStats updates internal stats about the receiver.
 func UpdateReceiverStats(rs *ReceiverStats) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -128,7 +128,7 @@ func UpdateReceiverStats(rs *ReceiverStats) {
 	languages = rs.Languages()
 }
 
-// Languages exposes languages reporting traces to the Agent
+// Languages exposes languages reporting traces to the Agent.
 func Languages() []string {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -142,7 +142,7 @@ func publishReceiverStats() interface{} {
 	return receiverStats
 }
 
-// UpdateSamplerInfo updates internal stats about signature sampling
+// UpdateSamplerInfo updates internal stats about signature sampling.
 func UpdateSamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -156,7 +156,7 @@ func publishSamplerInfo() interface{} {
 	return samplerInfo
 }
 
-// UpdatePrioritySamplerInfo updates internal stats about priority sampling
+// UpdatePrioritySamplerInfo updates internal stats about priority sampling.
 func UpdatePrioritySamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -170,7 +170,7 @@ func publishPrioritySamplerInfo() interface{} {
 	return prioritySamplerInfo
 }
 
-// UpdateErrorsSamplerInfo updates internal stats about error sampling
+// UpdateErrorsSamplerInfo updates internal stats about error sampling.
 func UpdateErrorsSamplerInfo(ss SamplerInfo) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -184,7 +184,7 @@ func publishErrorsSamplerInfo() interface{} {
 	return errorsSamplerInfo
 }
 
-// UpdateRateByService updates the RateByService map
+// UpdateRateByService updates the RateByService map.
 func UpdateRateByService(rbs map[string]float64) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -197,7 +197,7 @@ func publishRateByService() interface{} {
 	return rateByService
 }
 
-// UpdateWatchdogInfo updates internal stats about the watchdog
+// UpdateWatchdogInfo updates internal stats about the watchdog.
 func UpdateWatchdogInfo(wi watchdog.Info) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -210,7 +210,7 @@ func publishWatchdogInfo() interface{} {
 	return watchdogInfo
 }
 
-// UpdatePreSampler updates internal stats about the pre-sampling
+// UpdatePreSampler updates internal stats about the pre-sampling.
 func UpdatePreSampler(ss sampler.PreSamplerStats) {
 	infoMu.Lock()
 	defer infoMu.Unlock()

--- a/info/sampler.go
+++ b/info/sampler.go
@@ -4,8 +4,6 @@ import "github.com/DataDog/datadog-trace-agent/sampler"
 
 // SamplerInfo represents internal stats and state of a sampler
 type SamplerInfo struct {
-	// EngineType contains the type of the engine (tells old sampler and new distributed sampler apart)
-	EngineType string
 	// Stats contains statistics about what the sampler is doing.
 	Stats SamplerStats
 	// State is the internal state of the sampler (for debugging mostly)

--- a/sampler/coresampler.go
+++ b/sampler/coresampler.go
@@ -33,15 +33,15 @@ const (
 	defaultSignatureScoreSlope  float64       = 3
 )
 
-// EngineType represent the type of a sampler engine
+// EngineType represents the type of a sampler engine.
 type EngineType int
 
 const (
-	// NormalScoreEngineType is the type of the ScoreEngine sampling non-error traces
+	// NormalScoreEngineType is the type of the ScoreEngine sampling non-error traces.
 	NormalScoreEngineType EngineType = iota
-	// ErrorScoreEngineType is the type of the ScoreEngine sampling error traces
+	// ErrorScoreEngineType is the type of the ScoreEngine sampling error traces.
 	ErrorsScoreEngineType
-	// PriorityEngineType is type of the priority sampler engine type
+	// PriorityEngineType is type of the priority sampler engine type.
 	PriorityEngineType
 )
 
@@ -55,7 +55,7 @@ type Engine interface {
 	Sample(trace model.Trace, root *model.Span, env string) bool
 	// GetState returns information about the sampler.
 	GetState() interface{}
-	// GetType returns the type of the sampler
+	// GetType returns the type of the sampler.
 	GetType() EngineType
 }
 

--- a/sampler/coresampler.go
+++ b/sampler/coresampler.go
@@ -33,6 +33,18 @@ const (
 	defaultSignatureScoreSlope  float64       = 3
 )
 
+// EngineType represent the type of a sampler engine
+type EngineType int
+
+const (
+	// NormalScoreEngineType is the type of the ScoreEngine sampling non-error traces
+	NormalScoreEngineType EngineType = iota
+	// ErrorScoreEngineType is the type of the ScoreEngine sampling error traces
+	ErrorsScoreEngineType
+	// PriorityEngineType is type of the priority sampler engine type
+	PriorityEngineType
+)
+
 // Engine is a common basic interface for sampler engines.
 type Engine interface {
 	// Run the sampler.
@@ -43,6 +55,8 @@ type Engine interface {
 	Sample(trace model.Trace, root *model.Span, env string) bool
 	// GetState returns information about the sampler.
 	GetState() interface{}
+	// GetType returns the type of the sampler
+	GetType() EngineType
 }
 
 // Sampler is the main component of the sampling logic

--- a/sampler/prioritysampler.go
+++ b/sampler/prioritysampler.go
@@ -135,3 +135,8 @@ func (s *PriorityEngine) getRateByService() map[string]float64 {
 	s.catalogMu.Lock()
 	return s.catalog.getRateByService(s.Sampler.GetAllSignatureSampleRates(), s.Sampler.GetDefaultSampleRate())
 }
+
+// GetType return the type of the sampler engine
+func (s *PriorityEngine) GetType() EngineType {
+	return PriorityEngineType
+}

--- a/sampler/scoresampler.go
+++ b/sampler/scoresampler.go
@@ -20,13 +20,25 @@ import (
 // ScoreEngine is the main component of the sampling logic
 type ScoreEngine struct {
 	// Sampler is the underlying sampler used by this engine, sharing logic among various engines.
-	Sampler *Sampler
+	Sampler    *Sampler
+	engineType EngineType
 }
 
 // NewScoreEngine returns an initialized Sampler
 func NewScoreEngine(extraRate float64, maxTPS float64) *ScoreEngine {
 	s := &ScoreEngine{
-		Sampler: newSampler(extraRate, maxTPS),
+		Sampler:    newSampler(extraRate, maxTPS),
+		engineType: NormalScoreEngineType,
+	}
+
+	return s
+}
+
+// NewErrorEngine returns an initialized Sampler
+func NewErrorsEngine(extraRate float64, maxTPS float64) *ScoreEngine {
+	s := &ScoreEngine{
+		Sampler:    newSampler(extraRate, maxTPS),
+		engineType: ErrorsScoreEngineType,
 	}
 
 	return s
@@ -88,4 +100,9 @@ func (s *ScoreEngine) Sample(trace model.Trace, root *model.Span, env string) bo
 // It returns an interface{}, as other samplers might return other informations.
 func (s *ScoreEngine) GetState() interface{} {
 	return s.Sampler.GetState()
+}
+
+// GetType returns the type of the sampler
+func (s *ScoreEngine) GetType() EngineType {
+	return s.engineType
 }

--- a/sampler/scoresampler.go
+++ b/sampler/scoresampler.go
@@ -34,7 +34,9 @@ func NewScoreEngine(extraRate float64, maxTPS float64) *ScoreEngine {
 	return s
 }
 
-// NewErrorEngine returns an initialized Sampler
+// NewErrorEngine returns an initialized Sampler dedicate to errors. It behaves
+// just like the the normal ScoreEngine except for its GetType method (useful
+// for reporting).
 func NewErrorsEngine(extraRate float64, maxTPS float64) *ScoreEngine {
 	s := &ScoreEngine{
 		Sampler:    newSampler(extraRate, maxTPS),


### PR DESCRIPTION
This PR add a dedicated error sampler to the trace-agent. The goal of this is to keep more error traces (which are the most interesting ones).

With this PR the `trace-agent` will maintain two different score samplers that will each have their own maximum TPS. One for traces containing errors and one for other traces. That way the TPS of errors that the agent sends to the API will be independent from the TPS of traces containing no errors.