### PR TITLE
config: fail start-up when hostname is empty

### DIFF
--- a/config/agent.go
+++ b/config/agent.go
@@ -175,7 +175,7 @@ func (c *AgentConfig) Validate() error {
 	}
 	if c.Hostname == "" {
 		if err := c.acquireHostname(); err != nil {
-			return ErrMissingHostname
+			return err
 		}
 	}
 	return nil
@@ -206,6 +206,9 @@ func (c *AgentConfig) acquireHostname() error {
 	c.Hostname = strings.TrimSpace(out.String())
 	if err != nil || c.Hostname == "" {
 		c.Hostname, err = os.Hostname()
+	}
+	if c.Hostname == "" {
+		err = ErrMissingHostname
 	}
 	return err
 }


### PR DESCRIPTION
If the trace agent fails to acquire a hostname after trying all fallbacks, it should fail to start.