### PR TITLE
config: make analyzed_spans configurable with an environment variable

### DIFF
--- a/config/agent_test.go
+++ b/config/agent_test.go
@@ -13,14 +13,14 @@ func TestDefaultConfig(t *testing.T) {
 	agentConfig := NewDefaultAgentConfig()
 
 	// assert that some sane defaults are set
-	assert.Equal(agentConfig.ReceiverHost, "localhost")
-	assert.Equal(agentConfig.ReceiverPort, 8126)
+	assert.Equal("localhost", agentConfig.ReceiverHost)
+	assert.Equal(8126, agentConfig.ReceiverPort)
 
-	assert.Equal(agentConfig.StatsdHost, "localhost")
-	assert.Equal(agentConfig.StatsdPort, 8125)
+	assert.Equal("localhost", agentConfig.StatsdHost)
+	assert.Equal(8125, agentConfig.StatsdPort)
 
-	assert.Equal(agentConfig.LogLevel, "INFO")
-	assert.Equal(agentConfig.Enabled, true)
+	assert.Equal("INFO", agentConfig.LogLevel)
+	assert.Equal(true, agentConfig.Enabled)
 
 }
 
@@ -155,9 +155,9 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	assert.Len(agentConfig.AnalyzedSpansByService, 2)
 	assert.Len(agentConfig.AnalyzedSpansByService["web"], 2)
 	assert.Len(agentConfig.AnalyzedSpansByService["db"], 1)
-	assert.Equal(agentConfig.AnalyzedSpansByService["web"]["request"], 0.8)
-	assert.Equal(agentConfig.AnalyzedSpansByService["web"]["django.request"], 0.9)
-	assert.Equal(agentConfig.AnalyzedSpansByService["db"]["intake"], 0.05)
+	assert.Equal(0.8, agentConfig.AnalyzedSpansByService["web"]["request"])
+	assert.Equal(0.9, agentConfig.AnalyzedSpansByService["web"]["django.request"])
+	assert.Equal(0.05, agentConfig.AnalyzedSpansByService["db"]["intake"])
 }
 
 func TestConfigNewIfExists(t *testing.T) {
@@ -197,15 +197,15 @@ func TestUndocumentedIni(t *testing.T) {
 	assert.NoError(err)
 
 	// analysis legacy
-	assert.Equal(c.AnalyzedRateByServiceLegacy["web"], 0.8)
-	assert.Equal(c.AnalyzedRateByServiceLegacy["intake"], 0.05)
+	assert.Equal(0.8, c.AnalyzedRateByServiceLegacy["web"])
+	assert.Equal(0.05, c.AnalyzedRateByServiceLegacy["intake"])
 	// analysis
 	assert.Len(c.AnalyzedSpansByService, 2)
 	assert.Len(c.AnalyzedSpansByService["web"], 2)
 	assert.Len(c.AnalyzedSpansByService["db"], 1)
-	assert.Equal(c.AnalyzedSpansByService["web"]["request"], 0.8)
-	assert.Equal(c.AnalyzedSpansByService["web"]["django.request"], 0.9)
-	assert.Equal(c.AnalyzedSpansByService["db"]["intake"], 0.05)
+	assert.Equal(0.8, c.AnalyzedSpansByService["web"]["request"])
+	assert.Equal(0.9, c.AnalyzedSpansByService["web"]["django.request"])
+	assert.Equal(0.05, c.AnalyzedSpansByService["db"]["intake"])
 }
 
 func TestAnalyzedSpansEnvConfig(t *testing.T) {
@@ -217,9 +217,9 @@ func TestAnalyzedSpansEnvConfig(t *testing.T) {
 	assert.Len(c.AnalyzedSpansByService, 2)
 	assert.Len(c.AnalyzedSpansByService["service1"], 2)
 	assert.Len(c.AnalyzedSpansByService["service2"], 1)
-	assert.Equal(c.AnalyzedSpansByService["service1"]["operation1"], 0.5)
-	assert.Equal(c.AnalyzedSpansByService["service1"]["operation3"], float64(0))
-	assert.Equal(c.AnalyzedSpansByService["service2"]["operation2"], float64(1))
+	assert.Equal(0.5, c.AnalyzedSpansByService["service1"]["operation1"], 0.5)
+	assert.Equal(float64(0), c.AnalyzedSpansByService["service1"]["operation3"])
+	assert.Equal(float64(1), c.AnalyzedSpansByService["service2"]["operation2"])
 
 	os.Setenv("DD_APM_ANALYZED_SPANS", "")
 }

--- a/config/agent_test.go
+++ b/config/agent_test.go
@@ -211,6 +211,7 @@ func TestUndocumentedIni(t *testing.T) {
 func TestAnalyzedSpansEnvConfig(t *testing.T) {
 	assert := assert.New(t)
 	os.Setenv("DD_APM_ANALYZED_SPANS", "service1|operation1=0.5,service2|operation2=1,service1|operation3=0")
+	defer os.Unsetenv("DD_APM_ANALYZED_SPANS")
 
 	c, _ := NewAgentConfig(nil, nil, nil)
 
@@ -221,5 +222,4 @@ func TestAnalyzedSpansEnvConfig(t *testing.T) {
 	assert.Equal(float64(0), c.AnalyzedSpansByService["service1"]["operation3"])
 	assert.Equal(float64(1), c.AnalyzedSpansByService["service2"]["operation2"])
 
-	os.Setenv("DD_APM_ANALYZED_SPANS", "")
 }

--- a/config/agent_test.go
+++ b/config/agent_test.go
@@ -207,3 +207,19 @@ func TestUndocumentedIni(t *testing.T) {
 	assert.Equal(c.AnalyzedSpansByService["web"]["django.request"], 0.9)
 	assert.Equal(c.AnalyzedSpansByService["db"]["intake"], 0.05)
 }
+
+func TestAnalyzedSpansEnvConfig(t *testing.T) {
+	assert := assert.New(t)
+	os.Setenv("DD_APM_ANALYZED_SPANS", "service1|operation1=0.5,service2|operation2=1,service1|operation3=0")
+
+	c, _ := NewAgentConfig(nil, nil, nil)
+
+	assert.Len(c.AnalyzedSpansByService, 2)
+	assert.Len(c.AnalyzedSpansByService["service1"], 2)
+	assert.Len(c.AnalyzedSpansByService["service2"], 1)
+	assert.Equal(c.AnalyzedSpansByService["service1"]["operation1"], 0.5)
+	assert.Equal(c.AnalyzedSpansByService["service1"]["operation3"], float64(0))
+	assert.Equal(c.AnalyzedSpansByService["service2"]["operation2"], float64(1))
+
+	os.Setenv("DD_APM_ANALYZED_SPANS", "")
+}

--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -71,49 +71,49 @@ func mergeEnv(c *AgentConfig) {
 	}
 
 	if v := os.Getenv("DD_APM_ANALYZED_SPANS"); v != "" {
-		var err error
-		c.AnalyzedSpansByService, err = readAnalyzedSpanEnvVariable(v)
-		if err != nil {
+		analyzedSpans, err := parseAnalyzedSpans(v)
+		if err == nil {
+			c.AnalyzedSpansByService = analyzedSpans
+		} else {
 			log.Errorf("Bad format for DD_APM_ANALYZED_SPANS it should be of the form \"service_name|operation_name=rate,other_service|other_operation=rate\", error: %v", err)
 		}
 	}
 }
 
 func parseNameAndRate(token string) (string, float64, error) {
-	splits := strings.Split(token, "=")
-	if len(splits) != 2 {
+	parts := strings.Split(token, "=")
+	if len(parts) != 2 {
 		return "", 0, fmt.Errorf("Bad format")
 	}
-	rate, err := strconv.ParseFloat(splits[1], 64)
+	rate, err := strconv.ParseFloat(parts[1], 64)
 	if err != nil {
 		return "", 0, fmt.Errorf("Unabled to parse rate")
 	}
-	return splits[0], rate, nil
+	return parts[0], rate, nil
 }
 
-func readAnalyzedSpanEnvVariable(analyzedSpansEnvVariable string) (map[string]map[string]float64, error) {
-	// the format is: service_name|operation_name=rate,other_service|other_operation=rate
-	analyzedSpansByService := make(map[string]map[string]float64)
-	if analyzedSpansEnvVariable == "" {
-		return analyzedSpansByService, nil
+// parseAnalyzedSpans parses the env string to extract a map of spans to be analyzed by service and operation.
+// the format is: service_name|operation_name=rate,other_service|other_operation=rate
+func parseAnalyzedSpans(env string) (analyzedSpans map[string]map[string]float64, err error) {
+	analyzedSpans = make(map[string]map[string]float64)
+	if env == "" {
+		return
 	}
-	tokens := strings.Split(analyzedSpansEnvVariable, ",")
+	tokens := strings.Split(env, ",")
 	for _, token := range tokens {
 		name, rate, err := parseNameAndRate(token)
 		if err != nil {
 			return nil, err
 		}
-		serviceName, operationName, err := parseAnalyzedSpanFormat(name)
+		serviceName, operationName, err := parseServiceAndOp(name)
 		if err != nil {
 			return nil, err
 		}
 
-		service := analyzedSpansByService[serviceName]
-		if service == nil {
-			service = make(map[string]float64)
-			analyzedSpansByService[serviceName] = service
+		if _, ok := analyzedSpans[serviceName]; !ok {
+			analyzedSpans[serviceName] = make(map[string]float64)
 		}
-		service[operationName] = rate
+		analyzedSpans[serviceName][operationName] = rate
 	}
-	return analyzedSpansByService, nil
+	return
 }

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -15,22 +15,20 @@ func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 	assert.Nil(err)
 	assert.Len(a, 1)
 	assert.Len(a["service"], 1)
-	assert.Equal(a["service"]["operation"], float64(1))
+	assert.Equal(float64(1), a["service"]["operation"])
 
-	a = nil
 	a, err = readAnalyzedSpanEnvVariable("service|operation=0.01")
 	assert.Nil(err)
 	assert.Len(a, 1)
 	assert.Len(a["service"], 1)
-	assert.Equal(a["service"]["operation"], 0.01)
+	assert.Equal(0.01, a["service"]["operation"])
 
-	a = nil
 	a, err = readAnalyzedSpanEnvVariable("service|operation=1,service2|operation2=1")
 	assert.Nil(err)
 	assert.Len(a, 2)
 	assert.Len(a["service"], 1)
-	assert.Equal(a["service"]["operation"], float64(1))
-	assert.Equal(a["service2"]["operation2"], float64(1))
+	assert.Equal(float64(1), a["service"]["operation"])
+	assert.Equal(float64(1), a["service2"]["operation2"])
 
 	a, err = readAnalyzedSpanEnvVariable("")
 	assert.Nil(err)

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -10,38 +10,39 @@ func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 	assert := assert.New(t)
 
 	// Check valid cases
+	t.Run("Check Valid Cases", func(t *testing.T) {
+		a, err := parseAnalyzedSpans("service|operation=1")
+		assert.Nil(err)
+		assert.Len(a, 1)
+		assert.Len(a["service"], 1)
+		assert.Equal(float64(1), a["service"]["operation"])
 
-	a, err := readAnalyzedSpanEnvVariable("service|operation=1")
-	assert.Nil(err)
-	assert.Len(a, 1)
-	assert.Len(a["service"], 1)
-	assert.Equal(float64(1), a["service"]["operation"])
+		a, err = parseAnalyzedSpans("service|operation=0.01")
+		assert.Nil(err)
+		assert.Len(a, 1)
+		assert.Len(a["service"], 1)
+		assert.Equal(0.01, a["service"]["operation"])
 
-	a, err = readAnalyzedSpanEnvVariable("service|operation=0.01")
-	assert.Nil(err)
-	assert.Len(a, 1)
-	assert.Len(a["service"], 1)
-	assert.Equal(0.01, a["service"]["operation"])
+		a, err = parseAnalyzedSpans("service|operation=1,service2|operation2=1")
+		assert.Nil(err)
+		assert.Len(a, 2)
+		assert.Len(a["service"], 1)
+		assert.Equal(float64(1), a["service"]["operation"])
+		assert.Equal(float64(1), a["service2"]["operation2"])
 
-	a, err = readAnalyzedSpanEnvVariable("service|operation=1,service2|operation2=1")
-	assert.Nil(err)
-	assert.Len(a, 2)
-	assert.Len(a["service"], 1)
-	assert.Equal(float64(1), a["service"]["operation"])
-	assert.Equal(float64(1), a["service2"]["operation2"])
+		a, err = parseAnalyzedSpans("")
+		assert.Nil(err)
+		assert.Len(a, 0)
+	})
 
-	a, err = readAnalyzedSpanEnvVariable("")
-	assert.Nil(err)
-	assert.Len(a, 0)
+	t.Run("Check Errors", func(t *testing.T) {
+		_, err := parseAnalyzedSpans("service|operation=")
+		assert.NotNil(err)
 
-	// Check errors
+		_, err = parseAnalyzedSpans("serviceoperation=1")
+		assert.NotNil(err)
 
-	a, err = readAnalyzedSpanEnvVariable("service|operation=")
-	assert.NotNil(err)
-
-	a, err = readAnalyzedSpanEnvVariable("serviceoperation=1")
-	assert.NotNil(err)
-
-	a, err = readAnalyzedSpanEnvVariable("service|operation=1,")
-	assert.NotNil(err)
+		_, err = parseAnalyzedSpans("service|operation=1,")
+		assert.NotNil(err)
+	})
 }

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -9,8 +9,7 @@ import (
 func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 	assert := assert.New(t)
 
-	// Check valid cases
-	t.Run("Check Valid Cases", func(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
 		a, err := parseAnalyzedSpans("service|operation=1")
 		assert.Nil(err)
 		assert.Len(a, 1)
@@ -35,7 +34,7 @@ func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 		assert.Len(a, 0)
 	})
 
-	t.Run("Check Errors", func(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
 		_, err := parseAnalyzedSpans("service|operation=")
 		assert.NotNil(err)
 

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
+	assert := assert.New(t)
+
+	// Check valid cases
+
+	a, err := readAnalyzedSpanEnvVariable("service|operation=1")
+	assert.Nil(err)
+	assert.Len(a, 1)
+	assert.Len(a["service"], 1)
+	assert.Equal(a["service"]["operation"], float64(1))
+
+	a = nil
+	a, err = readAnalyzedSpanEnvVariable("service|operation=0.01")
+	assert.Nil(err)
+	assert.Len(a, 1)
+	assert.Len(a["service"], 1)
+	assert.Equal(a["service"]["operation"], 0.01)
+
+	a = nil
+	a, err = readAnalyzedSpanEnvVariable("service|operation=1,service2|operation2=1")
+	assert.Nil(err)
+	assert.Len(a, 2)
+	assert.Len(a["service"], 1)
+	assert.Equal(a["service"]["operation"], float64(1))
+	assert.Equal(a["service2"]["operation2"], float64(1))
+
+	a, err = readAnalyzedSpanEnvVariable("")
+	assert.Nil(err)
+	assert.Len(a, 0)
+
+	// Check errors
+
+	a, err = readAnalyzedSpanEnvVariable("service|operation=")
+	assert.NotNil(err)
+
+	a, err = readAnalyzedSpanEnvVariable("serviceoperation=1")
+	assert.NotNil(err)
+
+	a, err = readAnalyzedSpanEnvVariable("service|operation=1,")
+	assert.NotNil(err)
+}

--- a/config/merge_yaml.go
+++ b/config/merge_yaml.go
@@ -229,18 +229,16 @@ func mergeYamlConfig(agentConf *AgentConfig, yc *YamlAgentConfig) error {
 	}
 	// undocumeted
 	for key, rate := range yc.TraceAgent.AnalyzedSpans {
-		serviceName, operationName, err := parseAnalyzedSpanFormat(key)
+		serviceName, operationName, err := parseServiceAndOp(key)
 		if err != nil {
 			log.Errorf("Error when parsing names", err)
 			continue
 		}
 
-		service := agentConf.AnalyzedSpansByService[serviceName]
-		if service == nil {
-			service = make(map[string]float64)
-			agentConf.AnalyzedSpansByService[serviceName] = service
+		if _, ok := agentConf.AnalyzedSpansByService[serviceName]; !ok {
+			agentConf.AnalyzedSpansByService[serviceName] = make(map[string]float64)
 		}
-		service[operationName] = rate
+		agentConf.AnalyzedSpansByService[serviceName][operationName] = rate
 	}
 
 	// undocumented


### PR DESCRIPTION
This PR makes it possible to configure spans to be analyzed as transactions with a environment variable. The format for this environment variable is:

```
DD_APM_ANALYZED_SPANS="service_name|operation_name=1,other_service|other_operation=0.5"
```