### PR TITLE
obfuscate: clean up SQL obfuscator

### DIFF
--- a/obfuscate/obfuscate.go
+++ b/obfuscate/obfuscate.go
@@ -13,7 +13,7 @@ import (
 // concurrent use.
 type Obfuscator struct {
 	opts  *config.ObfuscationConfig
-	sql   *tokenConsumer
+	sql   *sqlObfuscator
 	es    *jsonObfuscator // nil if disabled
 	mongo *jsonObfuscator // nil if disabled
 }
@@ -25,7 +25,7 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	}
 	o := Obfuscator{
 		opts: cfg,
-		sql:  newTokenConsumer(),
+		sql:  newSQLObfuscator(),
 	}
 	if cfg.ES.Enabled {
 		o.es = newJSONObfuscator(&cfg.ES)

--- a/obfuscate/sql_tokenizer.go
+++ b/obfuscate/sql_tokenizer.go
@@ -66,8 +66,8 @@ func NewStringTokenizer(sql string) *Tokenizer {
 }
 
 // Reset the underlying buffer and positions
-func (tkn *Tokenizer) Reset() {
-	tkn.InStream.Reset("")
+func (tkn *Tokenizer) Reset(in string) {
+	tkn.InStream.Reset(in)
 	tkn.Position = 0
 	tkn.lastChar = 0
 }


### PR DESCRIPTION
* Renaming and simplifying comments
* Removed `agent.parse.error` tag as it brought no real details about parsing errors.
* Reset obfuscator only once, before it runs.

No apparent impact on performance:
```
name                      old time/op    new time/op    delta
Tokenizer/Escaping/512-8    7.27µs ± 0%    7.30µs ± 0%  +0.32%
Tokenizer/Grouping/199-8    4.16µs ± 0%    4.17µs ± 0%  +0.19%

name                      old alloc/op   new alloc/op   delta
Tokenizer/Escaping/512-8    4.40kB ± 0%    4.40kB ± 0%   0.00%
Tokenizer/Grouping/199-8    2.72kB ± 0%    2.72kB ± 0%   0.00%

name                      old allocs/op  new allocs/op  delta
Tokenizer/Escaping/512-8      87.0 ± 0%      87.0 ± 0%   0.00%
Tokenizer/Grouping/199-8      68.0 ± 0%      68.0 ± 0%   0.00%
```