### PR TITLE
config: add support for SOCKS5 and deprecate proxy.http(s)

### DIFF
--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/cihub/seelog"
 )
 
+// TODO(x): remove deprecated environment variable support in 7.x
+
 const (
 	envAPIKey          = "DD_API_KEY"               // API KEY
 	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled

--- a/config/merge_yaml_test.go
+++ b/config/merge_yaml_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"net/url"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,5 +22,56 @@ func TestParseRepaceRules(t *testing.T) {
 	}
 	for _, r := range rules {
 		assert.Equal(r.Pattern, r.Re.String())
+	}
+}
+
+func TestProxyURL(t *testing.T) {
+	for name, tt := range map[string]struct {
+		cfg  proxy
+		want *url.URL
+	}{
+		"http": {
+			cfg: proxy{HTTP: "http://proxy.addr"},
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "proxy.addr",
+			},
+		},
+		"https": {
+			cfg: proxy{HTTPS: "https://proxy.addr"},
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "proxy.addr",
+			},
+		},
+		"url/http": {
+			cfg: proxy{URL: "http://proxy.addr"},
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "proxy.addr",
+			},
+		},
+		"url/https": {
+			cfg: proxy{URL: "https://proxy.addr"},
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "proxy.addr",
+			},
+		},
+		"url/socks5": {
+			cfg: proxy{URL: "socks5://proxy.addr"},
+			want: &url.URL{
+				Scheme: "socks5",
+				Host:   "proxy.addr",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg := New()
+			cfg.loadYamlConfig(&YamlAgentConfig{Proxy: tt.cfg})
+			if got := cfg.ProxyURL; !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("expected %#v, got %#v", tt.want, got)
+			}
+		})
 	}
 }

--- a/datadog.example.yaml
+++ b/datadog.example.yaml
@@ -27,7 +27,8 @@ api_key: 1234
 # 
 # # Proxy settings
 # proxy:
-#   https: https://my-proxy.com
+#   # Use a proxy (http, https or socks5 supported)
+#   url: socks5://my-proxy.com
 #   # Override proxy for this list of entries.
 #   no_proxy:
 #     - https://trace.agent.datadoghq.com


### PR DESCRIPTION
This change adds support for SOCKS5 proxies (which was practically already
supported via the existing proxy settings and their mechanics, but confusingly
implemented) using the `proxy.url` setting.

It also deprecates the unnecessary `proxy.http` and `proxy.https`
settings in the example files and marks them as such. The scheme can
already be deduced from the URL.