### PR TITLE
config: remove configurable initial pre sample rate

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -76,7 +76,7 @@ func NewHTTPReceiver(
 	// use buffered channels so that handlers are not waiting on downstream processing
 	return &HTTPReceiver{
 		Stats:      info.NewReceiverStats(),
-		PreSampler: sampler.NewPreSampler(conf.PreSampleRate),
+		PreSampler: sampler.NewPreSampler(),
 		Out:        out,
 
 		conf:     conf,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -559,8 +559,8 @@ func TestReceiverPreSamplerCancel(t *testing.T) {
 	msgp.Encode(&buf, testutil.GetTestTrace(n, n, true))
 
 	conf := newTestReceiverConfig()
-	conf.PreSampleRate = 0.000001 // Make sure we sample aggressively
 	receiver := newTestReceiverFromConfig(conf)
+	receiver.PreSampler.SetRate(0.000001) // Make sure we sample aggressively
 
 	server := httptest.NewServer(http.HandlerFunc(receiver.httpHandleWithVersion(v04, receiver.handleTraces)))
 

--- a/cmd/trace-agent/agent.go
+++ b/cmd/trace-agent/agent.go
@@ -329,9 +329,6 @@ func (a *Agent) watchdog() {
 
 	// Adjust pre-sampling dynamically
 	rate, err := sampler.CalcPreSampleRate(a.conf.MaxCPU, wi.CPU.UserAvg, a.Receiver.PreSampler.RealRate())
-	if rate > a.conf.PreSampleRate {
-		rate = a.conf.PreSampleRate
-	}
 	if err != nil {
 		log.Warnf("problem computing pre-sample rate: %v", err)
 	}

--- a/config/agent.go
+++ b/config/agent.go
@@ -48,7 +48,6 @@ type AgentConfig struct {
 
 	// Sampler configuration
 	ExtraSampleRate float64
-	PreSampleRate   float64
 	MaxTPS          float64
 
 	// Receiver
@@ -116,7 +115,6 @@ func New() *AgentConfig {
 		ExtraAggregators: []string{"http.status_code"},
 
 		ExtraSampleRate: 1.0,
-		PreSampleRate:   1.0,
 		MaxTPS:          10,
 
 		ReceiverHost:    "localhost",
@@ -139,7 +137,7 @@ func New() *AgentConfig {
 		MaxConnections:   200, // in practice, rarely goes over 20
 		WatchdogInterval: time.Minute,
 
-		Ignore: make(map[string][]string),
+		Ignore:                      make(map[string][]string),
 		AnalyzedRateByServiceLegacy: make(map[string]float64),
 		AnalyzedSpansByService:      make(map[string]map[string]float64),
 	}

--- a/config/merge_ini.go
+++ b/config/merge_ini.go
@@ -174,11 +174,6 @@ func (c *AgentConfig) loadIniConfig(conf *File) {
 	if v, e := conf.GetFloat("trace.sampler", "extra_sample_rate"); e == nil {
 		c.ExtraSampleRate = v
 	}
-	// undocumented
-	// TODO: remove, should stay internal?
-	if v, e := conf.GetFloat("trace.sampler", "pre_sample_rate"); e == nil {
-		c.PreSampleRate = v
-	}
 	if v, e := conf.GetFloat("trace.sampler", "max_traces_per_second"); e == nil {
 		c.MaxTPS = v
 	}

--- a/sampler/presampler.go
+++ b/sampler/presampler.go
@@ -47,11 +47,11 @@ type PreSampler struct {
 }
 
 // NewPreSampler returns an initialized presampler
-func NewPreSampler(rate float64) *PreSampler {
+func NewPreSampler() *PreSampler {
 	decayFactor := 9.0 / 8.0
 	return &PreSampler{
 		stats: PreSamplerStats{
-			Rate: rate,
+			Rate: 1,
 		},
 		decayPeriod: defaultDecayPeriod,
 		decayFactor: decayFactor,

--- a/sampler/presampler_test.go
+++ b/sampler/presampler_test.go
@@ -86,7 +86,7 @@ func TestPreSamplerRace(t *testing.T) {
 	var wg sync.WaitGroup
 
 	const N = 1000
-	ps := NewPreSampler(1.0)
+	ps := NewPreSampler()
 	wg.Add(5)
 
 	go func() {
@@ -130,7 +130,7 @@ func TestPreSamplerRace(t *testing.T) {
 func TestPreSamplerSampleWithCount(t *testing.T) {
 	assert := assert.New(t)
 
-	ps := NewPreSampler(1.0)
+	ps := NewPreSampler()
 	ps.SetRate(0.2)
 	assert.Equal(0.2, ps.RealRate(), "by default, RealRate returns wished rate")
 	assert.True(ps.sampleWithCount(100), "always accept first payload")
@@ -162,7 +162,7 @@ func TestPreSamplerSampleWithCount(t *testing.T) {
 func TestPreSamplerError(t *testing.T) {
 	assert := assert.New(t)
 
-	ps := NewPreSampler(1.0)
+	ps := NewPreSampler()
 	assert.Equal("", ps.stats.Error, "fresh pre-sampler should have no error")
 	ps.SetError(fmt.Errorf("bad news"))
 	assert.Equal("bad news", ps.stats.Error, `error should be "bad news"`)


### PR DESCRIPTION
Remove unused `conf.PreSampleRate`, an option never meant to be exposed.

This is a no-op change. Only cleaning the code before future work on the pre-sampler.