### PR TITLE
obfuscate: added obfuscator for http.url and error.stack

### DIFF
--- a/config/agent_test.go
+++ b/config/agent_test.go
@@ -97,6 +97,16 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.Equal("0.0.0.0", c.ReceiverHost)
 
 	assert.EqualValues([]string{"/health", "/500"}, c.Ignore["resource"])
+
+	o := c.Obfuscation
+	assert.NotNil(o)
+	assert.True(o.ES.Enabled)
+	assert.EqualValues([]string{"user_id", "category_id"}, o.ES.KeepValues)
+	assert.True(o.Mongo.Enabled)
+	assert.EqualValues([]string{"uid", "cat_id"}, o.Mongo.KeepValues)
+	assert.True(o.HTTP.RemoveQueryString)
+	assert.True(o.HTTP.RemovePathDigits)
+	assert.True(o.RemoveStackTraces)
 }
 
 func TestUndocumentedYamlConfig(t *testing.T) {

--- a/config/test_cases/full.yaml
+++ b/config/test_cases/full.yaml
@@ -27,5 +27,9 @@ apm_config:
     mongodb:
       enabled: true
       keep_values:
-        - user_id
-        - category_id
+        - uid
+        - cat_id
+    http:
+      remove_query_string: true
+      remove_paths_with_digits: true
+    remove_stack_traces: true

--- a/obfuscate/http.go
+++ b/obfuscate/http.go
@@ -1,0 +1,56 @@
+package obfuscate
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/DataDog/datadog-trace-agent/model"
+)
+
+// obfuscateHTTP obfuscates query strings and path segments containing digits in the span's
+// "http.url" tag, when one or both of these options are enabled.
+func (o *Obfuscator) obfuscateHTTP(span *model.Span) {
+	if span.Meta == nil {
+		return
+	}
+	if !o.opts.HTTP.RemoveQueryString && !o.opts.HTTP.RemovePathDigits {
+		// nothing to do
+		return
+	}
+	const k = "http.url"
+	val, ok := span.Meta[k]
+	if !ok {
+		return
+	}
+	u, err := url.Parse(val)
+	if err != nil {
+		// should not happen for valid URLs, but better obfuscate everything
+		// rather than expose sensitive information when this option is on.
+		span.Meta[k] = "?"
+		return
+	}
+	if o.opts.HTTP.RemoveQueryString && u.RawQuery != "" {
+		u.ForceQuery = true // add the '?'
+		u.RawQuery = ""
+	}
+	if o.opts.HTTP.RemovePathDigits {
+		segs := strings.Split(u.Path, "/")
+		var changed bool
+		for i, seg := range segs {
+			for _, ch := range []byte(seg) {
+				if ch >= '0' && ch <= '9' {
+					// we can not set the question mark directly here because the url
+					// package will escape it into %3F, so we use this placeholder and
+					// replace it further down.
+					segs[i] = "/REDACTED/"
+					changed = true
+					break
+				}
+			}
+		}
+		if changed {
+			u.Path = strings.Join(segs, "/")
+		}
+	}
+	span.Meta[k] = strings.Replace(u.String(), "/REDACTED/", "?", -1)
+}

--- a/obfuscate/http_test.go
+++ b/obfuscate/http_test.go
@@ -1,0 +1,159 @@
+package obfuscate
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/DataDog/datadog-trace-agent/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// inOutTest is holds a test input and an expected output.
+type inOutTest struct{ in, out string }
+
+func TestObfuscateHTTP(t *testing.T) {
+	const testURL = "http://foo.com/1/2/3?q=james"
+
+	t.Run("disabled", testHTTPObfuscation(&inOutTest{
+		in:  testURL,
+		out: testURL,
+	}, nil))
+
+	t.Run("query", func(t *testing.T) {
+		conf := &config.HTTPObfuscationConfig{RemoveQueryString: true}
+		for ti, tt := range []inOutTest{
+			{
+				in:  "http://foo.com/",
+				out: "http://foo.com/",
+			},
+			{
+				in:  "http://foo.com/123",
+				out: "http://foo.com/123",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?search=bar&page=2",
+				out: "http://foo.com/id/123/page/1?",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?search=bar&page=2#fragment",
+				out: "http://foo.com/id/123/page/1?#fragment",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?blabla",
+				out: "http://foo.com/id/123/page/1?",
+			},
+			{
+				in:  "http://foo.com/id/123/pa%3Fge/1?blabla",
+				out: "http://foo.com/id/123/pa%3Fge/1?",
+			},
+		} {
+			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))
+		}
+	})
+
+	t.Run("digits", func(t *testing.T) {
+		conf := &config.HTTPObfuscationConfig{RemovePathDigits: true}
+		for ti, tt := range []inOutTest{
+			{
+				in:  "http://foo.com/",
+				out: "http://foo.com/",
+			},
+			{
+				in:  "http://foo.com/name?query=search",
+				out: "http://foo.com/name?query=search",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?search=bar&page=2",
+				out: "http://foo.com/id/?/page/??search=bar&page=2",
+			},
+			{
+				in:  "http://foo.com/id/a1/page/1qwe233?search=bar&page=2#fragment-123",
+				out: "http://foo.com/id/?/page/??search=bar&page=2#fragment-123",
+			},
+			{
+				in:  "http://foo.com/123",
+				out: "http://foo.com/?",
+			},
+			{
+				in:  "http://foo.com/123/abcd9",
+				out: "http://foo.com/?/?",
+			},
+			{
+				in:  "http://foo.com/123/name/abcd9",
+				out: "http://foo.com/?/name/?",
+			},
+			{
+				in:  "http://foo.com/123/name/abcd9",
+				out: "http://foo.com/?/name/?",
+			},
+			{
+				in:  "http://foo.com/1%3F3/nam%3Fe/abcd9",
+				out: "http://foo.com/?/nam%3Fe/?",
+			},
+		} {
+			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))
+		}
+	})
+
+	t.Run("both", func(t *testing.T) {
+		conf := &config.HTTPObfuscationConfig{RemoveQueryString: true, RemovePathDigits: true}
+		for ti, tt := range []inOutTest{
+			{
+				in:  "http://foo.com/",
+				out: "http://foo.com/",
+			},
+			{
+				in:  "http://foo.com/name/id",
+				out: "http://foo.com/name/id",
+			},
+			{
+				in:  "http://foo.com/name/id?query=search",
+				out: "http://foo.com/name/id?",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?search=bar&page=2",
+				out: "http://foo.com/id/?/page/??",
+			},
+			{
+				in:  "http://foo.com/id/123/page/1?search=bar&page=2#fragment",
+				out: "http://foo.com/id/?/page/??#fragment",
+			},
+			{
+				in:  "http://foo.com/1%3F3/nam%3Fe/abcd9",
+				out: "http://foo.com/?/nam%3Fe/?",
+			},
+			{
+				in:  "http://foo.com/id/123/pa%3Fge/1?blabla",
+				out: "http://foo.com/id/?/pa%3Fge/??",
+			},
+		} {
+			t.Run(strconv.Itoa(ti), testHTTPObfuscation(&tt, conf))
+		}
+	})
+
+	t.Run("wrong-type", func(t *testing.T) {
+		assert := assert.New(t)
+		span := model.Span{Type: "web", Meta: map[string]string{"http.url": testURL}}
+		cfg := config.HTTPObfuscationConfig{RemoveQueryString: true, RemovePathDigits: true}
+		NewObfuscator(&config.ObfuscationConfig{HTTP: cfg}).Obfuscate(&span)
+		assert.Equal(testURL, span.Meta["http.url"])
+	})
+}
+
+// testHTTPObfuscation tests that the given input results in the given output using the passed configuration.
+func testHTTPObfuscation(tt *inOutTest, conf *config.HTTPObfuscationConfig) func(t *testing.T) {
+	return func(t *testing.T) {
+		var cfg config.HTTPObfuscationConfig
+		if conf != nil {
+			cfg = *conf
+		}
+		assert := assert.New(t)
+		span := model.Span{
+			Type: "http",
+			Meta: map[string]string{"http.url": tt.in},
+		}
+		NewObfuscator(&config.ObfuscationConfig{HTTP: cfg}).Obfuscate(&span)
+		assert.Equal(tt.out, span.Meta["http.url"])
+	}
+}

--- a/obfuscate/obfusacte.go
+++ b/obfuscate/obfusacte.go
@@ -34,9 +34,11 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 func (o *Obfuscator) Obfuscate(span *model.Span) {
 	switch span.Type {
 	case "sql", "cassandra":
-		o.quantizeSQL(span)
+		o.obfuscateSQL(span)
 	case "redis":
 		o.quantizeRedis(span)
+	case "http":
+		o.obfuscateHTTP(span)
 	case "mongodb":
 		o.obfuscateJSON(span, "mongodb.query", o.mongo)
 	case "elasticsearch":

--- a/obfuscate/obfusacte.go
+++ b/obfuscate/obfusacte.go
@@ -7,7 +7,8 @@ import (
 	"github.com/DataDog/datadog-trace-agent/model"
 )
 
-// Obfuscator quantizes and obfuscates spans.
+// Obfuscator quantizes and obfuscates spans. The obfuscator is not safe for
+// concurrent use.
 type Obfuscator struct {
 	opts  *config.ObfuscationConfig
 	es    *jsonObfuscator // nil if disabled

--- a/obfuscate/sql.go
+++ b/obfuscate/sql.go
@@ -208,7 +208,7 @@ var tokenQuantizer = NewTokenConsumer(
 	})
 
 // QuantizeSQL generates resource and sql.query meta for SQL spans
-func (*Obfuscator) quantizeSQL(span *model.Span) {
+func (*Obfuscator) obfuscateSQL(span *model.Span) {
 	if span.Resource == "" {
 		return
 	}


### PR DESCRIPTION
Enables opt-in obfuscation of `http.url` tags in `http` type spans and of `error.stack` tags in all span types.

- [x] Add unit tests
- [x] Test with Datadog UI (with stack traces, with digits, with query, with all and disabled)