### PR TITLE
cmd/trace-agent: add a metric when the agent starts.

### DIFF
--- a/cmd/trace-agent/main.go
+++ b/cmd/trace-agent/main.go
@@ -203,6 +203,11 @@ func runAgent(ctx context.Context) {
 		die("cannot configure dogstatsd: %v", err)
 	}
 
+	// count the number of times the agent started
+	statsd.Client.Count("datadog.trace_agent.started", 1, []string{
+		"version:" + info.Version,
+	}, 1)
+
 	// Seed rand
 	rand.Seed(time.Now().UTC().UnixNano())
 


### PR DESCRIPTION
**main: add a metric when the agent starts.**

This metrics allows to track the restarts of the trace-agent,
independently from whatever supervisor it's using.