### PR TITLE
doc: add example yaml file

### DIFF
--- a/datadog.example.yaml
+++ b/datadog.example.yaml
@@ -1,0 +1,91 @@
+# This file describes the trace agent specific configuration and its defaults.
+# It does not cover the entirety of configuration available to the Datadog
+# Agent 6. To get an overview of all the options, see:
+# https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+#
+# The minimum necessary configuration to run the trace agent is uncommented.
+
+# Your Datadog API key. It can be found here:
+# https://app.datadoghq.com/account/settings
+api_key: 1234
+ 
+# # The host of the Datadog intake server where the agent will be
+# # sending stats.
+# dd_url: https://app.datadog.com
+# 
+# # hostname
+# hostname: localhost
+# 
+# # logging level
+# log_level: info
+# 
+# # Trace agent listening port
+# listen_port: 8126
+# 
+# # Statsd listening port
+# dogstatsd_port: 8125
+# 
+# # Proxy settings
+# proxy:
+#   https: https://my-proxy.com
+#   # Override proxy for this list of entries.
+#   no_proxy:
+#     - https://trace.agent.datadog.com
+# 
+# # True to skip SSL validation when connecting through a trusted proxy.
+# skip_ssl_validation: true
+ 
+# APM configuration section:
+apm_config:
+  enabled: true # enable APM
+# 
+#   # Trace intake API.
+#   apm_dd_url: trace.agent.datadog.com
+# 
+#   # The environment under which traces will be classified in Datadog.
+#   env: pre-prod
+# 
+#   # Extra sample rate to apply to internal samplers.
+#   extra_sample_rate: 1.0
+# 
+#   # Maximum number of traces per second to sample.
+#   max_traces_per_second: 10
+# 
+#   # Traces having a root span with this resource will be filtered out.
+#   ignore_resources:
+#     - secret/resource
+# 
+#   # The file path where the log will be written to.
+#   log_file: /var/log/datadog.log
+# 
+#   # Defines a set of rules to replace or remove certain services, resources, tags containing
+#   # potentially sensitive information. Simply use the tag name, for services or resources
+#   # use "service.name" or "resource.name".
+#   replace_tags:
+#     # Remove all query parameters from "http.url" tag:
+#     - name: "http.url"
+#       pattern: "\?.*$"
+#       repl: "?"
+# 
+#     # Remove all stack traces:
+#     - name: "error.stack"
+#       pattern: "(?s).*"
+#       repl: "?"
+# 
+#   # The port that the receiver listens on.
+#   receiver_port: 8126
+# 
+#   # If true, the agent will bind to 0.0.0.0 exposing itself to remote traffic.
+#   apm_non_local_traffic: false
+# 
+#   # Maximum memory to allow for the trace agent.
+#   # The agent will be killed if this number is surpassed.
+#   max_memory: 500000000
+# 
+#   # Maximum CPU percentage allowed to be occupied by the trace agent
+#   # The agent will be killed if this number is surpassed.
+#   max_cpu_percent: 0.5
+# 
+#   # Maximum number of simultaenous connections allowed by the agent.
+#   # The agent will be killed if this number is surpassed.
+#   max_connection: 200


### PR DESCRIPTION
Adds an `example.yaml` configuration to serve as guidance for an overview of all agent configuration options.