### PR TITLE
obfuscate: s/strings.Builder/bytes.Buffer (downgrade to go1.9.4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
           resource_class: large
 
           docker:
-               - image: circleci/golang:1.10
+               - image: circleci/golang:1.9.4
 
           steps:
                - checkout

--- a/obfuscate/json.go
+++ b/obfuscate/json.go
@@ -1,6 +1,7 @@
 package obfuscate
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/config"
@@ -54,7 +55,7 @@ func (p *jsonObfuscator) setKey() {
 }
 
 func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
-	var out strings.Builder
+	var out bytes.Buffer
 	buf := make([]byte, 0, 10) // recording key token
 	p.scan.reset()
 	for _, c := range data {

--- a/obfuscate/redis.go
+++ b/obfuscate/redis.go
@@ -1,6 +1,7 @@
 package obfuscate
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/model"
@@ -20,7 +21,7 @@ var redisCompoundCommandSet = map[string]bool{
 func (*Obfuscator) quantizeRedis(span *model.Span) {
 	query := compactWhitespaces(span.Resource)
 
-	var resource strings.Builder
+	var resource bytes.Buffer
 	truncated := false
 	nbCmds := 0
 


### PR DESCRIPTION
A small performance hit is observed:
```
name                  old time/op    new time/op    delta
ObfuscateJSON/5003-8    48.4µs ± 0%    46.9µs ± 0%   -3.10%
ObfuscateJSON/437-8     6.77µs ± 0%    6.64µs ± 0%   -1.93%
ObfuscateJSON/671-8     6.81µs ± 0%    6.86µs ± 0%   +0.73%

name                  old alloc/op   new alloc/op   delta
ObfuscateJSON/5003-8    22.1kB ± 0%    23.8kB ± 0%   +7.41%
ObfuscateJSON/437-8     2.95kB ± 0%    3.47kB ± 0%  +17.62%
ObfuscateJSON/671-8     3.02kB ± 0%    3.47kB ± 0%  +15.12%

name                  old allocs/op  new allocs/op  delta
ObfuscateJSON/5003-8       203 ± 0%       199 ± 0%   -1.97%
ObfuscateJSON/437-8       48.0 ± 0%      46.0 ± 0%   -4.17%
ObfuscateJSON/671-8       42.0 ± 0%      40.0 ± 0%   -4.76%
```