### PR TITLE
writer: Set additional HTTP headers when querying Datadog.

### DIFF
--- a/writer/datadog_endpoint.go
+++ b/writer/datadog_endpoint.go
@@ -4,9 +4,21 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+
+	"github.com/DataDog/datadog-trace-agent/info"
 )
 
-const apiHTTPHeaderKey = "DD-Api-Key"
+const (
+	userAgentPrefix     = "Datadog Trace Agent"
+	userAgentSupportURL = "https://github.com/DataDog/datadog-trace-agent"
+)
+
+// userAgent is the computed user agent we'll use when
+// communicating with Datadog
+var userAgent = fmt.Sprintf(
+	"%s/%s/%s (+%s)",
+	userAgentPrefix, info.Version, info.GitCommit, userAgentSupportURL,
+)
 
 // DatadogEndpoint sends payloads to Datadog API.
 type DatadogEndpoint struct {
@@ -41,9 +53,8 @@ func (e *DatadogEndpoint) Write(payload *Payload) error {
 		return err
 	}
 
-	// Set API key in the header and issue the request
-	req.Header.Set(apiHTTPHeaderKey, e.apiKey)
-
+	req.Header.Set("DD-Api-Key", e.apiKey)
+	req.Header.Set("User-Agent", userAgent)
 	SetExtraHeaders(req.Header, payload.Headers)
 
 	resp, err := e.client.Do(req)


### PR DESCRIPTION
User-Agent: A helpful information to have. Instead of the Go default
(`Go-http-client/1.1`), the string will be unique to the tracer, will
have the version, and a link to this GitHub repo (example: `Datadog Trace Agent/6.2.0/422142 (+https://github.com/DataDog/datadog-trace-agent)`).