### PR TITLE
obfuscate: added obfuscator for http.url and error.stack

### DIFF
--- a/config/merge_yaml_test.go
+++ b/config/merge_yaml_test.go
@@ -22,3 +22,22 @@ func TestParseRepaceRules(t *testing.T) {
 		assert.Equal(r.Pattern, r.Re.String())
 	}
 }
+
+func TestLoadYamlAgentConfig(t *testing.T) {
+	t.Run("Obfuscation", func(t *testing.T) {
+		assert := assert.New(t)
+		conf := New()
+		yc := &YamlAgentConfig{
+			TraceAgent: traceAgent{
+				Obfuscation: &ObfuscationConfig{RemoveStackTraces: true},
+			},
+		}
+		conf.loadYamlConfig(yc)
+		assert.NotNil(conf.Obfuscation)
+		assert.NotNil(conf.ReplaceTags)
+		assert.Len(conf.ReplaceTags, 1)
+		assert.Equal("error.stack", conf.ReplaceTags[0].Name)
+		assert.NotNil(conf.ReplaceTags[0].Re)
+		assert.Equal("?", conf.ReplaceTags[0].Repl)
+	})
+}

--- a/config/test_cases/full.yaml
+++ b/config/test_cases/full.yaml
@@ -29,3 +29,7 @@ apm_config:
       keep_values:
         - user_id
         - category_id
+    http:
+      remove_query_string: true
+      remove_path_digits: true
+    remove_stack_traces: true

--- a/obfuscate/http.go
+++ b/obfuscate/http.go
@@ -1,0 +1,53 @@
+package obfuscate
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+)
+
+// httpReplaceQueryRegexp is the regular expression used to replace
+// query strings after HTTP URLs.
+const httpReplaceQueryRegexp = `\?.*$`
+
+func (o *Obfuscator) obfuscateHTTP(span *model.Span) {
+	if span.Meta == nil {
+		return
+	}
+	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
+		// nothing to do
+		return
+	}
+	const k = "http.url"
+	val, ok := span.Meta[k]
+	if !ok {
+		return
+	}
+	uri, err := url.Parse(val)
+	if err != nil {
+		// should not happen for valid URLs, but better obfuscate everything
+		// rather than exposing sensitive information when this option
+		// is set.
+		span.Meta[k] = "?"
+		return
+	}
+	if o.opts.HTTP.RemoveQueryString {
+		uri.ForceQuery = true // add the '?'
+		uri.RawQuery = ""
+	}
+	if o.opts.HTTP.RemovePathDigits {
+		segs := strings.Split(uri.Path, "/")
+		var changed bool
+		for i, seg := range segs {
+			if strings.IndexAny(seg, "0123456789") > -1 {
+				segs[i] = "?"
+				changed = true
+			}
+		}
+		if changed {
+			uri.Path = strings.Join(segs, "/")
+		}
+	}
+	span.Meta[k] = uri.String()
+}

--- a/obfuscate/http_test.go
+++ b/obfuscate/http_test.go
@@ -1,0 +1,45 @@
+package obfuscate
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObfuscateHTTP(t *testing.T) {
+	const httpURL = "http://myweb.site/id/123/page/1?q=james&uid=a4f"
+	testSpan := &model.Span{
+		Type: "http",
+		Meta: map[string]string{
+			"http.url": httpURL,
+		},
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		assert := assert.New(t)
+		span := *testSpan
+		NewObfuscator(&config.ObfuscationConfig{}).Obfuscate(&span)
+		assert.Equal(httpURL, span.Meta["http.url"])
+	})
+
+	t.Run("enabled-query", func(t *testing.T) {
+		assert := assert.New(t)
+		span := *testSpan
+		NewObfuscator(&config.ObfuscationConfig{
+			HTTP: config.HTTPObfuscationConfig{RemoveQueryString: true},
+		}).Obfuscate(&span)
+		assert.Equal("http://myweb.site/id/123/page/1?", span.Meta["http.url"])
+	})
+
+	t.Run("enabled-digits", func(t *testing.T) {
+		assert := assert.New(t)
+		span := *testSpan
+		NewObfuscator(&config.ObfuscationConfig{
+			HTTP: config.HTTPObfuscationConfig{RemovePathDigits: true},
+		}).Obfuscate(&span)
+		assert.Equal("http://myweb.site/id/?/page/??", span.Meta["http.url"])
+		assert.Equal("foo bar", span.Meta["error.stack"])
+	})
+}

--- a/obfuscate/obfusacte.go
+++ b/obfuscate/obfusacte.go
@@ -34,9 +34,11 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 func (o *Obfuscator) Obfuscate(span *model.Span) {
 	switch span.Type {
 	case "sql", "cassandra":
-		o.quantizeSQL(span)
+		o.obfuscateSQL(span)
 	case "redis":
 		o.quantizeRedis(span)
+	case "http":
+		o.obfuscateHTTP(span)
 	case "mongodb":
 		o.obfuscateJSON(span, "mongodb.query", o.mongo)
 	case "elasticsearch":

--- a/obfuscate/sql.go
+++ b/obfuscate/sql.go
@@ -208,7 +208,7 @@ var tokenQuantizer = NewTokenConsumer(
 	})
 
 // QuantizeSQL generates resource and sql.query meta for SQL spans
-func (*Obfuscator) quantizeSQL(span *model.Span) {
+func (*Obfuscator) obfuscateSQL(span *model.Span) {
 	if span.Resource == "" {
 		return
 	}


### PR DESCRIPTION
Enables opt-in obfuscation of `http.url` tags in `http` type spans and of `error.stack` tags in all span types.