### PR TITLE
cmd/trace-agent: improve Agent.Process readability and add Span.SetMetric

### DIFF
--- a/cmd/trace-agent/transaction_sampler_test.go
+++ b/cmd/trace-agent/transaction_sampler_test.go
@@ -12,8 +12,7 @@ import (
 func createTrace(serviceName string, operationName string, topLevel bool, hasPriority bool, priority int) processedTrace {
 	ws := model.WeightedSpan{TopLevel: topLevel, Span: &model.Span{Service: serviceName, Name: operationName}}
 	if hasPriority {
-		ws.Metrics = make(map[string]float64)
-		ws.Metrics[sampler.SamplingPriorityKey] = float64(priority)
+		ws.SetMetric(sampler.SamplingPriorityKey, float64(priority))
 	}
 	wt := model.WeightedTrace{&ws}
 	return processedTrace{WeightedTrace: wt, Root: ws.Span}

--- a/model/span.go
+++ b/model/span.go
@@ -44,3 +44,11 @@ func (s *Span) Weight() float64 {
 
 	return 1.0 / sampleRate
 }
+
+// SetMetric sets a value in the span Metrics map.
+func (s *Span) SetMetric(key string, val float64) {
+	if s.Metrics == nil {
+		s.Metrics = make(map[string]float64)
+	}
+	s.Metrics[key] = val
+}

--- a/model/top_level.go
+++ b/model/top_level.go
@@ -44,17 +44,11 @@ func (s *Span) setTopLevel(topLevel bool) {
 			return
 		}
 		delete(s.Metrics, topLevelKey)
-		if len(s.Metrics) == 0 {
-			s.Metrics = nil
-		}
 		return
-	}
-	if s.Metrics == nil {
-		s.Metrics = make(map[string]float64, 1)
 	}
 	// Setting the metrics value, so that code downstream in the pipeline
 	// can identify this as top-level without recomputing everything.
-	s.Metrics[topLevelKey] = 1
+	s.SetMetric(topLevelKey, 1)
 }
 
 // TopLevel returns true if span is top-level.

--- a/model/top_level_test.go
+++ b/model/top_level_test.go
@@ -139,7 +139,7 @@ func TestTopLevelGetSetMetrics(t *testing.T) {
 	span.setTopLevel(true)
 	assert.Equal(float64(1), span.Metrics["_top_level"], "should have a _top_level:1 flag")
 	span.setTopLevel(false)
-	assert.Nil(span.Metrics, "no meta at all")
+	assert.Equal(len(span.Metrics), 0, "no meta at all")
 
 	span.Metrics = map[string]float64{"custom": 42}
 

--- a/sampler/coresampler.go
+++ b/sampler/coresampler.go
@@ -174,8 +174,5 @@ func GetTraceAppliedSampleRate(root *model.Span) float64 {
 
 // SetTraceAppliedSampleRate sets the currently applied sample rate in the trace data to allow chained up sampling.
 func SetTraceAppliedSampleRate(root *model.Span, sampleRate float64) {
-	if root.Metrics == nil {
-		root.Metrics = make(map[string]float64)
-	}
-	root.Metrics[model.SpanSampleRateMetricKey] = sampleRate
+	root.SetMetric(model.SpanSampleRateMetricKey, sampleRate)
 }


### PR DESCRIPTION
- Reorder the content of `Agent.Process` by more meaningful units and add extra comments.
- Add a `Span.SetMetric` function and use it in relevant places.

This prepare future changes involving that function and the usage of many more metrics.

It should have been two PRs (they are 2 commits) but as they are built on top of each other, I went for the easy way.