### PR TITLE
obfuscate: use strings.Builder from go1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
           resource_class: large
 
           docker:
-               - image: circleci/golang:1.9.4
+               - image: circleci/golang:1.10
 
           steps:
                - checkout

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ it manually.
 
 ## Development
 
-First, make sure Go 1.9+ is installed. You can do this by following the steps on the [official website](https://golang.org/dl/).
+First, make sure Go 1.10+ is installed. You can do this by following the steps on the [official website](https://golang.org/dl/).
 
 Then, download (or update) the latest source by running:
 ```bash

--- a/config/merge_ini.go
+++ b/config/merge_ini.go
@@ -142,7 +142,7 @@ func (c *AgentConfig) loadIniConfig(conf *File) {
 		for key, rate := range rates {
 			serviceName, operationName, err := parseServiceAndOp(key)
 			if err != nil {
-				log.Errorf("Error when parsing names", err)
+				log.Errorf("Error when parsing names: %v", err)
 				continue
 			}
 			rate, err := strconv.ParseFloat(rate, 64)

--- a/obfuscate/json.go
+++ b/obfuscate/json.go
@@ -1,7 +1,6 @@
 package obfuscate
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/config"
@@ -55,7 +54,7 @@ func (p *jsonObfuscator) setKey() {
 }
 
 func (p *jsonObfuscator) obfuscate(data []byte) (string, error) {
-	var out bytes.Buffer
+	var out strings.Builder
 	buf := make([]byte, 0, 10) // recording key token
 	p.scan.reset()
 	for _, c := range data {

--- a/obfuscate/redis.go
+++ b/obfuscate/redis.go
@@ -1,7 +1,6 @@
 package obfuscate
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/DataDog/datadog-trace-agent/model"
@@ -24,7 +23,7 @@ var redisCompoundCommandSet = map[string]bool{
 func (*Obfuscator) quantizeRedis(span *model.Span) {
 	query := compactWhitespaces(span.Resource)
 
-	var resource bytes.Buffer
+	var resource strings.Builder
 	truncated := false
 	nbCmds := 0
 
@@ -91,7 +90,7 @@ func (*Obfuscator) obfuscateRedis(span *model.Span) {
 	}
 	t := newRedisTokenizer([]byte(span.Meta[redisRawCommand]))
 	var (
-		str  bytes.Buffer
+		str  strings.Builder
 		cmd  string
 		args []string
 	)
@@ -119,7 +118,7 @@ func (*Obfuscator) obfuscateRedis(span *model.Span) {
 	span.Meta[redisRawCommand] = str.String()
 }
 
-func obfuscateRedisCmd(out *bytes.Buffer, cmd string, args ...string) {
+func obfuscateRedisCmd(out *strings.Builder, cmd string, args ...string) {
 	out.WriteString(cmd)
 	if len(args) == 0 {
 		return

--- a/obfuscate/redis_tokenizer.go
+++ b/obfuscate/redis_tokenizer.go
@@ -2,6 +2,7 @@ package obfuscate
 
 import (
 	"bytes"
+	"strings"
 )
 
 // redisTokenType specifies the token type returned by the tokenizer.
@@ -82,7 +83,7 @@ func (t *redisTokenizer) next() {
 // scanCommand scans a command from the buffer.
 func (t *redisTokenizer) scanCommand() (tok string, typ redisTokenType, done bool) {
 	var (
-		str     bytes.Buffer
+		str     strings.Builder
 		started bool
 	)
 	for {
@@ -113,7 +114,7 @@ func (t *redisTokenizer) scanCommand() (tok string, typ redisTokenType, done boo
 // scanArg scans an argument from the buffer.
 func (t *redisTokenizer) scanArg() (tok string, typ redisTokenType, done bool) {
 	var (
-		str    bytes.Buffer
+		str    strings.Builder
 		quoted bool // in quoted string
 		escape bool // escape sequence
 	)


### PR DESCRIPTION
This change updates JSON and Redis obfuscator to use `strings.Builder`
instead of `bytes.Buffer` for a minor speed increase. It also updates CI
to use go1.10, where this new structure was added.

Additionally, it also fixes a minor bug with an error message in the `config`
package.