### PR TITLE
writer: split stats writer payloads based on number of entries.

### DIFF
--- a/config/merge_ini.go
+++ b/config/merge_ini.go
@@ -243,6 +243,10 @@ func readServiceWriterConfig(confFile *File, section string) writerconfig.Servic
 func readStatsWriterConfig(confFile *File, section string) writerconfig.StatsWriterConfig {
 	c := writerconfig.DefaultStatsWriterConfig()
 
+	if v, e := confFile.GetInt(section, "max_entries_per_payload"); e == nil {
+		c.MaxEntriesPerPayload = v
+	}
+
 	if v, e := confFile.GetInt(section, "update_info_period_seconds"); e == nil {
 		c.UpdateInfoPeriod = time.Duration(v) * time.Second
 	}

--- a/config/merge_yaml.go
+++ b/config/merge_yaml.go
@@ -84,6 +84,7 @@ type serviceWriter struct {
 }
 
 type statsWriter struct {
+	MaxEntriesPerPayload   int                    `yaml:"max_entries_per_payload"`
 	UpdateInfoPeriod       int                    `yaml:"update_info_period_seconds"`
 	QueueablePayloadSender queueablePayloadSender `yaml:"queue"`
 }
@@ -267,6 +268,10 @@ func readServiceWriterConfigYaml(yc serviceWriter) writerconfig.ServiceWriterCon
 
 func readStatsWriterConfigYaml(yc statsWriter) writerconfig.StatsWriterConfig {
 	c := writerconfig.DefaultStatsWriterConfig()
+
+	if yc.MaxEntriesPerPayload > 0 {
+		c.MaxEntriesPerPayload = yc.MaxEntriesPerPayload
+	}
 
 	if yc.UpdateInfoPeriod > 0 {
 		c.UpdateInfoPeriod = getDuration(yc.UpdateInfoPeriod)

--- a/info/writer.go
+++ b/info/writer.go
@@ -27,6 +27,7 @@ type StatsWriterInfo struct {
 	StatsBuckets int64
 	Errors       int64
 	Retries      int64
+	Splits       int64
 	Bytes        int64
 }
 

--- a/writer/config/stats_writer.go
+++ b/writer/config/stats_writer.go
@@ -2,10 +2,12 @@ package config
 
 import "time"
 
-// maxEntriesPerPayload is the maximum number of entries in a stat payload. A
-// value of 0 disables splitting all together. For now, the feature is disabled
-// by default.
-const maxEntriesPerPayload = 0
+// maxEntriesPerPayload is the maximum number of entries in a stat payload. An
+// entry has an average size of 125 bytes in a compressed payload. The current
+// Datadog intake API limits a compressed payload to ~3MB (24,000 entries), but
+// let's have the default ensure we don't have paylods > 1.5 MB (12,000
+// entries).
+const maxEntriesPerPayload = 12000
 
 // StatsWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
 type StatsWriterConfig struct {

--- a/writer/config/stats_writer.go
+++ b/writer/config/stats_writer.go
@@ -2,16 +2,23 @@ package config
 
 import "time"
 
+// maxEntriesPerPayload is the maximum number of entries in a stat payload. A
+// value of 0 disables splitting all together. For now, the feature is disabled
+// by default.
+const maxEntriesPerPayload = 0
+
 // StatsWriterConfig contains the configuration to customize the behaviour of a TraceWriter.
 type StatsWriterConfig struct {
-	UpdateInfoPeriod time.Duration
-	SenderConfig     QueuablePayloadSenderConf
+	MaxEntriesPerPayload int
+	UpdateInfoPeriod     time.Duration
+	SenderConfig         QueuablePayloadSenderConf
 }
 
 // DefaultStatsWriterConfig creates a new instance of a StatsWriterConfig using default values.
 func DefaultStatsWriterConfig() StatsWriterConfig {
 	return StatsWriterConfig{
-		UpdateInfoPeriod: 1 * time.Minute,
-		SenderConfig:     DefaultQueuablePayloadSenderConf(),
+		MaxEntriesPerPayload: maxEntriesPerPayload,
+		UpdateInfoPeriod:     1 * time.Minute,
+		SenderConfig:         DefaultQueuablePayloadSenderConf(),
 	}
 }

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -108,6 +108,9 @@ func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
 		nbEntries, nbStatBuckets, len(payloads),
 	)
 
+	if len(payloads) > 1 {
+		atomic.AddInt64(&w.info.Splits, 1)
+	}
 	atomic.AddInt64(&w.info.StatsBuckets, int64(nbStatBuckets))
 
 	headers := map[string]string{
@@ -285,12 +288,14 @@ func (w *StatsWriter) monitor() {
 			swInfo.StatsBuckets = atomic.SwapInt64(&w.info.StatsBuckets, 0)
 			swInfo.Bytes = atomic.SwapInt64(&w.info.Bytes, 0)
 			swInfo.Retries = atomic.SwapInt64(&w.info.Retries, 0)
+			swInfo.Splits = atomic.SwapInt64(&w.info.Splits, 0)
 			swInfo.Errors = atomic.SwapInt64(&w.info.Errors, 0)
 
 			w.statsClient.Count("datadog.trace_agent.stats_writer.payloads", int64(swInfo.Payloads), nil, 1)
 			w.statsClient.Count("datadog.trace_agent.stats_writer.stats_buckets", int64(swInfo.StatsBuckets), nil, 1)
 			w.statsClient.Count("datadog.trace_agent.stats_writer.bytes", int64(swInfo.Bytes), nil, 1)
 			w.statsClient.Count("datadog.trace_agent.stats_writer.retries", int64(swInfo.Retries), nil, 1)
+			w.statsClient.Count("datadog.trace_agent.stats_writer.splits", int64(swInfo.Splits), nil, 1)
 			w.statsClient.Count("datadog.trace_agent.stats_writer.errors", int64(swInfo.Errors), nil, 1)
 
 			info.UpdateStatsWriterInfo(swInfo)

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -14,87 +14,72 @@ import (
 	writerconfig "github.com/DataDog/datadog-trace-agent/writer/config"
 )
 
-// StatsWriter ingests stats buckets and flushes their aggregation to the API.
+// StatsWriter ingests stats buckets and flushes them to the API.
 type StatsWriter struct {
-	stats    info.StatsWriterInfo
-	hostName string
-	env      string
-	conf     writerconfig.StatsWriterConfig
-	InStats  <-chan []model.StatsBucket
-
 	BaseWriter
+
+	// InStats is the stream of stat buckets to send out.
+	InStats <-chan []model.StatsBucket
+
+	// info contains various statistics about the writer, which are
+	// occasionally sent as metrics to Datadog.
+	info info.StatsWriterInfo
+
+	// hostName specifies the resolved host name on which the agent is
+	// running, to be sent as part of a stats payload.
+	hostName string
+
+	// env is environment this agent is configured with, to be sent as part
+	// of the stats payload.
+	env string
+
+	conf writerconfig.StatsWriterConfig
 }
 
-// NewStatsWriter returns a new writer for services.
+// NewStatsWriter returns a new writer for stats.
 func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket) *StatsWriter {
 	writerConf := conf.StatsWriterConfig
 	log.Infof("Stats writer initializing with config: %+v", writerConf)
 
+	bw := *NewBaseWriter(conf, "/api/v0.2/stats", func(endpoint Endpoint) PayloadSender {
+		return NewCustomQueuablePayloadSender(endpoint, writerConf.SenderConfig)
+	})
 	return &StatsWriter{
-		hostName: conf.HostName,
-		env:      conf.DefaultEnv,
-		conf:     writerConf,
-		InStats:  InStats,
-		BaseWriter: *NewBaseWriter(conf, "/api/v0.2/stats", func(endpoint Endpoint) PayloadSender {
-			return NewCustomQueuablePayloadSender(endpoint, writerConf.SenderConfig)
-		}),
+		BaseWriter: bw,
+		InStats:    InStats,
+		hostName:   conf.HostName,
+		env:        conf.DefaultEnv,
+		conf:       writerConf,
 	}
 }
 
-// Start starts the writer.
+// Start starts the writer, awaiting stat buckets and flushing them.
 func (w *StatsWriter) Start() {
 	w.BaseWriter.Start()
+
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
 	}()
+
+	go func() {
+		defer watchdog.LogOnPanic()
+		w.monitor()
+	}()
 }
 
-// Run runs the main loop of the writer goroutine. If flushes
-// stats buckets once received from the concentrator.
+// Run runs the event loop of the writer's main goroutine. It reads stat buckets
+// from InStats, builds stat payloads and sends them out using the base writer.
 func (w *StatsWriter) Run() {
 	w.exitWG.Add(1)
 	defer w.exitWG.Done()
 
 	log.Debug("starting stats writer")
 
-	updateInfoTicker := time.NewTicker(w.conf.UpdateInfoPeriod)
-	defer updateInfoTicker.Stop()
-
-	// Monitor sender for events
-	go func() {
-		for event := range w.payloadSender.Monitor() {
-			if event == nil {
-				continue
-			}
-
-			switch event := event.(type) {
-			case SenderSuccessEvent:
-				log.Infof("flushed stat payload to the API, time:%s, size:%d bytes", event.SendStats.SendTime,
-					len(event.Payload.Bytes))
-				w.statsClient.Gauge("datadog.trace_agent.stats_writer.flush_duration",
-					event.SendStats.SendTime.Seconds(), nil, 1)
-				atomic.AddInt64(&w.stats.Payloads, 1)
-			case SenderFailureEvent:
-				log.Errorf("failed to flush stat payload, time:%s, size:%d bytes, error: %s",
-					event.SendStats.SendTime, len(event.Payload.Bytes), event.Error)
-				atomic.AddInt64(&w.stats.Errors, 1)
-			case SenderRetryEvent:
-				log.Errorf("retrying flush stat payload, retryNum: %d, delay:%s, error: %s",
-					event.RetryNum, event.RetryDelay, event.Error)
-				atomic.AddInt64(&w.stats.Retries, 1)
-			default:
-				log.Debugf("don't know how to handle event with type %T", event)
-			}
-		}
-	}()
-
 	for {
 		select {
 		case stats := <-w.InStats:
 			w.handleStats(stats)
-		case <-updateInfoTicker.C:
-			go w.updateInfo()
 		case <-w.exit:
 			log.Info("exiting stats writer")
 			return
@@ -102,22 +87,25 @@ func (w *StatsWriter) Run() {
 	}
 }
 
-// Stop stops the main Run loop.
+// Stop stops the writer
 func (w *StatsWriter) Stop() {
 	close(w.exit)
 	w.exitWG.Wait()
+
+	// Closing the base writer, among other things, will close the
+	// w.payloadSender.Monitor() channel, stoping the monitoring
+	// goroutine.
 	w.BaseWriter.Stop()
 }
 
 func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
 	numStats := len(stats)
-
-	// If no stats, we can't construct anything
 	if numStats == 0 {
 		return
 	}
+
 	log.Debugf("going to flush stats buckets, %d buckets", numStats)
-	atomic.AddInt64(&w.stats.StatsBuckets, int64(numStats))
+	atomic.AddInt64(&w.info.StatsBuckets, int64(numStats))
 
 	statsPayload := &model.StatsPayload{
 		HostName: w.hostName,
@@ -137,28 +125,67 @@ func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
 		"Content-Encoding": "gzip",
 	}
 
-	atomic.AddInt64(&w.stats.Bytes, int64(len(data)))
+	atomic.AddInt64(&w.info.Bytes, int64(len(data)))
 
 	payload := NewPayload(data, headers)
 
 	w.payloadSender.Send(payload)
 }
 
-func (w *StatsWriter) updateInfo() {
-	var swInfo info.StatsWriterInfo
+// monitor runs the event loop of the writer's monitoring
+// goroutine. It:
+// - reads events from the payload sender's monitor channel, logs
+//   them, send out statsd metrics, and updates the writer info
+// - periodically dumps the writer info
+func (w *StatsWriter) monitor() {
+	monC := w.payloadSender.Monitor()
 
-	// Load counters and reset them for the next flush
-	swInfo.Payloads = atomic.SwapInt64(&w.stats.Payloads, 0)
-	swInfo.StatsBuckets = atomic.SwapInt64(&w.stats.StatsBuckets, 0)
-	swInfo.Bytes = atomic.SwapInt64(&w.stats.Bytes, 0)
-	swInfo.Retries = atomic.SwapInt64(&w.stats.Retries, 0)
-	swInfo.Errors = atomic.SwapInt64(&w.stats.Errors, 0)
+	infoTicker := time.NewTicker(w.conf.UpdateInfoPeriod)
+	defer infoTicker.Stop()
 
-	w.statsClient.Count("datadog.trace_agent.stats_writer.payloads", int64(swInfo.Payloads), nil, 1)
-	w.statsClient.Count("datadog.trace_agent.stats_writer.stats_buckets", int64(swInfo.StatsBuckets), nil, 1)
-	w.statsClient.Count("datadog.trace_agent.stats_writer.bytes", int64(swInfo.Bytes), nil, 1)
-	w.statsClient.Count("datadog.trace_agent.stats_writer.retries", int64(swInfo.Retries), nil, 1)
-	w.statsClient.Count("datadog.trace_agent.stats_writer.errors", int64(swInfo.Errors), nil, 1)
+	for {
+		select {
+		case e, ok := <-monC:
+			if !ok {
+				break
+			}
 
-	info.UpdateStatsWriterInfo(swInfo)
+			switch e := e.(type) {
+			case SenderSuccessEvent:
+				log.Infof("flushed stat payload to the API, time:%s, size:%d bytes", e.SendStats.SendTime,
+					len(e.Payload.Bytes))
+				w.statsClient.Gauge("datadog.trace_agent.stats_writer.flush_duration",
+					e.SendStats.SendTime.Seconds(), nil, 1)
+				atomic.AddInt64(&w.info.Payloads, 1)
+			case SenderFailureEvent:
+				log.Errorf("failed to flush stat payload, time:%s, size:%d bytes, error: %s",
+					e.SendStats.SendTime, len(e.Payload.Bytes), e.Error)
+				atomic.AddInt64(&w.info.Errors, 1)
+			case SenderRetryEvent:
+				log.Errorf("retrying flush stat payload, retryNum: %d, delay:%s, error: %s",
+					e.RetryNum, e.RetryDelay, e.Error)
+				atomic.AddInt64(&w.info.Retries, 1)
+			default:
+				log.Debugf("don't know how to handle event with type %T", e)
+			}
+
+		case <-infoTicker.C:
+			var swInfo info.StatsWriterInfo
+
+			// Load counters and reset them for the next flush
+			swInfo.Payloads = atomic.SwapInt64(&w.info.Payloads, 0)
+			swInfo.StatsBuckets = atomic.SwapInt64(&w.info.StatsBuckets, 0)
+			swInfo.Bytes = atomic.SwapInt64(&w.info.Bytes, 0)
+			swInfo.Retries = atomic.SwapInt64(&w.info.Retries, 0)
+			swInfo.Errors = atomic.SwapInt64(&w.info.Errors, 0)
+
+			w.statsClient.Count("datadog.trace_agent.stats_writer.payloads", int64(swInfo.Payloads), nil, 1)
+			w.statsClient.Count("datadog.trace_agent.stats_writer.stats_buckets", int64(swInfo.StatsBuckets), nil, 1)
+			w.statsClient.Count("datadog.trace_agent.stats_writer.bytes", int64(swInfo.Bytes), nil, 1)
+			w.statsClient.Count("datadog.trace_agent.stats_writer.retries", int64(swInfo.Retries), nil, 1)
+			w.statsClient.Count("datadog.trace_agent.stats_writer.errors", int64(swInfo.Errors), nil, 1)
+
+			info.UpdateStatsWriterInfo(swInfo)
+		}
+	}
 }

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -167,6 +168,190 @@ func TestStatsWriter_UpdateInfoHandling(t *testing.T) {
 	errorsSummary := countSummaries["datadog.trace_agent.stats_writer.errors"]
 	assert.True(len(errorsSummary.Calls) >= 3, "There should have been multiple errors count calls")
 	assert.Equal(expectedNumErrors, errorsSummary.Sum)
+}
+
+func TestStatsWriter_BuildPayloads(t *testing.T) {
+	t.Run("common case, no duplicate entries", func(t *testing.T) {
+		assert := assert.New(t)
+
+		sw, _, _, _ := testStatsWriter()
+
+		// This gives us a total of 45 entries. 3 per span, 5
+		// spans per stat bucket. Each buckets have the same
+		// time window (start: 0, duration 1e9).
+		stats := []model.StatsBucket{
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+		}
+
+		// Remove duplicates so that we have a predictable state. In another
+		// case we'll test with duplicates.
+		expectedNbEntries := removeDuplicateEntries(stats)
+
+		expectedNbPayloads := int(math.Ceil(float64(expectedNbEntries) / 12))
+
+		// Compute our expected number of entries by payload
+		expectedNbEntriesByPayload := make([]int, expectedNbPayloads)
+		for i := 0; i < expectedNbEntries; i++ {
+			expectedNbEntriesByPayload[i%expectedNbPayloads]++
+		}
+
+		expectedCounts := countsByEntries(stats)
+
+		payloads, nbStatBuckets, nbEntries := sw.buildPayloads(stats, 12)
+
+		assert.Equal(expectedNbPayloads, len(payloads))
+		assert.Equal(expectedNbPayloads, nbStatBuckets)
+		assert.Equal(expectedNbEntries, nbEntries)
+
+		for i := 0; i < expectedNbPayloads; i++ {
+			assert.Equal(1, len(payloads[i].Stats))
+			assert.Equal(expectedNbEntriesByPayload[i], len(payloads[i].Stats[0].Counts))
+		}
+
+		assertCountByEntries(assert, expectedCounts, payloads)
+	})
+
+	t.Run("common case, with duplicate entries", func(t *testing.T) {
+		assert := assert.New(t)
+
+		sw, _, _, _ := testStatsWriter()
+
+		// This gives us a total of 45 entries. 3 per span, 5
+		// spans per stat bucket. Each buckets have the same
+		// time window (start: 0, duration 1e9).
+		stats := []model.StatsBucket{
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+		}
+
+		// Remove duplicates so that we have a predictable
+		// state.
+		expectedNbEntries := removeDuplicateEntries(stats)
+
+		// Ensure we have 45 - 2 entries, as we'll duplicate 2
+		// of them.
+		for ekey := range stats[0].Counts {
+			if expectedNbEntries == 43 {
+				break
+			}
+
+			delete(stats[0].Counts, ekey)
+			expectedNbEntries--
+		}
+
+		// Force 2 duplicates
+		i := 0
+		for ekey, e := range stats[0].Counts {
+			if i >= 2 {
+				break
+			}
+			stats[1].Counts[ekey] = e
+			i++
+		}
+
+		expectedNbPayloads := int(math.Ceil(float64(expectedNbEntries) / 12))
+
+		// Compute our expected number of entries by payload
+		expectedNbEntriesByPayload := make([]int, expectedNbPayloads)
+		for i := 0; i < expectedNbEntries; i++ {
+			expectedNbEntriesByPayload[i%expectedNbPayloads]++
+		}
+
+		expectedCounts := countsByEntries(stats)
+
+		payloads, nbStatBuckets, nbEntries := sw.buildPayloads(stats, 12)
+
+		assert.Equal(expectedNbPayloads, len(payloads))
+		assert.Equal(expectedNbPayloads, nbStatBuckets)
+		assert.Equal(expectedNbEntries, nbEntries)
+
+		for i := 0; i < expectedNbPayloads; i++ {
+			assert.Equal(1, len(payloads[i].Stats))
+			assert.Equal(expectedNbEntriesByPayload[i], len(payloads[i].Stats[0].Counts))
+		}
+
+		assertCountByEntries(assert, expectedCounts, payloads)
+	})
+
+	t.Run("no need for split", func(t *testing.T) {
+		assert := assert.New(t)
+
+		sw, _, _, _ := testStatsWriter()
+		sw.Start()
+
+		// This gives us a tota of 45 entries. 3 per span, 5 spans per
+		// stat bucket. Each buckets have the same time window (start:
+		// 0, duration 1e9).
+		stats := []model.StatsBucket{
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+			fixtures.RandomStatsBucket(5),
+		}
+
+		payloads, nbStatBuckets, nbEntries := sw.buildPayloads(stats, 1337)
+
+		assert.Equal(1, len(payloads))
+		assert.Equal(3, nbStatBuckets)
+		assert.Equal(45, nbEntries)
+
+		assert.Equal(3, len(payloads[0].Stats))
+		assert.Equal(15, len(payloads[0].Stats[0].Counts))
+		assert.Equal(15, len(payloads[0].Stats[1].Counts))
+		assert.Equal(15, len(payloads[0].Stats[2].Counts))
+	})
+}
+
+func removeDuplicateEntries(stats []model.StatsBucket) int {
+	nbEntries := 0
+	entries := make(map[string]struct{}, 45)
+	for _, s := range stats {
+		for ekey := range s.Counts {
+			if _, ok := entries[ekey]; !ok {
+				entries[ekey] = struct{}{}
+				nbEntries++
+			} else {
+				delete(s.Counts, ekey)
+			}
+		}
+	}
+	return nbEntries
+}
+
+func countsByEntries(stats []model.StatsBucket) map[string]float64 {
+	counts := make(map[string]float64)
+	for _, s := range stats {
+		for k, c := range s.Counts {
+			v, ok := counts[k]
+			if !ok {
+				v = 0
+			}
+			v += c.Value
+			counts[k] = v
+		}
+	}
+
+	return counts
+}
+
+func assertCountByEntries(assert *assert.Assertions, expectedCounts map[string]float64, payloads []*model.StatsPayload) {
+	actualCounts := make(map[string]float64)
+	for _, p := range payloads {
+		for _, s := range p.Stats {
+			for ekey, e := range s.Counts {
+				v, ok := actualCounts[ekey]
+				if !ok {
+					v = 0
+				}
+				v += e.Value
+				actualCounts[ekey] = v
+			}
+		}
+	}
+
+	assert.Equal(expectedCounts, actualCounts)
 }
 
 func calculateStatPayloadSize(buckets []model.StatsBucket) int64 {


### PR DESCRIPTION
Adds a splitting logic in the stats writer in order never to exceed a pre-configured maximum number of "entries" in a stats payload.

Doing so ensures we don't hit the maximum payload size of the Datadog trace intake API.

The first commit is just a cleanup of the stats writer code, and some added comments.

The second commit adds the configuration value `max_entries_per_payload`. This value should be tweaked very cautiously. Setting it too low will have the agent send much more payloads than it should when flushing, which will impact performances and will hit the backend significantly more. Setting the value too high, and the payloads might end up being rejected due to their size.

The third commit is the actual splitting logic + unit tests.