### PR TITLE
Revert "config: add support for SOCKS5 and deprecate proxy.http(s) (#478)"

### DIFF
--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -10,8 +10,6 @@ import (
 	log "github.com/cihub/seelog"
 )
 
-// TODO(x): remove deprecated environment variable support in 7.x
-
 const (
 	envAPIKey          = "DD_API_KEY"               // API KEY
 	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled

--- a/config/merge_yaml.go
+++ b/config/merge_yaml.go
@@ -31,12 +31,9 @@ type YamlAgentConfig struct {
 	TraceAgent traceAgent `yaml:"apm_config"`
 }
 
-// TODO(x): Remove deprecated fields in 7.x
-
 type proxy struct {
-	HTTP    string   `yaml:"http"`  // deprecated; use URL
-	HTTPS   string   `yaml:"https"` // deprecated; use URL
-	URL     string   `yaml:"url"`
+	HTTP    string   `yaml:"http"`
+	HTTPS   string   `yaml:"https"`
 	NoProxy []string `yaml:"no_proxy"`
 }
 
@@ -207,19 +204,12 @@ func (c *AgentConfig) loadYamlConfig(yc *YamlAgentConfig) {
 			break
 		}
 	}
-	for field, rawUrl := range map[string]string{
-		"http":  yc.Proxy.HTTP,
-		"https": yc.Proxy.HTTPS,
-		"url":   yc.Proxy.URL,
-	} {
-		if rawUrl == "" {
-			continue
-		}
-		url, err := url.Parse(rawUrl)
+	if yc.Proxy.HTTPS != "" {
+		url, err := url.Parse(yc.Proxy.HTTPS)
 		if err == nil {
 			c.ProxyURL = url
 		} else {
-			log.Errorf("Failed to parse proxy URL from proxy.%s configuration: %s", field, err)
+			log.Errorf("Failed to parse proxy URL from proxy.https configuration: %s", err)
 		}
 	}
 	if yc.SkipSSLValidation != nil {

--- a/config/merge_yaml_test.go
+++ b/config/merge_yaml_test.go
@@ -1,8 +1,6 @@
 package config
 
 import (
-	"net/url"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,56 +20,5 @@ func TestParseRepaceRules(t *testing.T) {
 	}
 	for _, r := range rules {
 		assert.Equal(r.Pattern, r.Re.String())
-	}
-}
-
-func TestProxyURL(t *testing.T) {
-	for name, tt := range map[string]struct {
-		cfg  proxy
-		want *url.URL
-	}{
-		"http": {
-			cfg: proxy{HTTP: "http://proxy.addr"},
-			want: &url.URL{
-				Scheme: "http",
-				Host:   "proxy.addr",
-			},
-		},
-		"https": {
-			cfg: proxy{HTTPS: "https://proxy.addr"},
-			want: &url.URL{
-				Scheme: "https",
-				Host:   "proxy.addr",
-			},
-		},
-		"url/http": {
-			cfg: proxy{URL: "http://proxy.addr"},
-			want: &url.URL{
-				Scheme: "http",
-				Host:   "proxy.addr",
-			},
-		},
-		"url/https": {
-			cfg: proxy{URL: "https://proxy.addr"},
-			want: &url.URL{
-				Scheme: "https",
-				Host:   "proxy.addr",
-			},
-		},
-		"url/socks5": {
-			cfg: proxy{URL: "socks5://proxy.addr"},
-			want: &url.URL{
-				Scheme: "socks5",
-				Host:   "proxy.addr",
-			},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			cfg := New()
-			cfg.loadYamlConfig(&YamlAgentConfig{Proxy: tt.cfg})
-			if got := cfg.ProxyURL; !reflect.DeepEqual(got, tt.want) {
-				t.Fatalf("expected %#v, got %#v", tt.want, got)
-			}
-		})
 	}
 }

--- a/datadog.example.yaml
+++ b/datadog.example.yaml
@@ -27,8 +27,7 @@ api_key: 1234
 # 
 # # Proxy settings
 # proxy:
-#   # Use a proxy (http, https or socks5 supported)
-#   url: socks5://my-proxy.com
+#   https: https://my-proxy.com
 #   # Override proxy for this list of entries.
 #   no_proxy:
 #     - https://trace.agent.datadoghq.com


### PR DESCRIPTION
This reverts commit b4b502c96691ad70e12fb90177180be22a83ff8d.

This change has to be postponed until it is part of the core agent. The
option added here does not exist in the core agent and has not yet been
decided as the key to use moving forward. Merging this will create
inconsistencies and complicated deprecation plans.