### PR TITLE
obfuscate: add `web` span type to obfuscated HTTP tags

### DIFF
--- a/obfuscate/http_test.go
+++ b/obfuscate/http_test.go
@@ -134,7 +134,7 @@ func TestObfuscateHTTP(t *testing.T) {
 
 	t.Run("wrong-type", func(t *testing.T) {
 		assert := assert.New(t)
-		span := model.Span{Type: "web", Meta: map[string]string{"http.url": testURL}}
+		span := model.Span{Type: "web_server", Meta: map[string]string{"http.url": testURL}}
 		cfg := config.HTTPObfuscationConfig{RemoveQueryString: true, RemovePathDigits: true}
 		NewObfuscator(&config.ObfuscationConfig{HTTP: cfg}).Obfuscate(&span)
 		assert.Equal(testURL, span.Meta["http.url"])

--- a/obfuscate/obfuscate.go
+++ b/obfuscate/obfuscate.go
@@ -47,7 +47,7 @@ func (o *Obfuscator) Obfuscate(span *model.Span) {
 		if o.opts.Memcached.Enabled {
 			o.obfuscateMemcached(span)
 		}
-	case "http":
+	case "web", "http":
 		o.obfuscateHTTP(span)
 	case "mongodb":
 		o.obfuscateJSON(span, "mongodb.query", o.mongo)

--- a/obfuscate/obfuscate_test.go
+++ b/obfuscate/obfuscate_test.go
@@ -167,6 +167,27 @@ func TestObfuscateConfig(t *testing.T) {
 		&config.ObfuscationConfig{},
 	))
 
+	t.Run("web/enabled", testConfig(
+		"web",
+		"http.url",
+		"http://mysite.mydomain/1/2?q=asd",
+		"http://mysite.mydomain/?/??",
+		&config.ObfuscationConfig{
+			HTTP: config.HTTPObfuscationConfig{
+				RemovePathDigits:  true,
+				RemoveQueryString: true,
+			},
+		},
+	))
+
+	t.Run("web/disabled", testConfig(
+		"web",
+		"http.url",
+		"http://mysite.mydomain/1/2?q=asd",
+		"http://mysite.mydomain/1/2?q=asd",
+		&config.ObfuscationConfig{},
+	))
+
 	t.Run("json/enabled", testConfig(
 		"elasticsearch",
 		"elasticsearch.body",


### PR DESCRIPTION
### Overview

Adds `web` as obfuscated `Span` type with `obfuscateHTTP`.