### PR TITLE
{cmd/trace-agent,writer}: fix race conditions

### DIFF
--- a/writer/fixtures_test.go
+++ b/writer/fixtures_test.go
@@ -99,8 +99,7 @@ func (c *testPayloadSender) Start() {
 
 // Run executes the core loop of this sender.
 func (c *testPayloadSender) Run() {
-	c.exitWG.Add(1)
-	defer c.exitWG.Done()
+	defer close(c.exit)
 
 	for {
 		select {
@@ -140,8 +139,7 @@ type testPayloadSenderMonitor struct {
 
 	sender PayloadSender
 
-	exit   chan struct{}
-	exitWG sync.WaitGroup
+	exit chan struct{}
 }
 
 // newTestPayloadSenderMonitor creates a new testPayloadSenderMonitor monitoring the specified sender.
@@ -159,8 +157,7 @@ func (m *testPayloadSenderMonitor) Start() {
 
 // Run executes the core loop of this monitor.
 func (m *testPayloadSenderMonitor) Run() {
-	m.exitWG.Add(1)
-	defer m.exitWG.Done()
+	defer close(m.exit)
 
 	for {
 		select {
@@ -187,8 +184,8 @@ func (m *testPayloadSenderMonitor) Run() {
 
 // Stop stops this payload monitor and waits for it to stop.
 func (m *testPayloadSenderMonitor) Stop() {
-	close(m.exit)
-	m.exitWG.Wait()
+	m.exit <- struct{}{}
+	<-m.exit
 }
 
 // SuccessPayloads returns a slice containing all successful payloads.

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -53,8 +53,7 @@ func (w *ServiceWriter) Start() {
 // Run runs the main loop of the writer goroutine. If buffers
 // services read from input chan and flushes them when necessary.
 func (w *ServiceWriter) Run() {
-	w.exitWG.Add(1)
-	defer w.exitWG.Done()
+	defer close(w.exit)
 
 	// for now, simply flush every x seconds
 	flushTicker := time.NewTicker(w.conf.FlushPeriod)
@@ -112,8 +111,8 @@ func (w *ServiceWriter) Run() {
 
 // Stop stops the main Run loop.
 func (w *ServiceWriter) Stop() {
-	close(w.exit)
-	w.exitWG.Wait()
+	w.exit <- struct{}{}
+	<-w.exit
 	w.BaseWriter.Stop()
 }
 

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -71,8 +71,7 @@ func (w *StatsWriter) Start() {
 // Run runs the event loop of the writer's main goroutine. It reads stat buckets
 // from InStats, builds stat payloads and sends them out using the base writer.
 func (w *StatsWriter) Run() {
-	w.exitWG.Add(1)
-	defer w.exitWG.Done()
+	defer close(w.exit)
 
 	log.Debug("starting stats writer")
 
@@ -89,8 +88,8 @@ func (w *StatsWriter) Run() {
 
 // Stop stops the writer
 func (w *StatsWriter) Stop() {
-	close(w.exit)
-	w.exitWG.Wait()
+	w.exit <- struct{}{}
+	<-w.exit
 
 	// Closing the base writer, among other things, will close the
 	// w.payloadSender.Monitor() channel, stoping the monitoring

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -76,8 +76,7 @@ func (w *TraceWriter) Start() {
 // Run runs the main loop of the writer goroutine. It sends traces to the payload constructor, flushing it periodically
 // and collects stats which are also reported periodically.
 func (w *TraceWriter) Run() {
-	w.exitWG.Add(1)
-	defer w.exitWG.Done()
+	defer close(w.exit)
 
 	// for now, simply flush every x seconds
 	flushTicker := time.NewTicker(w.conf.FlushPeriod)
@@ -137,8 +136,8 @@ func (w *TraceWriter) Run() {
 
 // Stop stops the main Run loop.
 func (w *TraceWriter) Stop() {
-	close(w.exit)
-	w.exitWG.Wait()
+	w.exit <- struct{}{}
+	<-w.exit
 	w.BaseWriter.Stop()
 }
 

--- a/writer/writer.go
+++ b/writer/writer.go
@@ -1,8 +1,6 @@
 package writer
 
 import (
-	"sync"
-
 	"github.com/DataDog/datadog-trace-agent/statsd"
 	log "github.com/cihub/seelog"
 
@@ -15,8 +13,7 @@ type BaseWriter struct {
 
 	statsClient statsd.StatsClient
 
-	exit   chan struct{}
-	exitWG *sync.WaitGroup
+	exit chan struct{}
 }
 
 // NewBaseWriter creates a new instance of a BaseWriter.
@@ -35,7 +32,6 @@ func NewBaseWriter(conf *config.AgentConfig, path string, senderFactory func(End
 		payloadSender: senderFactory(endpoint),
 		statsClient:   statsd.Client,
 		exit:          make(chan struct{}),
-		exitWG:        &sync.WaitGroup{},
 	}
 }
 


### PR DESCRIPTION
Fixes some (non-fatal) race conditions detected by the `-race` flag.