### PR TITLE
quantizer: reduce spaces in quantized queries.

### DIFF
--- a/cmd/trace-agent/agent_test.go
+++ b/cmd/trace-agent/agent_test.go
@@ -93,12 +93,12 @@ func TestFormatTrace(t *testing.T) {
 	assert.Equal(5000, len(result.Resource))
 	assert.NotEqual("Non-parsable SQL query", result.Resource)
 	assert.NotContains(result.Resource, "42")
-	assert.Contains(result.Resource, "SELECT name FROM people WHERE age = ?")
+	assert.Contains(result.Resource, "SELECT name FROM people WHERE age=?")
 
 	assert.Equal(5003, len(result.Meta["sql.query"])) // Ellipsis added in quantizer
 	assert.NotEqual("Non-parsable SQL query", result.Meta["sql.query"])
 	assert.NotContains(result.Meta["sql.query"], "42")
-	assert.Contains(result.Meta["sql.query"], "SELECT name FROM people WHERE age = ?")
+	assert.Contains(result.Meta["sql.query"], "SELECT name FROM people WHERE age=?")
 }
 
 func BenchmarkAgentTraceProcessing(b *testing.B) {

--- a/quantizer/cassandra_test.go
+++ b/quantizer/cassandra_test.go
@@ -25,29 +25,29 @@ func TestCassQuantizer(t *testing.T) {
 		// List compacted and replaced
 		{
 			"select key, status, modified from org_check_run where org_id = %s and check in (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
-			"select key, status, modified from org_check_run where org_id = ? and check in ( ? )",
+			"select key, status, modified from org_check_run where org_id=? and check in (?)",
 		},
 		// Some whitespace-y things
 		{
 			"select key, status, modified from org_check_run where org_id = %s and check in (%s, %s, %s)",
-			"select key, status, modified from org_check_run where org_id = ? and check in ( ? )",
+			"select key, status, modified from org_check_run where org_id=? and check in (?)",
 		},
 		{
 			"select key, status, modified from org_check_run where org_id = %s and check in (%s , %s , %s )",
-			"select key, status, modified from org_check_run where org_id = ? and check in ( ? )",
+			"select key, status, modified from org_check_run where org_id=? and check in (?)",
 		},
 		// %s replaced with ? as in sql quantize
 		{
 			"select key, status, modified from org_check_run where org_id = %s and check = %s",
-			"select key, status, modified from org_check_run where org_id = ? and check = ?",
+			"select key, status, modified from org_check_run where org_id=? and check=?",
 		},
 		{
 			"select key, status, modified from org_check_run where org_id = %s and check = %s",
-			"select key, status, modified from org_check_run where org_id = ? and check = ?",
+			"select key, status, modified from org_check_run where org_id=? and check=?",
 		},
 		{
 			"SELECT timestamp, processes FROM process_snapshot.minutely WHERE org_id = ? AND host = ? AND timestamp >= ? AND timestamp <= ?",
-			"SELECT timestamp, processes FROM process_snapshot.minutely WHERE org_id = ? AND host = ? AND timestamp >= ? AND timestamp <= ?",
+			"SELECT timestamp, processes FROM process_snapshot.minutely WHERE org_id=? AND host=? AND timestamp >= ? AND timestamp <= ?",
 		},
 	}
 

--- a/quantizer/sql.go
+++ b/quantizer/sql.go
@@ -154,13 +154,20 @@ func (t *TokenConsumer) Process(in string) (string, error) {
 		}
 
 		// write the resulting buffer
-		if buff != nil {
+		if len(buff) != 0 {
 			// ensure that whitespaces properly separate
 			// received tokens
-			if out.Len() != 0 && token != ',' {
-				out.WriteRune(' ')
+			if out.Len() != 0 {
+				switch token {
+				case ',', '=', ')', '.': // no space before these tokens
+				default:
+					switch t.lastToken {
+					case '=', '(', '.': // no space after these tokens
+					default:
+						out.WriteRune(' ')
+					}
+				}
 			}
-
 			out.Write(buff)
 		}
 

--- a/quantizer/sql_test.go
+++ b/quantizer/sql_test.go
@@ -38,16 +38,16 @@ func TestMain(m *testing.M) {
 func TestSQLResourceQuery(t *testing.T) {
 	assert := assert.New(t)
 	span := &model.Span{
-		Resource: "SELECT * FROM users WHERE id = 42",
+		Resource: "SELECT * FROM users WHERE id=42",
 		Type:     "sql",
 		Meta: map[string]string{
-			"sql.query": "SELECT * FROM users WHERE id = 42",
+			"sql.query": "SELECT * FROM users WHERE id=42",
 		},
 	}
 
 	Quantize(span)
-	assert.Equal("SELECT * FROM users WHERE id = ?", span.Resource)
-	assert.Equal("SELECT * FROM users WHERE id = 42", span.Meta["sql.query"])
+	assert.Equal("SELECT * FROM users WHERE id=?", span.Resource)
+	assert.Equal("SELECT * FROM users WHERE id=42", span.Meta["sql.query"])
 }
 
 func TestSQLResourceWithoutQuery(t *testing.T) {
@@ -58,8 +58,8 @@ func TestSQLResourceWithoutQuery(t *testing.T) {
 	}
 
 	Quantize(span)
-	assert.Equal("SELECT * FROM users WHERE id = ?", span.Resource)
-	assert.Equal("SELECT * FROM users WHERE id = ?", span.Meta["sql.query"])
+	assert.Equal("SELECT * FROM users WHERE id=?", span.Resource)
+	assert.Equal("SELECT * FROM users WHERE id=?", span.Meta["sql.query"])
 }
 
 func TestSQLResourceWithError(t *testing.T) {
@@ -104,106 +104,106 @@ func TestSQLQuantizer(t *testing.T) {
 	cases := []sqlTestCase{
 		{
 			"select * from users where id = 42",
-			"select * from users where id = ?",
+			"select * from users where id=?",
 		},
 		{
 			"SELECT host, status FROM ec2_status WHERE org_id = 42",
-			"SELECT host, status FROM ec2_status WHERE org_id = ?",
+			"SELECT host, status FROM ec2_status WHERE org_id=?",
 		},
 		{
 			"SELECT host, status FROM ec2_status WHERE org_id=42",
-			"SELECT host, status FROM ec2_status WHERE org_id = ?",
+			"SELECT host, status FROM ec2_status WHERE org_id=?",
 		},
 		{
 			"-- get user \n--\n select * \n   from users \n    where\n       id = 214325346",
-			"select * from users where id = ?",
+			"select * from users where id=?",
 		},
 		{
 			"SELECT * FROM `host` WHERE `id` IN (42, 43) /*comment with parameters,host:localhost,url:controller#home,id:FF005:00CAA*/",
-			"SELECT * FROM host WHERE id IN ( ? )",
+			"SELECT * FROM host WHERE id IN (?)",
 		},
 		{
 			"SELECT `host`.`address` FROM `host` WHERE org_id=42",
-			"SELECT host . address FROM host WHERE org_id = ?",
+			"SELECT host.address FROM host WHERE org_id=?",
 		},
 		{
 			`SELECT "host"."address" FROM "host" WHERE org_id=42`,
-			`SELECT host . address FROM host WHERE org_id = ?`,
+			`SELECT host.address FROM host WHERE org_id=?`,
 		},
 		{
 			`SELECT * FROM host WHERE id IN (42, 43) /*
 			multiline comment with parameters,
 			host:localhost,url:controller#home,id:FF005:00CAA
 			*/`,
-			"SELECT * FROM host WHERE id IN ( ? )",
+			"SELECT * FROM host WHERE id IN (?)",
 		},
 		{
 			"UPDATE user_dash_pref SET json_prefs = %(json_prefs)s, modified = '2015-08-27 22:10:32.492912' WHERE user_id = %(user_id)s AND url = %(url)s",
-			"UPDATE user_dash_pref SET json_prefs = ? modified = ? WHERE user_id = ? AND url = ?"},
+			"UPDATE user_dash_pref SET json_prefs=? modified=? WHERE user_id=? AND url=?"},
 		{
 			"SELECT DISTINCT host.id AS host_id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = %(org_id_1)s AND host.name NOT IN (%(name_1)s) AND host.name IN (%(name_2)s, %(name_3)s, %(name_4)s, %(name_5)s)",
-			"SELECT DISTINCT host.id FROM host JOIN host_alias ON host_alias.host_id = host.id WHERE host.org_id = ? AND host.name NOT IN ( ? ) AND host.name IN ( ? )",
+			"SELECT DISTINCT host.id FROM host JOIN host_alias ON host_alias.host_id=host.id WHERE host.org_id=? AND host.name NOT IN (?) AND host.name IN (?)",
 		},
 		{
-			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = %(org_id)s AND metric_key = ANY(array[75])",
-			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = ? AND metric_key = ANY ( array [ ? ] )",
+			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = %(org_id)s AND metric_key=ANY(array[75])",
+			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id=? AND metric_key=ANY (array [ ? ])",
 		},
 		{
 			"SELECT org_id, metric_key   FROM metrics_metadata   WHERE org_id = %(org_id)s AND metric_key = ANY(array[21, 25, 32])",
-			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id = ? AND metric_key = ANY ( array [ ? ] )",
+			"SELECT org_id, metric_key FROM metrics_metadata WHERE org_id=? AND metric_key=ANY (array [ ? ])",
 		},
 		{
-			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1",
-			"SELECT articles.* FROM articles WHERE articles.id = ? LIMIT ?",
+			"SELECT articles.* FROM articles WHERE articles.id=1 LIMIT 1",
+			"SELECT articles.* FROM articles WHERE articles.id=? LIMIT ?",
 		},
 
 		{
 			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1, 20",
-			"SELECT articles.* FROM articles WHERE articles.id = ? LIMIT ?",
+			"SELECT articles.* FROM articles WHERE articles.id=? LIMIT ?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1, 20;",
-			"SELECT articles.* FROM articles WHERE articles.id = ? LIMIT ?",
+			"SELECT articles.* FROM articles WHERE articles.id=? LIMIT ?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 15,20;",
-			"SELECT articles.* FROM articles WHERE articles.id = ? LIMIT ?",
+			"SELECT articles.* FROM articles WHERE articles.id=? LIMIT ?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE articles.id = 1 LIMIT 1;",
-			"SELECT articles.* FROM articles WHERE articles.id = ? LIMIT ?",
+			"SELECT articles.* FROM articles WHERE articles.id=? LIMIT ?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE (articles.created_at BETWEEN '2016-10-31 23:00:00.000000' AND '2016-11-01 23:00:00.000000')",
-			"SELECT articles.* FROM articles WHERE ( articles.created_at BETWEEN ? AND ? )",
+			"SELECT articles.* FROM articles WHERE (articles.created_at BETWEEN ? AND ?)",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE (articles.created_at BETWEEN $1 AND $2)",
-			"SELECT articles.* FROM articles WHERE ( articles.created_at BETWEEN ? AND ? )",
+			"SELECT articles.* FROM articles WHERE (articles.created_at BETWEEN ? AND ?)",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE (articles.published != true)",
-			"SELECT articles.* FROM articles WHERE ( articles.published != ? )",
+			"SELECT articles.* FROM articles WHERE (articles.published != ?)",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE (title = 'guides.rubyonrails.org')",
-			"SELECT articles.* FROM articles WHERE ( title = ? )",
+			"SELECT articles.* FROM articles WHERE (title=?)",
 		},
 		{
-			"SELECT articles.* FROM articles WHERE ( title = ? ) AND ( author = ? )",
-			"SELECT articles.* FROM articles WHERE ( title = ? ) AND ( author = ? )",
+			"SELECT articles.* FROM articles WHERE (title = ?) AND (author=?)",
+			"SELECT articles.* FROM articles WHERE (title=?) AND (author=?)",
 		},
 		{
-			"SELECT articles.* FROM articles WHERE ( title = :title )",
-			"SELECT articles.* FROM articles WHERE ( title = :title )",
+			"SELECT articles.* FROM articles WHERE (title = :title)",
+			"SELECT articles.* FROM articles WHERE (title=:title)",
 		},
 		{
-			"SELECT articles.* FROM articles WHERE ( title = @title )",
-			"SELECT articles.* FROM articles WHERE ( title = @title )",
+			"SELECT articles.* FROM articles WHERE (title = @title)",
+			"SELECT articles.* FROM articles WHERE (title=@title)",
 		},
 		{
 			"SELECT date(created_at) as ordered_date, sum(price) as total_price FROM orders GROUP BY date(created_at) HAVING sum(price) > 100",
-			"SELECT date ( created_at ), sum ( price ) FROM orders GROUP BY date ( created_at ) HAVING sum ( price ) > ?",
+			"SELECT date (created_at), sum (price) FROM orders GROUP BY date (created_at) HAVING sum (price) > ?",
 		},
 		{
 			"SELECT * FROM articles WHERE id > 10 ORDER BY id asc LIMIT 20",
@@ -211,19 +211,19 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id = author.id AND posts.published = 't'",
-			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id = author.id AND posts.published = ?",
+			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id=author.id AND posts.published=?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE articles.id IN (1, 3, 5)",
-			"SELECT articles.* FROM articles WHERE articles.id IN ( ? )",
+			"SELECT articles.* FROM articles WHERE articles.id IN (?)",
 		},
 		{
 			"SELECT * FROM clients WHERE (clients.first_name = 'Andy') LIMIT 1 BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES ('2011-08-30 05:22:57', 'Andy', 1, NULL, '2011-08-30 05:22:57') COMMIT",
-			"SELECT * FROM clients WHERE ( clients.first_name = ? ) LIMIT ? BEGIN INSERT INTO clients ( created_at, first_name, locked, orders_count, updated_at ) VALUES ( ? ) COMMIT",
+			"SELECT * FROM clients WHERE (clients.first_name=?) LIMIT ? BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES (?) COMMIT",
 		},
 		{
 			"SELECT * FROM clients WHERE (clients.first_name = 'Andy') LIMIT 15, 25 BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES ('2011-08-30 05:22:57', 'Andy', 1, NULL, '2011-08-30 05:22:57') COMMIT",
-			"SELECT * FROM clients WHERE ( clients.first_name = ? ) LIMIT ? BEGIN INSERT INTO clients ( created_at, first_name, locked, orders_count, updated_at ) VALUES ( ? ) COMMIT",
+			"SELECT * FROM clients WHERE (clients.first_name=?) LIMIT ? BEGIN INSERT INTO clients (created_at, first_name, locked, orders_count, updated_at) VALUES (?) COMMIT",
 		},
 		{
 			"SAVEPOINT \"s139956586256192_x1\"",
@@ -231,59 +231,59 @@ func TestSQLQuantizer(t *testing.T) {
 		},
 		{
 			"INSERT INTO user (id, username) VALUES ('Fred','Smith'), ('John','Smith'), ('Michael','Smith'), ('Robert','Smith');",
-			"INSERT INTO user ( id, username ) VALUES ( ? )",
+			"INSERT INTO user (id, username) VALUES (?)",
 		},
 		{
-			"CREATE KEYSPACE Excelsior WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 3};",
-			"CREATE KEYSPACE Excelsior WITH replication = ?",
+			"CREATE KEYSPACE Excelsior WITH replication={'class': 'SimpleStrategy', 'replication_factor' : 3};",
+			"CREATE KEYSPACE Excelsior WITH replication=?",
 		},
 		{
 			`SELECT "webcore_page"."id" FROM "webcore_page" WHERE "webcore_page"."slug" = %s ORDER BY "webcore_page"."path" ASC LIMIT 1`,
-			"SELECT webcore_page . id FROM webcore_page WHERE webcore_page . slug = ? ORDER BY webcore_page . path ASC LIMIT ?",
+			"SELECT webcore_page.id FROM webcore_page WHERE webcore_page.slug=? ORDER BY webcore_page.path ASC LIMIT ?",
 		},
 		{
 			"SELECT server_table.host AS host_id FROM table#.host_tags as server_table WHERE server_table.host_id = 50",
-			"SELECT server_table.host FROM table#.host_tags WHERE server_table.host_id = ?",
+			"SELECT server_table.host FROM table#.host_tags WHERE server_table.host_id=?",
 		},
 		{
 			`INSERT INTO delayed_jobs (attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at) VALUES (0, '2016-12-04 17:09:59', NULL, '--- !ruby/object:Delayed::PerformableMethod\nobject: !ruby/object:Item\n  store:\n  - a simple string\n  - an \'escaped \' string\n  - another \'escaped\' string\n  - 42\n  string: a string with many \\\\\'escapes\\\\\'\nmethod_name: :show_store\nargs: []\n', NULL, NULL, NULL, 0, NULL, '2016-12-04 17:09:59', '2016-12-04 17:09:59')`,
-			"INSERT INTO delayed_jobs ( attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at ) VALUES ( ? )",
+			"INSERT INTO delayed_jobs (attempts, created_at, failed_at, handler, last_error, locked_at, locked_by, priority, queue, run_at, updated_at) VALUES (?)",
 		},
 		{
 			"SELECT name, pretty_print(address) FROM people;",
-			"SELECT name, pretty_print ( address ) FROM people",
+			"SELECT name, pretty_print (address) FROM people",
 		},
 		{
 			"* SELECT * FROM fake_data(1, 2, 3);",
-			"* SELECT * FROM fake_data ( ? )",
+			"* SELECT * FROM fake_data (?)",
 		},
 		{
 			"CREATE FUNCTION add(integer, integer) RETURNS integer\n AS 'select $1 + $2;'\n LANGUAGE SQL\n IMMUTABLE\n RETURNS NULL ON NULL INPUT;",
-			"CREATE FUNCTION add ( integer, integer ) RETURNS integer LANGUAGE SQL IMMUTABLE RETURNS ? ON ? INPUT",
+			"CREATE FUNCTION add (integer, integer) RETURNS integer LANGUAGE SQL IMMUTABLE RETURNS ? ON ? INPUT",
 		},
 		{
-			"SELECT * FROM public.table ( array [ ROW ( array [ 'magic', 'foo',",
-			"SELECT * FROM public.table ( array [ ROW ( array [ ?",
+			"SELECT * FROM public.table (array [ ROW (array [ 'magic', 'foo',",
+			"SELECT * FROM public.table (array [ ROW (array [ ?",
 		},
 		{
 			"SELECT pg_try_advisory_lock (123) AS t46eef3f025cc27feb31ca5a2d668a09a",
-			"SELECT pg_try_advisory_lock ( ? )",
+			"SELECT pg_try_advisory_lock (?)",
 		},
 		{
 			"INSERT INTO `qual-aa`.issues (alert0 , alert1) VALUES (NULL, NULL)",
-			"INSERT INTO qual-aa . issues ( alert0, alert1 ) VALUES ( ? )",
+			"INSERT INTO qual-aa.issues (alert0, alert1) VALUES (?)",
 		},
 		{
 			"INSERT INTO user (id, email, name) VALUES (null, ?, ?)",
-			"INSERT INTO user ( id, email, name ) VALUES ( ? )",
+			"INSERT INTO user (id, email, name) VALUES (?)",
 		},
 		{
-			"select * from users where id = 214325346     # This comment continues to the end of line",
-			"select * from users where id = ?",
+			"select * from users where id=214325346     # This comment continues to the end of line",
+			"select * from users where id=?",
 		},
 		{
 			"select * from users where id = 214325346     -- This comment continues to the end of line",
-			"select * from users where id = ?",
+			"select * from users where id=?",
 		},
 		{
 			"SELECT * FROM /* this is an in-line comment */ users;",
@@ -302,11 +302,11 @@ func TestSQLQuantizer(t *testing.T) {
 			WHERE ROW(5*t2.s1,77)=
 			(SELECT 50,11*s1 FROM t4 UNION SELECT 50,77 FROM
 			(SELECT * FROM t5) AS t5)));`,
-			"DELETE FROM t1 WHERE s11 > ANY ( SELECT COUNT ( * ) FROM t2 WHERE NOT EXISTS ( SELECT * FROM t3 WHERE ROW ( ? * t2.s1, ? ) = ( SELECT ? * s1 FROM t4 UNION SELECT ? FROM ( SELECT * FROM t5 ) ) ) )",
+			"DELETE FROM t1 WHERE s11 > ANY (SELECT COUNT (*) FROM t2 WHERE NOT EXISTS (SELECT * FROM t3 WHERE ROW (? * t2.s1, ?)=(SELECT ? * s1 FROM t4 UNION SELECT ? FROM (SELECT * FROM t5))))",
 		},
 		{
-			"SET @g = 'POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))';",
-			"SET @g = ?",
+			"SET @g= 'POLYGON((0 0,10 0,10 10,0 10,0 0),(5 5,7 5,7 7,5 7, 5 5))';",
+			"SET @g=?",
 		},
 	}
 
@@ -326,11 +326,11 @@ func TestMultipleProcess(t *testing.T) {
 	}{
 		{
 			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id = author.id AND posts.published = 't'",
-			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id = author.id AND posts.published = ?",
+			"SELECT clients.* FROM clients INNER JOIN posts ON posts.author_id=author.id AND posts.published=?",
 		},
 		{
 			"SELECT articles.* FROM articles WHERE articles.id IN (1, 3, 5)",
-			"SELECT articles.* FROM articles WHERE articles.id IN ( ? )",
+			"SELECT articles.* FROM articles WHERE articles.id IN (?)",
 		},
 	}
 


### PR DESCRIPTION
This is a breaking change. It removes spaces:
* Before any of the characters: ` ,=).`
* After any of the characters: `=(.`

This was causing a lot of unnecessary extra bytes previously.