### PR TITLE
model: Use original metric name if parsing had an error.

### DIFF
--- a/model/normalizer.go
+++ b/model/normalizer.go
@@ -49,11 +49,11 @@ func (s *Span) Normalize() error {
 		return fmt.Errorf("span.normalize: `Name` too long (max %d chars): %s", MaxNameLen, s.Name)
 	}
 	// name shall comply with Datadog metric name normalization
-	var ok bool
-	s.Name, ok = normMetricNameParse(s.Name)
+	name, ok := normMetricNameParse(s.Name)
 	if !ok {
 		return fmt.Errorf("span.normalize: invalid `Name`: %s", s.Name)
 	}
+	s.Name = name
 
 	// Resource
 	if s.Resource == "" {

--- a/model/normalizer_test.go
+++ b/model/normalizer_test.go
@@ -65,6 +65,20 @@ func TestNormalizeName(t *testing.T) {
 	}
 }
 
+func TestNormalizeNameFailure(t *testing.T) {
+	invalidNames := []string{
+		"",   // Empty.
+		"/",  // No alphanumerics.
+		"//", // Still no alphanumerics.
+		strings.Repeat("x", MaxNameLen+1), // Too long.
+	}
+	s := testSpan()
+	for _, v := range invalidNames {
+		s.Name = v
+		assert.Error(t, s.Normalize())
+	}
+}
+
 func TestNormalizeResourcePassThru(t *testing.T) {
 	s := testSpan()
 	before := s.Resource


### PR DESCRIPTION
Fixes errors that were logged with an empty name, eg:
"dropping trace reason: invalid span  span.normalize: invalid `Name`:"