### PR TITLE
quantizer: allow variable assignments in SQL queries

### DIFF
--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -157,8 +157,17 @@ func (t *TokenConsumer) Process(in string) (string, error) {
 		if buff != nil {
 			// ensure that whitespaces properly separate
 			// received tokens
-			if out.Len() != 0 && token != ',' {
-				out.WriteRune(' ')
+			if out.Len() != 0 {
+				switch token {
+				case ',':
+				case '=':
+					if t.lastToken == ':' {
+						break
+					}
+					fallthrough
+				default:
+					out.WriteRune(' ')
+				}
 			}
 
 			out.Write(buff)

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -312,7 +312,7 @@ func TestSQLQuantizer(t *testing.T) {
 			`SELECT daily_values.*,
                     LEAST((5040000 - @runtot), value) AS value,
                     ` + "(@runtot := @runtot + daily_values.value) AS total FROM (SELECT @runtot:=0) AS n, `daily_values`  WHERE `daily_values`.`subject_id` = 12345 AND `daily_values`.`subject_type` = 'Skippity' AND (daily_values.date BETWEEN '2018-05-09' AND '2018-06-19') HAVING value >= 0 ORDER BY date",
-			`SELECT daily_values.*, LEAST ( ( ? - @runtot ), value ), ( @runtot : = @runtot + daily_values.value ) FROM ( SELECT @runtot : = ? ), daily_values WHERE daily_values . subject_id = ? AND daily_values . subject_type = ? AND ( daily_values.date BETWEEN ? AND ? ) HAVING value >= ? ORDER BY date`,
+			`SELECT daily_values.*, LEAST ( ( ? - @runtot ), value ), ( @runtot := @runtot + daily_values.value ) FROM ( SELECT @runtot := ? ), daily_values WHERE daily_values . subject_id = ? AND daily_values . subject_type = ? AND ( daily_values.date BETWEEN ? AND ? ) HAVING value >= ? ORDER BY date`,
 		},
 	}
 

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -308,6 +308,12 @@ func TestSQLQuantizer(t *testing.T) {
 			"SET @g = 'POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))';",
 			"SET @g = ?",
 		},
+		{
+			`SELECT daily_values.*,
+                    LEAST((5040000 - @runtot), value) AS value,
+                    ` + "(@runtot := @runtot + daily_values.value) AS total FROM (SELECT @runtot:=0) AS n, `daily_values`  WHERE `daily_values`.`subject_id` = 12345 AND `daily_values`.`subject_type` = 'Skippity' AND (daily_values.date BETWEEN '2018-05-09' AND '2018-06-19') HAVING value >= 0 ORDER BY date",
+			`SELECT daily_values.*, LEAST ( ( ? - @runtot ), value ), ( @runtot : = @runtot + daily_values.value ) FROM ( SELECT @runtot : = ? ), daily_values WHERE daily_values . subject_id = ? AND daily_values . subject_type = ? AND ( daily_values.date BETWEEN ? AND ? ) HAVING value >= ? ORDER BY date`,
+		},
 	}
 
 	for _, c := range cases {

--- a/quantizer/tokenizer.go
+++ b/quantizer/tokenizer.go
@@ -93,13 +93,16 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 		return tkn.scanIdentifier()
 	case isDigit(ch):
 		return tkn.scanNumber(false)
-	case ch == ':':
-		return tkn.scanBindVar()
 	default:
 		tkn.next()
 		switch ch {
 		case EOFChar:
 			return EOFChar, nil
+		case ':':
+			if tkn.lastChar != '=' {
+				return tkn.scanBindVar()
+			}
+			fallthrough
 		case '=', ',', ';', '(', ')', '+', '*', '&', '|', '^', '~', '[', ']', '?':
 			return int(ch), []byte{byte(ch)}
 		case '.':
@@ -296,10 +299,8 @@ func (tkn *Tokenizer) scanEscapeSequence(braces rune) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanBindVar() (int, []byte) {
-	buffer := &bytes.Buffer{}
-	buffer.WriteByte(byte(tkn.lastChar))
+	buffer := bytes.NewBufferString(":")
 	token := ValueArg
-	tkn.next()
 	if tkn.lastChar == ':' {
 		token = ListArg
 		buffer.WriteByte(byte(tkn.lastChar))


### PR DESCRIPTION
This change alters the tokenizer to allow `:=` assignments in SELECT
parameters, treating them as regular assignments. Previously this would
cause the parser to return an error and fail to tokenize the query.

Now `:=` will be seen as a valid assignment.