### PR TITLE
config: add 'site' option

### DIFF
--- a/config/agent_test.go
+++ b/config/agent_test.go
@@ -63,6 +63,24 @@ func TestConfigHostname(t *testing.T) {
 	})
 }
 
+func TestSite(t *testing.T) {
+	for name, tt := range map[string]struct {
+		file string
+		url  string
+	}{
+		"default":  {"./testdata/site_default.yaml", "https://trace.agent.datadoghq.com"},
+		"eu":       {"./testdata/site_eu.yaml", "https://trace.agent.datadoghq.eu"},
+		"url":      {"./testdata/site_url.yaml", "some.other.datadoghq.eu"},
+		"override": {"./testdata/site_override.yaml", "some.other.datadoghq.eu"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := Load(tt.file)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.url, cfg.APIEndpoint)
+		})
+	}
+}
+
 func TestDefaultConfig(t *testing.T) {
 	assert := assert.New(t)
 	c := New()

--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	envAPIKey          = "DD_API_KEY"               // API KEY
+	envSite            = "DD_SITE"                  // server site (us, eu)
 	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled
 	envURL             = "DD_APM_DD_URL"            // APM URL
 	envProxyDeprecated = "HTTPS_PROXY"              // (deprecated) proxy URL
@@ -53,8 +54,15 @@ func (c *AgentConfig) loadEnv() {
 		c.Hostname = v
 	}
 
+	site := os.Getenv(envSite)
+	if site != "" {
+		c.APIEndpoint = apiEndpointPrefix + site
+	}
 	if v := os.Getenv(envURL); v != "" {
 		c.APIEndpoint = v
+		if site != "" {
+			log.Infof("'DD_SITE' and 'DD_APM_DD_URL' are both set, using endpoint: %q", v)
+		}
 	}
 
 	if v := os.Getenv(envAPIKey); v != "" {

--- a/config/testdata/site_default.yaml
+++ b/config/testdata/site_default.yaml
@@ -1,0 +1,2 @@
+api_key: api_key_test
+dd_url: https://app.datadoghq.com

--- a/config/testdata/site_eu.yaml
+++ b/config/testdata/site_eu.yaml
@@ -1,0 +1,3 @@
+api_key: api_key_test
+dd_url: https://app.datadoghq.com
+site: datadoghq.eu

--- a/config/testdata/site_override.yaml
+++ b/config/testdata/site_override.yaml
@@ -1,0 +1,5 @@
+api_key: api_key_test
+dd_url: https://app.datadoghq.com
+site: datadoghq.br
+apm_config:
+  apm_dd_url: some.other.datadoghq.eu

--- a/config/testdata/site_url.yaml
+++ b/config/testdata/site_url.yaml
@@ -1,0 +1,4 @@
+api_key: api_key_test
+dd_url: https://app.datadoghq.com
+apm_config:
+  apm_dd_url: some.other.datadoghq.eu

--- a/datadog.example.yaml
+++ b/datadog.example.yaml
@@ -8,9 +8,13 @@
 # Your Datadog API key. It can be found here:
 # https://app.datadoghq.com/account/settings
 api_key: 1234
- 
-# # The host of the Datadog intake server where the agent will be
-# # sending stats.
+
+# # The site of the Datadog intake to send data to.
+# # Defaults to 'datadoghq.com', set to 'datadoghq.eu' to send data to the EU site.
+# site: datadoghq.com
+#
+# # The host of the Datadog intake server where the agent will be sending stats.
+# # Overrides the setting from "site".
 # dd_url: https://app.datadog.com
 # 
 # # hostname
@@ -39,7 +43,8 @@ api_key: 1234
 apm_config:
   enabled: true # enable APM
 # 
-#   # Trace intake API.
+#   # Trace intake API. If set, it will override the top level "site" setting.
+#   # Defaults to 'https://trace.agent.<site>'.
 #   apm_dd_url: trace.agent.datadog.com
 # 
 #   # The environment under which traces will be classified in Datadog.


### PR DESCRIPTION
Adds support for a new `site` top level configuration option, such that:
* When `site` is set, `https://trace.agent.<site>` is used.
* When both `site` and `apm_dd_url` are set, the latter takes precedence and user is notified.
* When only `apm_dd_url` is set, that value will be used.