### PR TITLE
config: use Python environment as fallback to compute hostname

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -178,21 +178,26 @@ func (c *AgentConfig) Validate() error {
 // tries to shell out to the infrastructure agent for this, if DD_AGENT_BIN is
 // set, otherwise falling back to os.Hostname.
 func (c *AgentConfig) acquireHostname() error {
-	var err error
-	if c.DDAgentBin == "" {
-		c.Hostname, err = os.Hostname()
-		return err
+	var cmd *exec.Cmd
+	if c.DDAgentBin != "" {
+		// Agent 6
+		cmd = exec.Command(c.DDAgentBin, "hostname")
+		cmd.Env = []string{}
+	} else {
+		// Most likely Agent 5. Try and obtain the hostname using the Agent's
+		// Python environment, which will cover several additional installation
+		// scenarios such as GCE, EC2, Kube, Docker, etc. In these scenarios
+		// Go's os.Hostname will not be able to obtain the correct host. Do not
+		// remove!
+		cmd = exec.Command(defaultDDAgentPy, "-c", "from utils.hostname import get_hostname; print get_hostname()")
+		cmd.Env = []string{defaultDDAgentPyEnv}
 	}
 	var out bytes.Buffer
-	cmd := exec.Command(c.DDAgentBin, "hostname")
 	cmd.Stdout = &out
 	cmd.Env = append(os.Environ(), cmd.Env...) // needed for Windows
-	err = cmd.Run()
-	if err != nil {
-		c.Hostname, err = os.Hostname()
-		return err
-	}
-	if strings.TrimSpace(out.String()) == "" {
+	err := cmd.Run()
+	c.Hostname = strings.TrimSpace(out.String())
+	if err != nil || c.Hostname == "" {
 		c.Hostname, err = os.Hostname()
 	}
 	return err

--- a/config/agent_nix.go
+++ b/config/agent_nix.go
@@ -6,7 +6,8 @@ const (
 	// DefaultLogFilePath is where the agent will write logs if not overriden in the conf
 	DefaultLogFilePath = "/var/log/datadog/trace-agent.log"
 
-	// Agent 5
+	// Agent 5 Python Environment - exposes access to Python utilities
+	// such as obtaining the hostname from GCE, EC2, Kube, etc.
 	defaultDDAgentPy    = "/opt/datadog-agent/embedded/bin/python"
 	defaultDDAgentPyEnv = "PYTHONPATH=/opt/datadog-agent/agent"
 

--- a/config/agent_windows.go
+++ b/config/agent_windows.go
@@ -4,7 +4,8 @@ const (
 	// DefaultLogFilePath is where the agent will write logs if not overriden in the conf
 	DefaultLogFilePath = "c:\\programdata\\datadog\\logs\\trace-agent.log"
 
-	// Agent 5
+	// Agent 5 Python Environment - exposes access to Python utilities
+	// such as obtaining the hostname from GCE, EC2, Kube, etc.
 	defaultDDAgentPy    = "c:\\Program Files\\Datadog\\Datadog Agent\\embedded\\python.exe"
 	defaultDDAgentPyEnv = "PYTHONPATH=c:\\Program Files\\Datadog\\Datadog Agent\\agent"
 


### PR DESCRIPTION
This change fixes a regression where the Python environment was removed
from the host acquiring process in #435 

The Python environment is needed because it uses a Datadog-specific
library which covers for scenarios such as GCE, EC2, Docker etc. for
hostname retrieval.