### PR TITLE
cmd/trace-agent: improvements to trace/transaction writing pipeline.

### DIFF
--- a/cmd/trace-agent/transaction_sampler_test.go
+++ b/cmd/trace-agent/transaction_sampler_test.go
@@ -38,15 +38,8 @@ func TestTransactionSampler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			analyzed := make(chan *model.Span, 1)
 			ts := newTransactionSampler(config)
-			ts.Extract(test.trace, analyzed)
-			close(analyzed)
-
-			analyzedSpans := make([]*model.Span, 0)
-			for s := range analyzed {
-				analyzedSpans = append(analyzedSpans, s)
-			}
+			analyzedSpans := ts.Extract(test.trace)
 
 			if test.expectedSampling {
 				assert.Len(analyzedSpans, 1, fmt.Sprintf("Trace %v should have been sampled", test.trace))

--- a/info/writer.go
+++ b/info/writer.go
@@ -2,13 +2,14 @@ package info
 
 // TraceWriterInfo represents statistics from the trace writer.
 type TraceWriterInfo struct {
-	Payloads     int64
-	Traces       int64
-	Transactions int64
-	Spans        int64
-	Errors       int64
-	Retries      int64
-	Bytes        int64
+	Payloads       int64
+	Traces         int64
+	Transactions   int64
+	Spans          int64
+	Errors         int64
+	Retries        int64
+	Bytes          int64
+	SingleMaxSpans int64
 }
 
 // ServiceWriterInfo represents statistics from the service writer.

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -21,240 +21,231 @@ import (
 var testHostName = "testhost"
 var testEnv = "testenv"
 
-func TestTraceWriter_TraceHandling(t *testing.T) {
-	assert := assert.New(t)
+func TestTraceWriter(t *testing.T) {
+	t.Run("payload flushing", func(t *testing.T) {
+		assert := assert.New(t)
 
-	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
-	traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
-	traceWriter.conf.FlushPeriod = 100 * time.Millisecond
+		// Create a trace writer, its incoming channel and the endpoint that receives the payloads
+		traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
+		// Set a maximum of 4 spans per payload
+		traceWriter.conf.MaxSpansPerPayload = 4
+		traceWriter.Start()
 
-	traceWriter.Start()
+		// Send a few sampled traces through the writer
+		sampledTraces := []*SampledTrace{
+			// These 2 should be grouped together in a single payload
+			randomSampledTrace(1, 1),
+			randomSampledTrace(1, 1),
+			// This one should be on its own in a single payload
+			randomSampledTrace(3, 1),
+			// This one should be on its own in a single payload
+			randomSampledTrace(5, 1),
+			// This one should be on its own in a single payload
+			randomSampledTrace(1, 1),
+		}
+		for _, sampledTrace := range sampledTraces {
+			traceChannel <- sampledTrace
+		}
 
-	// Given a set of 6 test traces
-	testTraces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(3, 5),
-		fixtures.RandomTrace(3, 1),
-	}
+		// Stop the trace writer to force everything to flush
+		close(traceChannel)
+		traceWriter.Stop()
 
-	// When sending those 6 traces
-	for _, trace := range testTraces {
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
+		expectedHeaders := map[string]string{
+			"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+			"Content-Type":                 "application/x-protobuf",
+			"Content-Encoding":             "gzip",
+		}
 
-	// And then waiting for more than flush period
-	time.Sleep(2 * traceWriter.conf.FlushPeriod)
-
-	// And then sending another trace
-	afterTrace := fixtures.RandomTrace(2, 2)
-	testTraces = append(testTraces, afterTrace)
-	traceChannel <- &afterTrace
-
-	// And stopping trace writer before flush ticker ticks (should still flush on exit though)
-	close(traceChannel)
-	traceWriter.Stop()
-
-	// Then the endpoint should have received 2 payloads, containing all sent traces
-	expectedHeaders := map[string]string{
-		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
-		"Content-Type":                 "application/x-protobuf",
-		"Content-Encoding":             "gzip",
-	}
-
-	assert.Len(testEndpoint.SuccessPayloads(), 2, "There should be 2 payloads")
-	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads())
-}
-
-func TestTraceWriter_BigTraceHandling(t *testing.T) {
-	assert := assert.New(t)
-
-	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
-	traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
-	traceWriter.conf.MaxSpansPerPayload = 3
-
-	traceWriter.Start()
-
-	// Given a set of 6 test traces
-	testTraces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(3, 5),
-		fixtures.RandomTrace(3, 1),
-	}
-
-	// When sending those 6 traces
-	for _, trace := range testTraces {
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
-
-	// And stopping trace writer
-	close(traceChannel)
-	traceWriter.Stop()
-
-	// Then the endpoint should have received several payloads, containing all sent traces but not going over
-	// the span limit.
-	expectedHeaders := map[string]string{
-		"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
-		"Content-Type":                 "application/x-protobuf",
-		"Content-Encoding":             "gzip",
-	}
-
-	numSpans := 0
-
-	for _, trace := range testTraces {
-		numSpans += len(trace)
-	}
-
-	expectedNumPayloads := int(math.Ceil(float64(numSpans) / float64(traceWriter.conf.MaxSpansPerPayload)))
-	assert.Len(testEndpoint.SuccessPayloads(), expectedNumPayloads, "There should be more than 1 payload")
-	assertPayloads(assert, traceWriter, expectedHeaders, testTraces, testEndpoint.SuccessPayloads())
-}
-
-func TestTraceWriter_UpdateInfoHandling(t *testing.T) {
-	assert := assert.New(t)
-
-	// Given a trace writer, its incoming channel and the endpoint that receives the payloads
-	traceWriter, traceChannel, testEndpoint, statsClient := testTraceWriter()
-	traceWriter.conf.FlushPeriod = 100 * time.Millisecond
-	traceWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
-
-	traceWriter.Start()
-
-	expectedNumPayloads := int64(0)
-	expectedNumSpans := int64(0)
-	expectedNumTraces := int64(0)
-	expectedNumBytes := int64(0)
-	expectedNumErrors := int64(0)
-	expectedMinNumRetries := int64(0)
-
-	// When sending 1 payload with 3 traces
-	expectedNumPayloads++
-	payload1Traces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-	}
-	for _, trace := range payload1Traces {
-		expectedNumTraces++
-		expectedNumSpans += int64(len(trace))
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
-	expectedNumBytes += calculateTracePayloadSize(payload1Traces)
-
-	// And waiting for twice the flush period to trigger payload sending and info updating
-	time.Sleep(2 * traceWriter.conf.FlushPeriod)
-
-	// And then sending a second payload with other 3 traces
-	expectedNumPayloads++
-	payload2Traces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-	}
-	for _, trace := range payload2Traces {
-		expectedNumTraces++
-		expectedNumSpans += int64(len(trace))
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
-	expectedNumBytes += calculateTracePayloadSize(payload2Traces)
-
-	// And waiting for twice the flush period to trigger payload sending and info updating
-	time.Sleep(2 * traceWriter.conf.FlushPeriod)
-
-	// And then sending a third payload with other 3 traces with an errored out endpoint
-	testEndpoint.SetError(fmt.Errorf("non retriable error"))
-	expectedNumErrors++
-	payload3Traces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-	}
-	for _, trace := range payload3Traces {
-		expectedNumTraces++
-		expectedNumSpans += int64(len(trace))
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
-	expectedNumBytes += calculateTracePayloadSize(payload3Traces)
-
-	// And waiting for twice the flush period to trigger payload sending and info updating
-	time.Sleep(2 * traceWriter.conf.FlushPeriod)
-
-	// And then sending a fourth payload with other 3 traces with an errored out endpoint but retriable
-	testEndpoint.SetError(&RetriableError{
-		err:      fmt.Errorf("non retriable error"),
-		endpoint: testEndpoint,
+		// Ensure that the number of payloads and their contents match our expectations. The MaxSpansPerPayload we
+		// set to 4 at the beginning should have been respected whenever possible.
+		assert.Len(testEndpoint.SuccessPayloads(), 4, "We expected 4 different payloads")
+		assertPayloads(assert, traceWriter, expectedHeaders, sampledTraces, testEndpoint.SuccessPayloads())
 	})
-	expectedMinNumRetries++
-	payload4Traces := []model.Trace{
-		fixtures.RandomTrace(3, 1),
-		fixtures.RandomTrace(1, 3),
-		fixtures.RandomTrace(9, 3),
-	}
-	for _, trace := range payload4Traces {
-		expectedNumTraces++
-		expectedNumSpans += int64(len(trace))
-		traceCopy := trace
-		traceChannel <- &traceCopy
-	}
-	expectedNumBytes += calculateTracePayloadSize(payload4Traces)
 
-	// And waiting for twice the flush period to trigger payload sending and info updating
-	time.Sleep(2 * traceWriter.conf.FlushPeriod)
+	t.Run("periodic flushing", func(t *testing.T) {
+		assert := assert.New(t)
 
-	close(traceChannel)
-	traceWriter.Stop()
+		testFlushPeriod := 100 * time.Millisecond
 
-	// Then we expect some counts to have been sent to the stats client for each update tick (there should have been
-	// at least 3 ticks)
-	countSummaries := statsClient.GetCountSummaries()
+		// Create a trace writer, its incoming channel and the endpoint that receives the payloads
+		traceWriter, traceChannel, testEndpoint, _ := testTraceWriter()
+		// Periodically flushing every 100ms
+		traceWriter.conf.FlushPeriod = testFlushPeriod
+		traceWriter.Start()
 
-	// Payload counts
-	payloadSummary := countSummaries["datadog.trace_agent.trace_writer.payloads"]
-	assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
-	assert.Equal(expectedNumPayloads, payloadSummary.Sum)
+		// Send a single trace that does not go over the span limit
+		testSampledTrace := randomSampledTrace(2, 2)
+		traceChannel <- testSampledTrace
 
-	// Traces counts
-	tracesSummary := countSummaries["datadog.trace_agent.trace_writer.traces"]
-	assert.True(len(tracesSummary.Calls) >= 3, "There should have been multiple traces count calls")
-	assert.Equal(expectedNumTraces, tracesSummary.Sum)
+		// Wait for twice the flush period
+		time.Sleep(2 * testFlushPeriod)
 
-	// Spans counts
-	spansSummary := countSummaries["datadog.trace_agent.trace_writer.spans"]
-	assert.True(len(spansSummary.Calls) >= 3, "There should have been multiple spans count calls")
-	assert.Equal(expectedNumSpans, spansSummary.Sum)
+		// Check that we received 1 payload that was flushed due to periodical flushing and that it matches the
+		// data we sent to the writer
+		receivedPayloads := testEndpoint.SuccessPayloads()
+		expectedHeaders := map[string]string{
+			"X-Datadog-Reported-Languages": strings.Join(info.Languages(), "|"),
+			"Content-Type":                 "application/x-protobuf",
+			"Content-Encoding":             "gzip",
+		}
+		assert.Len(receivedPayloads, 1, "We expected 1 payload")
+		assertPayloads(assert, traceWriter, expectedHeaders, []*SampledTrace{testSampledTrace},
+			testEndpoint.SuccessPayloads())
 
-	// Bytes counts
-	bytesSummary := countSummaries["datadog.trace_agent.trace_writer.bytes"]
-	assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
-	// FIXME: Is GZIP non-deterministic? Why won't equal work here?
-	assert.True(math.Abs(float64(expectedNumBytes-bytesSummary.Sum)) < 100., "Bytes should be within expectations")
+		// Wrap up
+		close(traceChannel)
+		traceWriter.Stop()
+	})
 
-	// Retry counts
-	retriesSummary := countSummaries["datadog.trace_agent.trace_writer.retries"]
-	assert.True(len(retriesSummary.Calls) >= 3, "There should have been multiple retries count calls")
-	assert.True(retriesSummary.Sum >= expectedMinNumRetries)
+	t.Run("periodic stats reporting", func(t *testing.T) {
+		assert := assert.New(t)
 
-	// Error counts
-	errorsSummary := countSummaries["datadog.trace_agent.trace_writer.errors"]
-	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
-	assert.Equal(expectedNumErrors, errorsSummary.Sum)
+		testFlushPeriod := 100 * time.Millisecond
+
+		// Create a trace writer, its incoming channel and the endpoint that receives the payloads
+		traceWriter, traceChannel, testEndpoint, statsClient := testTraceWriter()
+		traceWriter.conf.FlushPeriod = 100 * time.Millisecond
+		traceWriter.conf.UpdateInfoPeriod = 100 * time.Millisecond
+		traceWriter.conf.MaxSpansPerPayload = 10
+		traceWriter.Start()
+
+		var (
+			expectedNumPayloads       int64
+			expectedNumSpans          int64
+			expectedNumTraces         int64
+			expectedNumBytes          int64
+			expectedNumErrors         int64
+			expectedMinNumRetries     int64
+			expectedNumSingleMaxSpans int64
+		)
+
+		// Send a bunch of sampled traces that should go together in a single payload
+		payload1SampledTraces := []*SampledTrace{
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+		}
+		expectedNumPayloads++
+		expectedNumSpans += 6
+		expectedNumTraces += 3
+		expectedNumBytes += calculateTracePayloadSize(payload1SampledTraces)
+
+		for _, sampledTrace := range payload1SampledTraces {
+			traceChannel <- sampledTrace
+		}
+
+		// Send a single trace that goes over the span limit
+		payload2SampledTraces := []*SampledTrace{
+			randomSampledTrace(20, 0),
+		}
+		expectedNumPayloads++
+		expectedNumSpans += 20
+		expectedNumTraces += 1
+		expectedNumBytes += calculateTracePayloadSize(payload2SampledTraces)
+		expectedNumSingleMaxSpans += 1
+
+		for _, sampledTrace := range payload2SampledTraces {
+			traceChannel <- sampledTrace
+		}
+
+		// Wait for twice the flush period
+		time.Sleep(2 * testFlushPeriod)
+
+		// Send a third payload with other 3 traces with an errored out endpoint
+		testEndpoint.SetError(fmt.Errorf("non retriable error"))
+		payload3SampledTraces := []*SampledTrace{
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+		}
+
+		expectedNumErrors++
+		expectedNumTraces += 3
+		expectedNumSpans += 6
+		expectedNumBytes += calculateTracePayloadSize(payload3SampledTraces)
+
+		for _, sampledTrace := range payload3SampledTraces {
+			traceChannel <- sampledTrace
+		}
+
+		// Wait for twice the flush period
+		time.Sleep(2 * testFlushPeriod)
+
+		// And then send a fourth payload with other 3 traces with an errored out endpoint but retriable
+		testEndpoint.SetError(&RetriableError{
+			err:      fmt.Errorf("non retriable error"),
+			endpoint: testEndpoint,
+		})
+		payload4SampledTraces := []*SampledTrace{
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+			randomSampledTrace(2, 0),
+		}
+
+		expectedMinNumRetries++
+		expectedNumTraces += 3
+		expectedNumSpans += 6
+		expectedNumBytes += calculateTracePayloadSize(payload4SampledTraces)
+
+		for _, sampledTrace := range payload4SampledTraces {
+			traceChannel <- sampledTrace
+		}
+
+		// Wait for twice the flush period to see at least one retry
+		time.Sleep(2 * testFlushPeriod)
+
+		// Close and stop
+		close(traceChannel)
+		traceWriter.Stop()
+
+		// Then we expect some counts to have been sent to the stats client for each update tick (there should have been
+		// at least 3 ticks)
+		countSummaries := statsClient.GetCountSummaries()
+
+		// Payload counts
+		payloadSummary := countSummaries["datadog.trace_agent.trace_writer.payloads"]
+		assert.True(len(payloadSummary.Calls) >= 3, "There should have been multiple payload count calls")
+		assert.Equal(expectedNumPayloads, payloadSummary.Sum)
+
+		// Traces counts
+		tracesSummary := countSummaries["datadog.trace_agent.trace_writer.traces"]
+		assert.True(len(tracesSummary.Calls) >= 3, "There should have been multiple traces count calls")
+		assert.Equal(expectedNumTraces, tracesSummary.Sum)
+
+		// Spans counts
+		spansSummary := countSummaries["datadog.trace_agent.trace_writer.spans"]
+		assert.True(len(spansSummary.Calls) >= 3, "There should have been multiple spans count calls")
+		assert.Equal(expectedNumSpans, spansSummary.Sum)
+
+		// Bytes counts
+		bytesSummary := countSummaries["datadog.trace_agent.trace_writer.bytes"]
+		assert.True(len(bytesSummary.Calls) >= 3, "There should have been multiple bytes count calls")
+		// FIXME: Is GZIP non-deterministic? Why won't equal work here?
+		assert.True(math.Abs(float64(expectedNumBytes-bytesSummary.Sum)) < 100., "Bytes should be within expectations")
+
+		// Retry counts
+		retriesSummary := countSummaries["datadog.trace_agent.trace_writer.retries"]
+		assert.True(len(retriesSummary.Calls) >= 3, "There should have been multiple retries count calls")
+		assert.True(retriesSummary.Sum >= expectedMinNumRetries)
+
+		// Error counts
+		errorsSummary := countSummaries["datadog.trace_agent.trace_writer.errors"]
+		assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
+		assert.Equal(expectedNumErrors, errorsSummary.Sum)
+
+		// Single trace max spans
+		singleMaxSpansSummary := countSummaries["datadog.trace_agent.trace_writer.single_max_spans"]
+		assert.True(len(singleMaxSpansSummary.Calls) >= 3, "There should have been multiple single max spans count calls")
+		assert.Equal(expectedNumSingleMaxSpans, singleMaxSpansSummary.Sum)
+	})
 }
 
-func calculateTracePayloadSize(traces []model.Trace) int64 {
-	apiTraces := make([]*model.APITrace, len(traces))
+func calculateTracePayloadSize(sampledTraces []*SampledTrace) int64 {
+	apiTraces := make([]*model.APITrace, len(sampledTraces))
 
-	for i, trace := range traces {
-		apiTraces[i] = trace.APITrace()
+	for i, trace := range sampledTraces {
+		apiTraces[i] = trace.Trace.APITrace()
 	}
 
 	tracePayload := model.TracePayload{
@@ -283,9 +274,19 @@ func calculateTracePayloadSize(traces []model.Trace) int64 {
 }
 
 func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expectedHeaders map[string]string,
-	expectedTraces []model.Trace, payloads []Payload) {
+	sampledTraces []*SampledTrace, payloads []Payload) {
 
-	seenAPITraces := []*model.APITrace(nil)
+	var expectedTraces []*model.Trace
+	var expectedTransactions []*model.Span
+
+	for _, sampledTrace := range sampledTraces {
+		expectedTraces = append(expectedTraces, sampledTrace.Trace)
+		expectedTransactions = append(expectedTransactions, sampledTrace.Transactions...)
+	}
+
+	var expectedTraceIdx int
+	var expectedTransactionIdx int
+
 	for _, payload := range payloads {
 		assert.Equal(expectedHeaders, payload.Headers, "Payload headers should match expectation")
 
@@ -306,50 +307,59 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 
 		for _, seenAPITrace := range tracePayload.Traces {
 			numSpans += len(seenAPITrace.Spans)
-			seenAPITraces = append(seenAPITraces, seenAPITrace)
-		}
 
-		assert.True(numSpans <= traceWriter.conf.MaxSpansPerPayload)
-	}
-
-	traceCount := 0
-
-	for _, trace := range expectedTraces {
-		for len(trace) > 0 {
-			seenAPITrace := seenAPITraces[traceCount]
-			seenAPITraceNumSpans := len(seenAPITrace.Spans)
-
-			expectedTrace := trace[:seenAPITraceNumSpans]
-
-			if seenAPITraceNumSpans < len(trace) {
-				trace = trace[seenAPITraceNumSpans:]
-			} else {
-				trace = nil
+			if !assert.True(proto.Equal(expectedTraces[expectedTraceIdx].APITrace(), seenAPITrace),
+				"Unmarshalled trace should match expectation at index %d", expectedTraceIdx) {
+				return
 			}
 
-			expectedTraceAPI := expectedTrace.APITrace()
+			expectedTraceIdx += 1
+		}
 
-			assert.True(proto.Equal(expectedTraceAPI, seenAPITraces[traceCount]),
-				"Unmarshalled trace payload should match expectation at index %d", traceCount)
-			traceCount++
+		for _, seenTransaction := range tracePayload.Transactions {
+			numSpans += 1
+
+			if !assert.True(proto.Equal(expectedTransactions[expectedTransactionIdx], seenTransaction),
+				"Unmarshalled transaction should match expectation at index %d", expectedTraceIdx) {
+				return
+			}
+
+			expectedTransactionIdx += 1
+		}
+
+		// If there's more than 1 trace or transaction in this payload, don't let it go over the limit. Otherwise,
+		// a single trace+transaction combination is allows to go over the limit.
+		if len(tracePayload.Traces) > 1 || len(tracePayload.Transactions) > 1 {
+			assert.True(numSpans <= traceWriter.conf.MaxSpansPerPayload)
 		}
 	}
-
 }
 
-func testTraceWriter() (*TraceWriter, chan *model.Trace, *testEndpoint, *fixtures.TestStatsClient) {
-	traceChannel := make(chan *model.Trace)
-	transactionChannel := make(chan *model.Span)
+func testTraceWriter() (*TraceWriter, chan *SampledTrace, *testEndpoint, *fixtures.TestStatsClient) {
+	payloadChannel := make(chan *SampledTrace)
 	conf := &config.AgentConfig{
 		HostName:          testHostName,
 		DefaultEnv:        testEnv,
 		TraceWriterConfig: writerconfig.DefaultTraceWriterConfig(),
 	}
-	traceWriter := NewTraceWriter(conf, traceChannel, transactionChannel)
+	traceWriter := NewTraceWriter(conf, payloadChannel)
 	testEndpoint := &testEndpoint{}
 	traceWriter.BaseWriter.payloadSender.setEndpoint(testEndpoint)
 	testStatsClient := &fixtures.TestStatsClient{}
 	traceWriter.statsClient = testStatsClient
 
-	return traceWriter, traceChannel, testEndpoint, testStatsClient
+	return traceWriter, payloadChannel, testEndpoint, testStatsClient
+}
+
+func randomSampledTrace(numSpans, numTransactions int) *SampledTrace {
+	if numSpans < numTransactions {
+		panic("can't have more transactions than spans in a RandomSampledTrace")
+	}
+
+	trace := fixtures.GetTestTrace(1, numSpans, true)[0]
+
+	return &SampledTrace{
+		Trace:        &trace,
+		Transactions: trace[:numTransactions],
+	}
 }


### PR DESCRIPTION
This PR reworks the logic around trace and transaction writing to fix some identified issues.

# Trace splitting

Traces are no longer arbitrarily split when writing. This introduced some issues later on in the server side processing pipeline, specially around priority sampling.

Instead, `MaxSpansPerPayload` is now a soft-limit. Whenever possible, payloads will respect said limit. In case a single trace + its transactions have more spans than that limit, then we still attempt to send that trace (on its own) to Datadog's API. There's a chance that the API will reject it if it goes over the input size limit but, if that happens, that means the trace is several MB big which is not normal anyway so the issue should be handled at the client side.

# Traces and transactions are written atomically

Before, traces and transactions were written asynchronously which could result in scenarios where a trace would be flushed to the API without some of its transactions which would only be flushed later on  in a consecutive payload. This introduced some issues during server-side processing where we might mistakenly not tag some transactions as having been sampled because we did not know about its associated trace.

With this change, traces and their respective transactions are treated "atomically" so that it can never happen that such a split occurs.