### PR TITLE
cmd/trace-agent: factor out receiver into "api" package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ci:
 	# task used by CI
 	GOOS=windows go build ./cmd/trace-agent # ensure windows builds
 	go get -u github.com/golang/lint/golint/...
-	golint -set_exit_status=1 ./cmd/trace-agent ./filters ./testutil ./info ./quantile ./obfuscate ./sampler ./statsd ./watchdog ./writer ./flags ./osutil
+	golint -set_exit_status=1 ./cmd/trace-agent ./filters ./api ./testutil ./info ./quantile ./obfuscate ./sampler ./statsd ./watchdog ./writer ./flags ./osutil
 	go test -v ./...
 
 windows:

--- a/api/listener.go
+++ b/api/listener.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"errors"
@@ -9,51 +9,51 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// RateLimitedListener wraps a regular TCPListener with rate limiting.
-type RateLimitedListener struct {
+// rateLimitedListener wraps a regular TCPListener with rate limiting.
+type rateLimitedListener struct {
 	connLease int32 // How many connections are available for this listener before rate-limiting kicks in
 	*net.TCPListener
 }
 
-// NewRateLimitedListener returns a new wrapped listener, which is non-initialized
-func NewRateLimitedListener(l net.Listener, conns int) (*RateLimitedListener, error) {
+// newRateLimitedListener returns a new wrapped listener, which is non-initialized
+func newRateLimitedListener(l net.Listener, conns int) (*rateLimitedListener, error) {
 	tcpL, ok := l.(*net.TCPListener)
 
 	if !ok {
 		return nil, errors.New("cannot wrap listener")
 	}
 
-	sl := &RateLimitedListener{connLease: int32(conns), TCPListener: tcpL}
+	sl := &rateLimitedListener{connLease: int32(conns), TCPListener: tcpL}
 
 	return sl, nil
 }
 
 // Refresh periodically refreshes the connection lease, and thus cancels any rate limits in place
-func (sl *RateLimitedListener) Refresh(conns int) {
+func (sl *rateLimitedListener) Refresh(conns int) {
 	for range time.Tick(30 * time.Second) {
 		atomic.StoreInt32(&sl.connLease, int32(conns))
 		log.Debugf("Refreshed the connection lease: %d conns available", conns)
 	}
 }
 
-// RateLimitedError  indicates a user request being blocked by our rate limit
+// rateLimitedError  indicates a user request being blocked by our rate limit
 // It satisfies the net.Error interface
-type RateLimitedError struct{}
+type rateLimitedError struct{}
 
 // Error returns an error string
-func (e *RateLimitedError) Error() string { return "request has been rate-limited" }
+func (e *rateLimitedError) Error() string { return "request has been rate-limited" }
 
 // Temporary tells the HTTP server loop that this error is temporary and recoverable
-func (e *RateLimitedError) Temporary() bool { return true }
+func (e *rateLimitedError) Temporary() bool { return true }
 
 // Timeout tells the HTTP server loop that this error is not a timeout
-func (e *RateLimitedError) Timeout() bool { return false }
+func (e *rateLimitedError) Timeout() bool { return false }
 
 // Accept reimplements the regular Accept but adds rate limiting.
-func (sl *RateLimitedListener) Accept() (net.Conn, error) {
+func (sl *rateLimitedListener) Accept() (net.Conn, error) {
 	if atomic.LoadInt32(&sl.connLease) <= 0 {
 		// we've reached our cap for this lease period, reject the request
-		return nil, &RateLimitedError{}
+		return nil, &rateLimitedError{}
 	}
 
 	for {

--- a/api/logger.go
+++ b/api/logger.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"sync"

--- a/api/responses.go
+++ b/api/responses.go
@@ -1,4 +1,4 @@
-package main
+package api
 
 import (
 	"encoding/json"

--- a/cmd/trace-agent/agent_test.go
+++ b/cmd/trace-agent/agent_test.go
@@ -163,7 +163,7 @@ func TestProcess(t *testing.T) {
 			Duration: (500 * time.Millisecond).Nanoseconds(),
 		}
 
-		stats := agent.Receiver.stats.GetTagStats(info.Tags{})
+		stats := agent.Receiver.Stats.GetTagStats(info.Tags{})
 		assert := assert.New(t)
 
 		agent.Process(model.Trace{spanValid})


### PR DESCRIPTION
The goal is to separate all the stuff from `cmd/trace-agent` into smaller packages and ultimately end up with a clear separation between the three main (high level) functionalities of the agent:

* API (aka receiver)
* Processing pipeline (sampling, collecting stats, etc. - currently cmd/trace-agent)
* Writers

Clearer separation will eventually facilitate better testing. There is no change to functionality.