### PR TITLE
quantizer: make sure there are enough elements in slice before accessing

### DIFF
--- a/quantizer/redis.go
+++ b/quantizer/redis.go
@@ -53,7 +53,7 @@ func QuantizeRedis(span *model.Span) {
 
 		command := strings.ToUpper(args[0])
 
-		if redisCompoundCommandSet[command] {
+		if redisCompoundCommandSet[command] && len(args) > 1 {
 			if strings.HasSuffix(args[1], redisTruncationMark) {
 				truncated = true
 				continue


### PR DESCRIPTION
Fixes a panic which occurred in situations where the number of arguments
was "unorthodox".