### PR TITLE
Makefile: add 'binaries' command to help release pre-compiled binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 raclette
+/bin/*
 /trace-agent
 /trace-agent-windows-386.exe
 /trace-agent-windows-amd64.exe

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,16 @@ install:
 	go generate ./info
 	go install ./cmd/trace-agent
 
+binaries:
+	test -n "$(V)" # $$V must be set to the release version, e.g. "make binaries V=1.2.3"
+
+	# cross-compiling binaries using suffix $(V)
+	mkdir -p ./bin
+	TRACE_AGENT_VERSION=$(V) go generate ./info
+	GOOS=windows GOARCH=amd64 go build -o ./bin/trace-agent-windows-amd64-$(V).exe ./cmd/trace-agent
+	GOOS=linux GOARCH=amd64 go build -o ./bin/trace-agent-linux-amd64-$(V) ./cmd/trace-agent
+	GOOS=darwin GOARCH=amd64 go build -o ./bin/trace-agent-darwin-amd64-$(V) ./cmd/trace-agent
+
 ci:
 	# task used by CI
 	GOOS=windows go build ./cmd/trace-agent # ensure windows builds

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,16 @@ install:
 	go install ./cmd/trace-agent
 
 binaries:
-	test -n "$(V)" # $$V must be set to the release version, e.g. "make binaries V=1.2.3"
+	test -n "$(V)" # $$V must be set to the release version tag, e.g. "make binaries V=1.2.3"
 
-	# cross-compiling binaries using suffix $(V)
+	# compiling release binaries for tag $(V)
+	git checkout $(V)
 	mkdir -p ./bin
 	TRACE_AGENT_VERSION=$(V) go generate ./info
 	GOOS=windows GOARCH=amd64 go build -o ./bin/trace-agent-windows-amd64-$(V).exe ./cmd/trace-agent
 	GOOS=linux GOARCH=amd64 go build -o ./bin/trace-agent-linux-amd64-$(V) ./cmd/trace-agent
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/trace-agent-darwin-amd64-$(V) ./cmd/trace-agent
+	git checkout -
 
 ci:
 	# task used by CI

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The APM agent (aka Trace Agent) isn't part of the OSX Datadog Agent yet, it need
 - Download the [latest OSX Trace Agent release](https://github.com/DataDog/datadog-trace-agent/releases/latest).
 - Run the Trace Agent using the Datadog Agent configuration.
 
-    `./trace-agent-osx-X.Y.Z -config /opt/datadog-agent/etc/datadog.yaml`
+    `./trace-agent-darwin-amd64-X.Y.Z -config /opt/datadog-agent/etc/datadog.yaml`
 
 - The Trace Agent should now be running in foreground, with an initial output similar to:
 


### PR DESCRIPTION
Allows running:
```bash
make binaries V=6.2.1
```
Which would result in checking out and compiling the binaries for revision `6.2.1` into the `./bin` folder. They are named `trace-agent-{$GOOS}-{$GOARCH}-6.2.1`