### PR TITLE
config: added proxy environment variable support

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -81,6 +81,10 @@ type AgentConfig struct {
 	ProxyURL          *url.URL
 	SkipSSLValidation bool
 
+	// NoProxy will be set to true when the proxy setting for the trace API endpoint
+	// needs to be ignored (e.g. it is part of the "no_proxy" list in the yaml settings).
+	NoProxy bool
+
 	// filtering
 	Ignore map[string][]string
 

--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -13,6 +14,8 @@ const (
 	envAPIKey          = "DD_API_KEY"               // API KEY
 	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled
 	envURL             = "DD_APM_DD_URL"            // APM URL
+	envProxyDeprecated = "HTTPS_PROXY"              // proxy URL (deprecated)
+	envProxy           = "DD_PROXY_HTTPS"           // proxy URL (overrides deprecated)
 	envHostname        = "DD_HOSTNAME"              // agent hostname
 	envBindHost        = "DD_BIND_HOST"             // statsd & receiver hostname
 	envReceiverPort    = "DD_RECEIVER_PORT"         // receiver port
@@ -99,6 +102,16 @@ func (c *AgentConfig) loadEnv() {
 			c.AnalyzedSpansByService = analyzedSpans
 		} else {
 			log.Errorf("Bad format for %s it should be of the form \"service_name|operation_name=rate,other_service|other_operation=rate\", error: %v", envAnalyzedSpans, err)
+		}
+	}
+	for _, env := range []string{envProxyDeprecated, envProxy} {
+		if v, ok := os.LookupEnv(env); ok {
+			url, err := url.Parse(v)
+			if err == nil {
+				c.ProxyURL = url
+			} else {
+				log.Errorf("Failed to parse proxy URL from proxy.https configuration: %s", err)
+			}
 		}
 	}
 }

--- a/config/merge_yaml.go
+++ b/config/merge_yaml.go
@@ -197,28 +197,21 @@ func (c *AgentConfig) loadYamlConfig(yc *YamlAgentConfig) {
 	if yc.StatsdPort > 0 {
 		c.StatsdPort = yc.StatsdPort
 	}
-
-	// respect Agent proxy configuration knowing we only have to support the APIEndpoint HTTPS case
-	if yc.Proxy.HTTPS != "" {
-		traceAgentNoProxy := false
-		for _, host := range yc.Proxy.NoProxy {
-			if host == c.APIEndpoint {
-				log.Info("Trace Agent endpoint matches proxy.no_proxy list item '%s': not using any proxy", host)
-				traceAgentNoProxy = true
-				break
-			}
-		}
-
-		if !traceAgentNoProxy {
-			url, err := url.Parse(yc.Proxy.HTTPS)
-			if err == nil {
-				c.ProxyURL = url
-			} else {
-				log.Errorf("Failed to parse proxy URL from proxy.https configuration: %s", err)
-			}
+	for _, host := range yc.Proxy.NoProxy {
+		if host == c.APIEndpoint {
+			log.Infof("Trace Agent endpoint matches `proxy.no_proxy` list item %q: ignoring proxy", host)
+			c.NoProxy = true
+			break
 		}
 	}
-
+	if yc.Proxy.HTTPS != "" {
+		url, err := url.Parse(yc.Proxy.HTTPS)
+		if err == nil {
+			c.ProxyURL = url
+		} else {
+			log.Errorf("Failed to parse proxy URL from proxy.https configuration: %s", err)
+		}
+	}
 	if yc.SkipSSLValidation != nil {
 		c.SkipSSLValidation = *yc.SkipSSLValidation
 	}

--- a/datadog.example.yaml
+++ b/datadog.example.yaml
@@ -30,7 +30,7 @@ api_key: 1234
 #   https: https://my-proxy.com
 #   # Override proxy for this list of entries.
 #   no_proxy:
-#     - https://trace.agent.datadog.com
+#     - https://trace.agent.datadoghq.com
 # 
 # # True to skip SSL validation when connecting through a trusted proxy.
 # skip_ssl_validation: true

--- a/writer/client.go
+++ b/writer/client.go
@@ -17,8 +17,8 @@ func NewClient(conf *config.AgentConfig) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.SkipSSLValidation},
 	}
-	if conf.ProxyURL != nil {
-		log.Infof("configuring proxy through host %s", conf.ProxyURL.Hostname())
+	if conf.ProxyURL != nil && !conf.NoProxy {
+		log.Infof("configuring proxy through: %s", conf.ProxyURL.String())
 		transport.Proxy = http.ProxyURL(conf.ProxyURL)
 	}
 	return &http.Client{Timeout: timeout, Transport: transport}

--- a/writer/client_test.go
+++ b/writer/client_test.go
@@ -1,0 +1,44 @@
+package writer
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/DataDog/datadog-trace-agent/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewClient(t *testing.T) {
+	assert := assert.New(t)
+	url, err := url.Parse("test_url")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("blank", func(t *testing.T) {
+		client := NewClient(&config.AgentConfig{})
+		transport := client.Transport.(*http.Transport)
+		assert.False(transport.TLSClientConfig.InsecureSkipVerify)
+		assert.Nil(transport.Proxy)
+	})
+
+	t.Run("no_proxy", func(t *testing.T) {
+		client := NewClient(&config.AgentConfig{
+			SkipSSLValidation: true,
+			ProxyURL:          url,
+			NoProxy:           true,
+		})
+		transport := client.Transport.(*http.Transport)
+		assert.True(transport.TLSClientConfig.InsecureSkipVerify)
+		assert.Nil(transport.Proxy)
+	})
+
+	t.Run("proxy", func(t *testing.T) {
+		client := NewClient(&config.AgentConfig{ProxyURL: url})
+		transport := client.Transport.(*http.Transport)
+		goturl, _ := transport.Proxy(nil)
+		assert.False(transport.TLSClientConfig.InsecureSkipVerify)
+		assert.Equal("test_url", goturl.String())
+	})
+}


### PR DESCRIPTION
This change adds support for the `DD_PROXY_HTTPS` and (now deprecated) `HTTPS_PROXY` environment variables in the trace agent. This is to match existing (and expected) Datadog Agent behavior.