### PR TITLE
build: make build fail on linting errors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
           resource_class: large
 
           docker:
-               - image: circleci/golang:1.9.4
+               - image: circleci/golang:1.9
 
           steps:
                - checkout

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ci:
 	# task used by CI
 	GOOS=windows go build ./cmd/trace-agent # ensure windows builds
 	go get -u github.com/golang/lint/golint/...
-	golint ./cmd/trace-agent ./filters ./fixtures ./info ./quantile ./quantizer ./sampler ./statsd ./watchdog ./writer
+	golint -set_exit_status=1 ./cmd/trace-agent ./filters ./fixtures ./info ./quantile ./quantizer ./sampler ./statsd ./watchdog ./writer
 	go test ./...
 
 windows:

--- a/cmd/trace-agent/receiver.go
+++ b/cmd/trace-agent/receiver.go
@@ -153,6 +153,7 @@ func (r *HTTPReceiver) Listen(addr, logExtra string) error {
 	return nil
 }
 
+// Stop stops the receiver and shuts down the HTTP server.
 func (r *HTTPReceiver) Stop() error {
 	expiry := time.Now().Add(20 * time.Second) // give it 20 seconds
 	ctx, _ := context.WithDeadline(context.Background(), expiry)

--- a/sampler/coresampler.go
+++ b/sampler/coresampler.go
@@ -39,7 +39,7 @@ type EngineType int
 const (
 	// NormalScoreEngineType is the type of the ScoreEngine sampling non-error traces.
 	NormalScoreEngineType EngineType = iota
-	// ErrorScoreEngineType is the type of the ScoreEngine sampling error traces.
+	// ErrorsScoreEngineType is the type of the ScoreEngine sampling error traces.
 	ErrorsScoreEngineType
 	// PriorityEngineType is type of the priority sampler engine type.
 	PriorityEngineType

--- a/sampler/scoresampler.go
+++ b/sampler/scoresampler.go
@@ -34,7 +34,7 @@ func NewScoreEngine(extraRate float64, maxTPS float64) *ScoreEngine {
 	return s
 }
 
-// NewErrorEngine returns an initialized Sampler dedicate to errors. It behaves
+// NewErrorsEngine returns an initialized Sampler dedicate to errors. It behaves
 // just like the the normal ScoreEngine except for its GetType method (useful
 // for reporting).
 func NewErrorsEngine(extraRate float64, maxTPS float64) *ScoreEngine {

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -141,9 +141,9 @@ func TestTraceWriter(t *testing.T) {
 		}
 		expectedNumPayloads++
 		expectedNumSpans += 20
-		expectedNumTraces += 1
+		expectedNumTraces++
 		expectedNumBytes += calculateTracePayloadSize(payload2SampledTraces)
-		expectedNumSingleMaxSpans += 1
+		expectedNumSingleMaxSpans++
 
 		for _, sampledTrace := range payload2SampledTraces {
 			traceChannel <- sampledTrace
@@ -313,18 +313,18 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 				return
 			}
 
-			expectedTraceIdx += 1
+			expectedTraceIdx++
 		}
 
 		for _, seenTransaction := range tracePayload.Transactions {
-			numSpans += 1
+			numSpans++
 
 			if !assert.True(proto.Equal(expectedTransactions[expectedTransactionIdx], seenTransaction),
 				"Unmarshalled transaction should match expectation at index %d", expectedTraceIdx) {
 				return
 			}
 
-			expectedTransactionIdx += 1
+			expectedTransactionIdx++
 		}
 
 		// If there's more than 1 trace or transaction in this payload, don't let it go over the limit. Otherwise,


### PR DESCRIPTION
This makes `golint` use exit status 1 when linting errors are found. It
also fixes any already-existing linting errors.