### PR TITLE
Makefile: add new packages to linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ci:
 	# task used by CI
 	GOOS=windows go build ./cmd/trace-agent # ensure windows builds
 	go get -u github.com/golang/lint/golint/...
-	golint -set_exit_status=1 ./cmd/trace-agent ./filters ./fixtures ./info ./quantile ./quantizer ./sampler ./statsd ./watchdog ./writer
+	golint -set_exit_status=1 ./cmd/trace-agent ./filters ./fixtures ./info ./quantile ./quantizer ./sampler ./statsd ./watchdog ./writer ./flags ./osutil
 	go test -v ./...
 
 windows:

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -6,7 +6,7 @@ var (
 	// ConfigPath specifies the path to the configuration file.
 	ConfigPath string
 
-	// PIDFilepath specifies the path to the PID file.
+	// PIDFilePath specifies the path to the PID file.
 	PIDFilePath string
 
 	// LogLevel specifies the log output level.

--- a/flags/flags_nix.go
+++ b/flags/flags_nix.go
@@ -2,6 +2,7 @@
 
 package flags
 
+// DefaultConfigPath specifies the default configuration file path for non-Windows systems.
 const DefaultConfigPath = "/opt/datadog-agent/etc/datadog.yaml"
 
 func registerOSSpecificFlags() {}


### PR DESCRIPTION
Packages `flags` and `osutil` were missing from linter.