### PR TITLE
cmd/trace-agent: force sampling of transactions with priority 2

### DIFF
--- a/cmd/trace-agent/agent.go
+++ b/cmd/trace-agent/agent.go
@@ -42,8 +42,8 @@ func (pt *processedTrace) getSamplingPriority() (int, bool) {
 	if pt.Root == nil {
 		return 0, false
 	}
-	priorityFloat, hasPriority := pt.Root.Metrics[sampler.SamplingPriorityKey]
-	return int(priorityFloat), hasPriority
+	p, ok := pt.Root.Metrics[sampler.SamplingPriorityKey]
+	return int(p), ok
 }
 
 // Agent struct holds all the sub-routines structs and make the data flow between them

--- a/sampler/prioritysampler.go
+++ b/sampler/prioritysampler.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	samplingPriorityKey = "_sampling_priority_v1"
+	// SamplingPriorityKey is the key of the sampling priority value in the metrics dictionnary of the root span
+	SamplingPriorityKey = "_sampling_priority_v1"
 	syncPeriod          = 3 * time.Second
 )
 
@@ -91,7 +92,7 @@ func (s *PriorityEngine) Sample(trace model.Trace, root *model.Span, env string)
 		return false
 	}
 
-	samplingPriority := root.Metrics[samplingPriorityKey]
+	samplingPriority := root.Metrics[SamplingPriorityKey]
 
 	// Regardless of rates, sampling here is based on the metadata set
 	// by the client library. Which, is turn, is based on agent hints,

--- a/sampler/prioritysampler.go
+++ b/sampler/prioritysampler.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	// SamplingPriorityKey is the key of the sampling priority value in the metrics dictionnary of the root span
+	// SamplingPriorityKey is the key of the sampling priority value in the metrics map of the root span
 	SamplingPriorityKey = "_sampling_priority_v1"
 	syncPeriod          = 3 * time.Second
 )

--- a/sampler/prioritysampler_test.go
+++ b/sampler/prioritysampler_test.go
@@ -48,7 +48,7 @@ func getTestTraceWithService(t *testing.T, service string, s *PriorityEngine) (m
 	if r <= rate {
 		priority = 1
 	}
-	trace[0].Metrics = map[string]float64{samplingPriorityKey: priority}
+	trace[0].Metrics = map[string]float64{SamplingPriorityKey: priority}
 	return trace, trace[0]
 }
 
@@ -67,7 +67,7 @@ func TestPrioritySample(t *testing.T) {
 	s = getTestPriorityEngine()
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
-	root.Metrics[samplingPriorityKey] = -1
+	root.Metrics[SamplingPriorityKey] = -1
 	assert.False(s.Sample(trace, root, env), "trace with negative priority is dropped")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a priority -1 trace should *NOT* impact sampler backend")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority -1 trace should *NOT* impact sampler backend")
@@ -75,7 +75,7 @@ func TestPrioritySample(t *testing.T) {
 	s = getTestPriorityEngine()
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
-	root.Metrics[samplingPriorityKey] = 0
+	root.Metrics[SamplingPriorityKey] = 0
 	assert.False(s.Sample(trace, root, env), "trace with priority 0 is dropped")
 	assert.True(0.0 < s.Sampler.Backend.GetTotalScore(), "sampling a priority 0 trace should increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority 0 trace should *NOT* increase sampled score")
@@ -83,7 +83,7 @@ func TestPrioritySample(t *testing.T) {
 	s = getTestPriorityEngine()
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
-	root.Metrics[samplingPriorityKey] = 1
+	root.Metrics[SamplingPriorityKey] = 1
 	assert.True(s.Sample(trace, root, env), "trace with priority 1 is kept")
 	assert.True(0.0 < s.Sampler.Backend.GetTotalScore(), "sampling a priority 0 trace should increase total score")
 	assert.True(0.0 < s.Sampler.Backend.GetSampledScore(), "sampling a priority 0 trace should increase sampled score")
@@ -91,7 +91,7 @@ func TestPrioritySample(t *testing.T) {
 	s = getTestPriorityEngine()
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
-	root.Metrics[samplingPriorityKey] = 2
+	root.Metrics[SamplingPriorityKey] = 2
 	assert.True(s.Sample(trace, root, env), "trace with priority 2 is kept")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a priority 2 trace should *NOT* increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a priority 2 trace should *NOT* increase sampled score")
@@ -99,12 +99,12 @@ func TestPrioritySample(t *testing.T) {
 	s = getTestPriorityEngine()
 	trace, root = getTestTraceWithService(t, "my-service", s)
 
-	root.Metrics[samplingPriorityKey] = 999
+	root.Metrics[SamplingPriorityKey] = 999
 	assert.True(s.Sample(trace, root, env), "trace with high priority is kept")
 	assert.Equal(0.0, s.Sampler.Backend.GetTotalScore(), "sampling a high priority trace should *NOT* increase total score")
 	assert.Equal(0.0, s.Sampler.Backend.GetSampledScore(), "sampling a high priority trace should *NOT* increase sampled score")
 
-	delete(root.Metrics, samplingPriorityKey)
+	delete(root.Metrics, SamplingPriorityKey)
 	assert.False(s.Sample(trace, root, env), "this should not happen but a trace without priority sampling set should be dropped")
 }
 


### PR DESCRIPTION
This PR makes sure that when a span from a trace with a sampling priority of 2 matches the criteria to be analyzed it is kept even if the rate based sampling policy would discard it.

Since these traces have been flagged as being of particular interest by the user, it makes sense to ensure the transactions too are always kept.