### PR TITLE
Ingest old traces and align their stats on oldestTs

### DIFF
--- a/cmd/trace-agent/agent.go
+++ b/cmd/trace-agent/agent.go
@@ -208,14 +208,6 @@ func (a *Agent) Process(t model.Trace) {
 	}
 	atomic.AddInt64(stat, 1)
 
-	if root.End() < model.Now()-2*a.conf.BucketInterval.Nanoseconds() {
-		log.Errorf("skipping trace with root too far in past, root:%v", *root)
-
-		atomic.AddInt64(&ts.TracesDropped, 1)
-		atomic.AddInt64(&ts.SpansDropped, int64(len(t)))
-		return
-	}
-
 	if !a.Blacklister.Allows(root) {
 		log.Debugf("trace rejected by blacklister. root: %v", root)
 		atomic.AddInt64(&ts.TracesFiltered, 1)

--- a/cmd/trace-agent/agent_test.go
+++ b/cmd/trace-agent/agent_test.go
@@ -208,27 +208,6 @@ func TestProcess(t *testing.T) {
 		assert.EqualValues(t, 4, stats.TracesPriority1)
 		assert.EqualValues(t, 5, stats.TracesPriority2)
 	})
-
-	t.Run("Stats/Dropped", func(t *testing.T) {
-		cfg := config.New()
-		cfg.APIKey = "test"
-		ctx, cancel := context.WithCancel(context.Background())
-		agent := NewAgent(ctx, cfg)
-		defer cancel()
-
-		span := &model.Span{
-			Resource: "SELECT name FROM people WHERE age = 42 AND extra = 55",
-			Type:     "sql",
-			Start:    time.Now().Add(-2 * time.Hour).UnixNano(),
-			Duration: (500 * time.Millisecond).Nanoseconds(),
-			Metrics:  map[string]float64{},
-		}
-		agent.Process(model.Trace{span, span})
-
-		stats := agent.Receiver.Stats.GetTagStats(info.Tags{})
-		assert.EqualValues(t, 1, stats.TracesDropped)
-		assert.EqualValues(t, 2, stats.SpansDropped)
-	})
 }
 
 func BenchmarkAgentTraceProcessing(b *testing.B) {

--- a/cmd/trace-agent/concentrator.go
+++ b/cmd/trace-agent/concentrator.go
@@ -12,6 +12,8 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
+const defaultBufferLen = 2
+
 // Concentrator produces time bucketed statistics from a stream of raw traces.
 // https://en.wikipedia.org/wiki/Knelson_concentrator
 // Gets an imperial shitton of traces, and outputs pre-computed data structures
@@ -21,6 +23,14 @@ type Concentrator struct {
 	aggregators []string
 	// bucket duration in nanoseconds
 	bsize int64
+	// Timestamp of the oldest time bucket for which we still allow data.
+	// Any ingested stats older than it gets added to that bucket.
+	oldestTs int64
+	// bufferLen is the number of 10s stats bucket we keep in memory before flushing them.
+	// It means that we can compute stats only for the last `bufferLen * bsize` and that we
+	// wait such time before flushing the stats.
+	// This only applies to past buckets. Stats buckets in the future are allowed with no restriction.
+	bufferLen int
 
 	OutStats chan []model.StatsBucket
 
@@ -37,6 +47,11 @@ func NewConcentrator(aggregators []string, bsize int64, out chan []model.StatsBu
 		aggregators: aggregators,
 		bsize:       bsize,
 		buckets:     make(map[int64]*model.StatsRawBucket),
+		// At start, only allow stats for the current time bucket. Ensure we don't
+		// override buckets which could have been sent before an Agent restart.
+		oldestTs: alignTs(model.Now(), bsize),
+		// TODO: Move to configuration.
+		bufferLen: defaultBufferLen,
 
 		OutStats: out,
 
@@ -87,6 +102,10 @@ func (c *Concentrator) Stop() {
 
 // Add appends to the proper stats bucket this trace's statistics
 func (c *Concentrator) Add(t processedTrace) {
+	c.addNow(t, model.Now())
+}
+
+func (c *Concentrator) addNow(t processedTrace, now int64) {
 	c.mu.Lock()
 
 	for _, s := range t.WeightedTrace {
@@ -95,6 +114,12 @@ func (c *Concentrator) Add(t processedTrace) {
 			continue
 		}
 		btime := s.End() - s.End()%c.bsize
+
+		// // If too far in the past, count in the oldest-allowed time bucket instead.
+		if btime < c.oldestTs {
+			btime = c.oldestTs
+		}
+
 		b, ok := c.buckets[btime]
 		if !ok {
 			b = model.NewStatsRawBucket(btime, c.bsize)
@@ -110,17 +135,20 @@ func (c *Concentrator) Add(t processedTrace) {
 
 // Flush deletes and returns complete statistic buckets
 func (c *Concentrator) Flush() []model.StatsBucket {
+	return c.flushNow(model.Now())
+}
+
+func (c *Concentrator) flushNow(now int64) []model.StatsBucket {
 	var sb []model.StatsBucket
-	now := model.Now()
 
 	c.mu.Lock()
 	for ts, srb := range c.buckets {
 		bucket := srb.Export()
 
-		// always keep one bucket opened
-		// this is a trade-off: we accept slightly late traces (clock skew and stuff)
-		// but we delay flushing by at most 2 buckets
-		if ts > now-2*c.bsize {
+		// Always keep `bufferLen` buckets (default is 2: current + previous one).
+		// This is a trade-off: we accept slightly late traces (clock skew and stuff)
+		// but we delay flushing by at most `bufferLen` buckets.
+		if ts > now-int64(c.bufferLen)*c.bsize {
 			continue
 		}
 
@@ -134,7 +162,22 @@ func (c *Concentrator) Flush() []model.StatsBucket {
 		sb = append(sb, bucket)
 		delete(c.buckets, ts)
 	}
+
+	// After flushing, update the oldest timestamp allowed to prevent having stats for
+	// an already-flushed bucket.
+	newOldestTs := alignTs(now, c.bsize) - int64(c.bufferLen-1)*c.bsize
+	if newOldestTs > c.oldestTs {
+		log.Debugf("update oldestTs to %d", newOldestTs)
+		c.oldestTs = newOldestTs
+	}
+
 	c.mu.Unlock()
 
 	return sb
+}
+
+// alignTs returns the provided timestamp truncated to the bucket size.
+// It gives us the start time of the time bucket in which such timestamp falls.
+func alignTs(ts int64, bsize int64) int64 {
+	return ts - ts%bsize
 }

--- a/cmd/trace-agent/concentrator.go
+++ b/cmd/trace-agent/concentrator.go
@@ -12,6 +12,8 @@ import (
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
+// defaultBufferLen represents the default buffer length; the number of bucket size
+// units used by the concentrator.
 const defaultBufferLen = 2
 
 // Concentrator produces time bucketed statistics from a stream of raw traces.
@@ -23,8 +25,8 @@ type Concentrator struct {
 	aggregators []string
 	// bucket duration in nanoseconds
 	bsize int64
-	// Timestamp of the oldest time bucket for which we still allow data.
-	// Any ingested stats older than it gets added to that bucket.
+	// Timestamp of the oldest time bucket for which we allow data.
+	// Any ingested stats older than it get added to this bucket.
 	oldestTs int64
 	// bufferLen is the number of 10s stats bucket we keep in memory before flushing them.
 	// It means that we can compute stats only for the last `bufferLen * bsize` and that we

--- a/cmd/trace-agent/concentrator_test.go
+++ b/cmd/trace-agent/concentrator_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -23,15 +24,15 @@ func getTsInBucket(alignedNow int64, bsize int64, offset int64) int64 {
 
 // testSpan avoids typo and inconsistency in test spans (typical pitfall: duration, start time,
 // and end time are aligned, and end time is the one that needs to be aligned
-func testSpan(c *Concentrator, spanID uint64, parentID uint64, duration, offset int64, service, resource string, err int32) *model.Span {
+func testSpan(spanID uint64, parentID uint64, duration, offset int64, service, resource string, err int32) *model.Span {
 	now := model.Now()
-	alignedNow := now - now%c.bsize
+	alignedNow := now - now%testBucketInterval
 
 	return &model.Span{
 		SpanID:   spanID,
 		ParentID: parentID,
 		Duration: duration,
-		Start:    getTsInBucket(alignedNow, c.bsize, offset) - duration,
+		Start:    getTsInBucket(alignedNow, testBucketInterval, offset) - duration,
 		Service:  service,
 		Name:     "query",
 		Resource: resource,
@@ -40,30 +41,24 @@ func testSpan(c *Concentrator, spanID uint64, parentID uint64, duration, offset 
 	}
 }
 
-func TestConcentratorStatsCounts(t *testing.T) {
+// TestConcentratorOldestTs tests that the Agent doesn't report time buckets from a
+// time before its start
+func TestConcentratorOldestTs(t *testing.T) {
 	assert := assert.New(t)
 	statsChan := make(chan []model.StatsBucket)
-	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
 
 	now := model.Now()
-	alignedNow := now - now%c.bsize
 
+	// Build that simply have spans spread over time windows.
 	trace := model.Trace{
-		// first bucket
-		testSpan(c, 1, 0, 24, 3, "A1", "resource1", 0),
-		testSpan(c, 2, 0, 12, 3, "A1", "resource1", 2),
-		testSpan(c, 3, 0, 40, 3, "A2", "resource2", 2),
-		testSpan(c, 4, 0, 300000000000, 3, "A2", "resource2", 2), // 5 minutes trace
-		testSpan(c, 5, 0, 30, 3, "A2", "resourcefoo", 0),
-		// second bucket
-		testSpan(c, 6, 0, 24, 2, "A1", "resource2", 0),
-		testSpan(c, 7, 0, 12, 2, "A1", "resource1", 2),
-		testSpan(c, 8, 0, 40, 2, "A2", "resource1", 2),
-		testSpan(c, 9, 0, 30, 2, "A2", "resource2", 2),
-		testSpan(c, 10, 0, 3600000000000, 2, "A2", "resourcefoo", 0), // 1 hour trace
-		// third bucket - but should not be flushed because it's the second to last
-		testSpan(c, 6, 0, 24, 1, "A1", "resource2", 0),
+		testSpan(1, 0, 50, 5, "A1", "resource1", 0),
+		testSpan(1, 0, 40, 4, "A1", "resource1", 0),
+		testSpan(1, 0, 30, 3, "A1", "resource1", 0),
+		testSpan(1, 0, 20, 2, "A1", "resource1", 0),
+		testSpan(1, 0, 10, 1, "A1", "resource1", 0),
+		testSpan(1, 0, 1, 0, "A1", "resource1", 0),
 	}
+
 	trace.ComputeTopLevel()
 	wt := model.NewWeightedTrace(trace, trace.GetRoot())
 
@@ -73,54 +68,191 @@ func TestConcentratorStatsCounts(t *testing.T) {
 		WeightedTrace: wt,
 	}
 
+	t.Run("cold", func(t *testing.T) {
+		// Running cold, all spans in the past should end up in the current time bucket.
+		flushTime := now
+		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+		c.Add(testTrace)
+
+		for i := 0; i < c.bufferLen; i++ {
+			stats := c.flushNow(flushTime)
+			if !assert.Equal(0, len(stats), "We should get exactly 0 StatsBucket") {
+				t.FailNow()
+			}
+			flushTime += testBucketInterval
+		}
+
+		stats := c.flushNow(flushTime)
+
+		if !assert.Equal(1, len(stats), "We should get exactly 1 StatsBucket") {
+			t.FailNow()
+		}
+
+		// First oldest bucket aggregates old past time buckets, it should have it all.
+		for key, count := range stats[0].Counts {
+			if key == "query|duration|env:none,resource:resource1,service:A1" {
+				assert.Equal(151, int(count.Value), "Wrong value for duration")
+			}
+			if key == "query|hits|env:none,resource:resource1,service:A1" {
+				assert.Equal(6, int(count.Value), "Wrong value for hits")
+			}
+		}
+	})
+
+	t.Run("hot", func(t *testing.T) {
+		flushTime := now
+		c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+		c.oldestTs = alignTs(now, c.bsize) - int64(c.bufferLen-1)*c.bsize
+		c.Add(testTrace)
+
+		for i := 0; i < c.bufferLen-1; i++ {
+			stats := c.flushNow(flushTime)
+			if !assert.Equal(0, len(stats), "We should get exactly 0 StatsBucket") {
+				t.FailNow()
+			}
+			flushTime += testBucketInterval
+		}
+
+		stats := c.flushNow(flushTime)
+		if !assert.Equal(1, len(stats), "We should get exactly 1 StatsBucket") {
+			t.FailNow()
+		}
+		flushTime += testBucketInterval
+
+		// First oldest bucket aggregates, it should have it all except the last span.
+		for key, count := range stats[0].Counts {
+			if key == "query|duration|env:none,resource:resource1,service:A1" {
+				assert.Equal(150, int(count.Value), "Wrong value for duration")
+			}
+			if key == "query|hits|env:none,resource:resource1,service:A1" {
+				assert.Equal(5, int(count.Value), "Wrong value for hits")
+			}
+		}
+
+		stats = c.flushNow(flushTime)
+		if !assert.Equal(1, len(stats), "We should get exactly 1 StatsBucket") {
+			t.FailNow()
+		}
+
+		// Stats of the last span.
+		for key, count := range stats[0].Counts {
+			if key == "query|duration|env:none,resource:resource1,service:A1" {
+				assert.Equal(1, int(count.Value), "Wrong value for duration")
+			}
+			if key == "query|hits|env:none,resource:resource1,service:A1" {
+				assert.Equal(1, int(count.Value), "Wrong value for hits")
+			}
+		}
+	})
+}
+
+//TestConcentratorStatsTotals tests that the total stats are correct, independently of the
+// time bucket they end up.
+func TestConcentratorStatsTotals(t *testing.T) {
+	assert := assert.New(t)
+	statsChan := make(chan []model.StatsBucket)
+	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+
+	now := model.Now()
+	alignedNow := alignTs(now, c.bsize)
+
+	// update oldestTs as it running for quite some time, to avoid the fact that at startup
+	// it only allows recent stats.
+	c.oldestTs = alignedNow - int64(c.bufferLen)*c.bsize
+
+	// Build that simply have spans spread over time windows.
+	trace := model.Trace{
+		testSpan(1, 0, 50, 5, "A1", "resource1", 0),
+		testSpan(1, 0, 40, 4, "A1", "resource1", 0),
+		testSpan(1, 0, 30, 3, "A1", "resource1", 0),
+		testSpan(1, 0, 20, 2, "A1", "resource1", 0),
+		testSpan(1, 0, 10, 1, "A1", "resource1", 0),
+		testSpan(1, 0, 1, 0, "A1", "resource1", 0),
+	}
+
+	trace.ComputeTopLevel()
+	wt := model.NewWeightedTrace(trace, trace.GetRoot())
+
+	testTrace := processedTrace{
+		Env:           "none",
+		Trace:         trace,
+		WeightedTrace: wt,
+	}
 	c.Add(testTrace)
-	stats := c.Flush()
 
-	if !assert.Equal(2, len(stats), "We should get exactly 2 StatsBucket") {
-		t.FailNow()
+	var hits float64
+	var duration float64
+
+	flushTime := now
+	for i := 0; i <= c.bufferLen; i++ {
+		stats := c.flushNow(flushTime)
+
+		if len(stats) == 0 {
+			continue
+		}
+
+		for key, count := range stats[0].Counts {
+			if key == "query|duration|env:none,resource:resource1,service:A1" {
+				duration += count.Value
+			}
+			if key == "query|hits|env:none,resource:resource1,service:A1" {
+				hits += count.Value
+			}
+		}
+		flushTime += c.bsize
 	}
 
-	// nothing guarantees the order of the buckets, they're from a map
-	var receivedBuckets []model.StatsBucket
-	if stats[0].Start < stats[1].Start {
-		receivedBuckets = []model.StatsBucket{stats[0], stats[1]}
-	} else {
-		receivedBuckets = []model.StatsBucket{stats[1], stats[0]}
+	assert.Equal(hits, float64(len(trace)), "Wrong value for total hits %d", hits)
+	assert.Equal(duration, float64(50+40+30+20+10+1), "Wrong value for total duration %d", duration)
+}
+
+// TestConcentratorStatsCounts tests exhaustively each stats bucket, over multiple time buckets.
+func TestConcentratorStatsCounts(t *testing.T) {
+	assert := assert.New(t)
+	statsChan := make(chan []model.StatsBucket)
+	c := NewConcentrator([]string{}, testBucketInterval, statsChan)
+
+	now := model.Now()
+	alignedNow := alignTs(now, c.bsize)
+
+	// update oldestTs as it running for quite some time, to avoid the fact that at startup
+	// it only allows recent stats.
+	c.oldestTs = alignedNow - int64(c.bufferLen)*c.bsize
+
+	// Build a trace with stats which should cover 3 time buckets.
+	trace := model.Trace{
+		// more than 2 buckets old, should be added to the 2 bucket-old, first flush.
+		testSpan(1, 0, 111, 10, "A1", "resource1", 0),
+		testSpan(1, 0, 222, 3, "A1", "resource1", 0),
+		// 2 buckets old, part of the first flush
+		testSpan(1, 0, 24, 2, "A1", "resource1", 0),
+		testSpan(2, 0, 12, 2, "A1", "resource1", 2),
+		testSpan(3, 0, 40, 2, "A2", "resource2", 2),
+		testSpan(4, 0, 300000000000, 2, "A2", "resource2", 2), // 5 minutes trace
+		testSpan(5, 0, 30, 2, "A2", "resourcefoo", 0),
+		// 1 bucket old, part of the second flush
+		testSpan(6, 0, 24, 1, "A1", "resource2", 0),
+		testSpan(7, 0, 12, 1, "A1", "resource1", 2),
+		testSpan(8, 0, 40, 1, "A2", "resource1", 2),
+		testSpan(9, 0, 30, 1, "A2", "resource2", 2),
+		testSpan(10, 0, 3600000000000, 1, "A2", "resourcefoo", 0), // 1 hour trace
+		// present data, part of the third flush
+		testSpan(6, 0, 24, 0, "A1", "resource2", 0),
 	}
 
-	// inspect our 2 stats buckets
-	assert.Equal(alignedNow-3*testBucketInterval, receivedBuckets[0].Start)
-	assert.Equal(alignedNow-2*testBucketInterval, receivedBuckets[1].Start)
-
-	var receivedCounts map[string]model.Count
-
-	// Start with the first/older bucket
-	receivedCounts = receivedBuckets[0].Counts
-	expectedCountValByKey := map[string]int64{
-		"query|duration|env:none,resource:resource1,service:A1":   36,
+	expectedCountValByKeyByTime := make(map[int64]map[string]int64)
+	expectedCountValByKeyByTime[alignedNow-2*testBucketInterval] = map[string]int64{
+		"query|duration|env:none,resource:resource1,service:A1":   369,
 		"query|duration|env:none,resource:resource2,service:A2":   300000000040,
 		"query|duration|env:none,resource:resourcefoo,service:A2": 30,
 		"query|errors|env:none,resource:resource1,service:A1":     1,
 		"query|errors|env:none,resource:resource2,service:A2":     2,
 		"query|errors|env:none,resource:resourcefoo,service:A2":   0,
-		"query|hits|env:none,resource:resource1,service:A1":       2,
+		"query|hits|env:none,resource:resource1,service:A1":       4,
 		"query|hits|env:none,resource:resource2,service:A2":       2,
 		"query|hits|env:none,resource:resourcefoo,service:A2":     1,
 	}
-
-	// FIXME[leo]: assert distributions!
-	// verify we got all counts
-	assert.Equal(len(expectedCountValByKey), len(receivedCounts), "GOT %v", receivedCounts)
-	// verify values
-	for key, val := range expectedCountValByKey {
-		count, ok := receivedCounts[key]
-		assert.True(ok, "%s was expected from concentrator", key)
-		assert.Equal(val, int64(count.Value), "Wrong value for count %s", key)
-	}
-
-	// same for second bucket
-	receivedCounts = receivedBuckets[1].Counts
-	expectedCountValByKey = map[string]int64{
+	expectedCountValByKeyByTime[alignedNow-1*testBucketInterval] = map[string]int64{
 		"query|duration|env:none,resource:resource1,service:A1":   12,
 		"query|duration|env:none,resource:resource2,service:A1":   24,
 		"query|duration|env:none,resource:resource1,service:A2":   40,
@@ -137,18 +269,68 @@ func TestConcentratorStatsCounts(t *testing.T) {
 		"query|hits|env:none,resource:resource2,service:A2":       1,
 		"query|hits|env:none,resource:resourcefoo,service:A2":     1,
 	}
+	expectedCountValByKeyByTime[alignedNow] = map[string]int64{
+		"query|duration|env:none,resource:resource2,service:A1": 24,
+		"query|errors|env:none,resource:resource2,service:A1":   0,
+		"query|hits|env:none,resource:resource2,service:A1":     1,
+	}
+	expectedCountValByKeyByTime[alignedNow+testBucketInterval] = map[string]int64{}
 
-	// verify we got all counts
-	assert.Equal(len(expectedCountValByKey), len(receivedCounts), "GOT %v", receivedCounts)
-	// verify values
-	for key, val := range expectedCountValByKey {
-		count, ok := receivedCounts[key]
-		assert.True(ok, "%s was expected from concentrator", key)
-		assert.Equal(val, int64(count.Value), "Wrong value for count %s", key)
+	trace.ComputeTopLevel()
+	wt := model.NewWeightedTrace(trace, trace.GetRoot())
+
+	testTrace := processedTrace{
+		Env:           "none",
+		Trace:         trace,
+		WeightedTrace: wt,
+	}
+	c.Add(testTrace)
+
+	// flush every testBucketInterval
+	flushTime := now
+	for i := 0; i <= c.bufferLen+2; i++ {
+		t.Run(fmt.Sprintf("flush-%d", i), func(t *testing.T) {
+			stats := c.flushNow(flushTime)
+
+			expectedFlushedTs := alignTs(flushTime, c.bsize) - int64(c.bufferLen)*testBucketInterval
+			if len(expectedCountValByKeyByTime[expectedFlushedTs]) == 0 {
+				// That's a flush for which we expect no data
+				return
+			}
+
+			if !assert.Equal(1, len(stats), "We should get exactly 1 StatsBucket") {
+				t.FailNow()
+			}
+
+			receivedBuckets := []model.StatsBucket{stats[0]}
+
+			assert.Equal(expectedFlushedTs, receivedBuckets[0].Start)
+
+			expectedCountValByKey := expectedCountValByKeyByTime[expectedFlushedTs]
+			receivedCounts := receivedBuckets[0].Counts
+
+			// verify we got all counts
+			assert.Equal(len(expectedCountValByKey), len(receivedCounts), "GOT %v", receivedCounts)
+			// verify values
+			for key, val := range expectedCountValByKey {
+				count, ok := receivedCounts[key]
+				assert.True(ok, "%s was expected from concentrator", key)
+				assert.Equal(val, int64(count.Value), "Wrong value for count %s", key)
+			}
+
+			// Flushing again at the same time should return nothing
+			stats = c.flushNow(flushTime)
+
+			if !assert.Equal(0, len(stats), "Second flush of the same time should be empty") {
+				t.FailNow()
+			}
+
+		})
+		flushTime += c.bsize
 	}
 }
 
-// This test makes sure that sublayers related stats are properly created
+// TestConcentratorSublayersStatsCounts tests exhaustively the sublayer stats of a single time window.
 func TestConcentratorSublayersStatsCounts(t *testing.T) {
 	assert := assert.New(t)
 	statsChan := make(chan []model.StatsBucket)
@@ -159,12 +341,12 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 
 	trace := model.Trace{
 		// first bucket
-		testSpan(c, 1, 0, 2000, 3, "A1", "resource1", 0),
-		testSpan(c, 2, 1, 1000, 3, "A2", "resource2", 0),
-		testSpan(c, 3, 1, 1000, 3, "A2", "resource3", 0),
-		testSpan(c, 4, 2, 40, 3, "A3", "resource4", 0),
-		testSpan(c, 5, 4, 300, 3, "A3", "resource5", 0),
-		testSpan(c, 6, 2, 30, 3, "A3", "resource6", 0),
+		testSpan(1, 0, 2000, 0, "A1", "resource1", 0),
+		testSpan(2, 1, 1000, 0, "A2", "resource2", 0),
+		testSpan(3, 1, 1000, 0, "A2", "resource3", 0),
+		testSpan(4, 2, 40, 0, "A3", "resource4", 0),
+		testSpan(5, 4, 300, 0, "A3", "resource5", 0),
+		testSpan(6, 2, 30, 0, "A3", "resource6", 0),
 	}
 	trace.ComputeTopLevel()
 	wt := model.NewWeightedTrace(trace, trace.GetRoot())
@@ -184,13 +366,13 @@ func TestConcentratorSublayersStatsCounts(t *testing.T) {
 	}
 
 	c.Add(testTrace)
-	stats := c.Flush()
+	stats := c.flushNow(alignedNow + int64(c.bufferLen)*c.bsize)
 
 	if !assert.Equal(1, len(stats), "We should get exactly 1 StatsBucket") {
 		t.FailNow()
 	}
 
-	assert.Equal(alignedNow-3*testBucketInterval, stats[0].Start)
+	assert.Equal(alignedNow, stats[0].Start)
 
 	var receivedCounts map[string]model.Count
 


### PR DESCRIPTION
This PR changes the way we aggregate and flush stats in the concentrator.

What it does.

- We no longer drop traces in `agent.Process`. The `concentrator` takes care of handling traces of any time itself.
- The previous constant of "2 active time buckets" is moved to `bufferLen`. You can see it previously used in `if model.Now()-2*a.conf.BucketInterval.Nanoseconds()` and `if ts > now-2*c.bsize` [1]. It still defaults to 2.
- `bufferLen` drives two things: it is the number of active time buckets for which we ingest statistics and the age of the time buckets we flush (aka. the delay before flushing a bucket).
 - During a flush, we move from `bufferLen +1` active buckets (2 in the past + the current one) to `bufferLen` (the current one + the old one). That's the same behavior as before.
 - During a flush, we flush only the buckets before `now-c.bufferLen*bsize`, like before. It means a latency of 1 to 2 bsize aka. 10s to 20s.
 - In practice, as a flush is triggered every `bsize`, we only flush one bucket, the one at `alignedNow-c.bufferLen*bsize`.
- To deal with old spans (aka. older than `oldestTs`, where `now + bufferLen*c.bsize < oldestTs < now + (bufferLen-1)*c.bsize`) we basically count the span as if its time was `oldestTs`. It means any old data ends up in the oldest bucket we kept.
- At boot, the Agent is stricter, only allowing/aligning stats to the current time bucket. That allows it not to flush a bucket for a time window it would have flushed before an Agent restart. 

![agent collector time buckets](https://user-images.githubusercontent.com/2720261/46959438-4ec7e980-d09c-11e8-8c04-b8deaaba6010.png)



[1] `bsize` is the length of a time bucket, it's isn't publicly configurable so consider it as always 10 seconds (there is a TODO in the code to remove its configuration interface).


It practice, we can summarize it to two core changes:

- We no longer create time buckets for spans arbitrarily far in the past (but with a recent root). That was leading to arbitrarily late stats buckets, wrongly processed in the pipeline / overriding what got flushed in the past. Instead, its stats are now counted in the `oldestTs` bucket.
- We no longer drop stats for traces with a root late in the past. Consistently with the previous point, it is counted in the  `oldestTs` bucket.


TODOS left:

- [ ] Configurable `bufferLen`.