### PR TITLE
writer: make internal identifiers private

### DIFF
--- a/writer/datadog_endpoint_test.go
+++ b/writer/datadog_endpoint_test.go
@@ -44,8 +44,8 @@ func TestNewClient(t *testing.T) {
 
 func TestNewEndpoints(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
-		e := NewEndpoints(&config.AgentConfig{Enabled: false}, "")
-		_, ok := e[0].(*NullEndpoint)
+		e := newEndpoints(&config.AgentConfig{Enabled: false}, "")
+		_, ok := e[0].(*nullEndpoint)
 		assert.True(t, ok)
 	})
 
@@ -68,7 +68,7 @@ func TestNewEndpoints(t *testing.T) {
 						}
 					}
 				}()
-				NewEndpoints(tt.cfg, "")
+				newEndpoints(tt.cfg, "")
 			})
 		}
 	})
@@ -77,12 +77,12 @@ func TestNewEndpoints(t *testing.T) {
 		for name, tt := range map[string]struct {
 			cfg  *config.AgentConfig
 			path string
-			exp  []*DatadogEndpoint
+			exp  []*datadogEndpoint
 		}{
 			"main": {
 				cfg:  &config.AgentConfig{Enabled: true, Endpoints: []*config.Endpoint{{Host: "host1", APIKey: "key1"}}},
 				path: "/api/trace",
-				exp:  []*DatadogEndpoint{{Host: "host1", APIKey: "key1", path: "/api/trace"}},
+				exp:  []*datadogEndpoint{{host: "host1", apiKey: "key1", path: "/api/trace"}},
 			},
 			"additional": {
 				cfg: &config.AgentConfig{
@@ -95,21 +95,21 @@ func TestNewEndpoints(t *testing.T) {
 					},
 				},
 				path: "/api/trace",
-				exp: []*DatadogEndpoint{
-					{Host: "host1", APIKey: "key1", path: "/api/trace"},
-					{Host: "host2", APIKey: "key2", path: "/api/trace"},
-					{Host: "host3", APIKey: "key3", path: "/api/trace"},
-					{Host: "host4", APIKey: "key4", path: "/api/trace"},
+				exp: []*datadogEndpoint{
+					{host: "host1", apiKey: "key1", path: "/api/trace"},
+					{host: "host2", apiKey: "key2", path: "/api/trace"},
+					{host: "host3", apiKey: "key3", path: "/api/trace"},
+					{host: "host4", apiKey: "key4", path: "/api/trace"},
 				},
 			},
 		} {
 			t.Run(name, func(t *testing.T) {
 				assert := assert.New(t)
-				e := NewEndpoints(tt.cfg, tt.path)
+				e := newEndpoints(tt.cfg, tt.path)
 				for i, want := range tt.exp {
-					got := e[i].(*DatadogEndpoint)
-					assert.Equal(want.Host, got.Host)
-					assert.Equal(want.APIKey, got.APIKey)
+					got := e[i].(*datadogEndpoint)
+					assert.Equal(want.host, got.host)
+					assert.Equal(want.apiKey, got.apiKey)
 					assert.Equal(want.path, got.path)
 				}
 			})
@@ -122,7 +122,7 @@ func TestNewEndpoints(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		e := NewEndpoints(&config.AgentConfig{
+		e := newEndpoints(&config.AgentConfig{
 			Enabled:  true,
 			ProxyURL: proxyURL,
 			Endpoints: []*config.Endpoint{
@@ -134,13 +134,13 @@ func TestNewEndpoints(t *testing.T) {
 
 		// proxy ok
 		for _, i := range []int{0, 1} {
-			tr := e[i].(*DatadogEndpoint).client.Transport.(*http.Transport)
+			tr := e[i].(*datadogEndpoint).client.Transport.(*http.Transport)
 			p, _ := tr.Proxy(nil)
 			assert.Equal("test_url", p.String())
 		}
 
 		// proxy skipped
-		tr := e[2].(*DatadogEndpoint).client.Transport.(*http.Transport)
+		tr := e[2].(*datadogEndpoint).client.Transport.(*http.Transport)
 		assert.Nil(tr.Proxy)
 	})
 }

--- a/writer/endpoint.go
+++ b/writer/endpoint.go
@@ -2,49 +2,41 @@ package writer
 
 import (
 	"fmt"
-	"net/http"
 
 	log "github.com/cihub/seelog"
 )
 
 const languageHeaderKey = "X-Datadog-Reported-Languages"
 
-// Endpoint is an interface where we send the data from the Agent.
-type Endpoint interface {
+// endpoint is an interface where we send the data from the Agent.
+type endpoint interface {
 	// Write writes the payload to the endpoint.
-	Write(payload *Payload) error
+	write(payload *payload) error
 
-	// BaseURL returns the base URL for this endpoint. e.g. For the URL "https://trace.agent.datadoghq.eu/api/v0.2/traces"
+	// baseURL returns the base URL for this endpoint. e.g. For the URL "https://trace.agent.datadoghq.eu/api/v0.2/traces"
 	// it returns "https://trace.agent.datadoghq.eu".
-	BaseURL() string
+	baseURL() string
 }
 
-// NullEndpoint is a void endpoint dropping data.
-type NullEndpoint struct{}
+// nullEndpoint is a void endpoint dropping data.
+type nullEndpoint struct{}
 
-// Write of NullEndpoint just drops the payload and log its size.
-func (ne *NullEndpoint) Write(payload *Payload) error {
-	log.Debug("null endpoint: dropping payload, size: %d", len(payload.Bytes))
+// Write of nullEndpoint just drops the payload and log its size.
+func (ne *nullEndpoint) write(payload *payload) error {
+	log.Debug("null endpoint: dropping payload, size: %d", len(payload.bytes))
 	return nil
 }
 
 // BaseURL implements Endpoint.
-func (ne *NullEndpoint) BaseURL() string { return "<NullEndpoint>" }
+func (ne *nullEndpoint) baseURL() string { return "<nullEndpoint>" }
 
-// SetExtraHeaders appends a header map to HTTP headers.
-func SetExtraHeaders(h http.Header, extras map[string]string) {
-	for key, value := range extras {
-		h.Set(key, value)
-	}
-}
-
-// RetriableError is an endpoint error that signifies that the associated operation can be retried at a later point.
-type RetriableError struct {
+// retriableError is an endpoint error that signifies that the associated operation can be retried at a later point.
+type retriableError struct {
 	err      error
-	endpoint Endpoint
+	endpoint endpoint
 }
 
 // Error returns the error string.
-func (re *RetriableError) Error() string {
+func (re *retriableError) Error() string {
 	return fmt.Sprintf("%s: %v", re.endpoint, re.err)
 }

--- a/writer/fixtures_test.go
+++ b/writer/fixtures_test.go
@@ -80,16 +80,16 @@ func RandomSizedPayload(size int) *Payload {
 
 // testPayloadSender is a PayloadSender that is connected to a testEndpoint, used for testing.
 type testPayloadSender struct {
+	*QueuablePayloadSender
 	testEndpoint *testEndpoint
-	BasePayloadSender
 }
 
 // newTestPayloadSender creates a new instance of a testPayloadSender.
 func newTestPayloadSender() *testPayloadSender {
 	testEndpoint := &testEndpoint{}
 	return &testPayloadSender{
-		testEndpoint:      testEndpoint,
-		BasePayloadSender: *NewBasePayloadSender(testEndpoint),
+		testEndpoint:          testEndpoint,
+		QueuablePayloadSender: NewQueuablePayloadSender(testEndpoint),
 	}
 }
 

--- a/writer/fixtures_test.go
+++ b/writer/fixtures_test.go
@@ -80,7 +80,7 @@ func RandomSizedPayload(size int) *Payload {
 
 // testPayloadSender is a PayloadSender that is connected to a testEndpoint, used for testing.
 type testPayloadSender struct {
-	*QueuablePayloadSender
+	*queuableSender
 	testEndpoint *testEndpoint
 }
 
@@ -88,8 +88,8 @@ type testPayloadSender struct {
 func newTestPayloadSender() *testPayloadSender {
 	testEndpoint := &testEndpoint{}
 	return &testPayloadSender{
-		testEndpoint:          testEndpoint,
-		QueuablePayloadSender: NewQueuablePayloadSender(testEndpoint),
+		testEndpoint:   testEndpoint,
+		queuableSender: newDefaultSender(testEndpoint),
 	}
 }
 

--- a/writer/fixtures_test.go
+++ b/writer/fixtures_test.go
@@ -158,7 +158,7 @@ func (m *testPayloadSenderMonitor) Run() {
 
 	for {
 		select {
-		case event, ok := <-m.sender.monitor():
+		case event, ok := <-m.sender.Monitor():
 			if !ok {
 				continue // wait for exit
 			}

--- a/writer/multi_writer.go
+++ b/writer/multi_writer.go
@@ -34,9 +34,9 @@ func newMultiSender(endpoints []endpoint, cfg config.QueuablePayloadSenderConf) 
 }
 
 // Start starts all senders.
-func (w *multiSender) start() {
+func (w *multiSender) Start() {
 	for _, sender := range w.senders {
-		sender.start()
+		sender.Start()
 	}
 	for _, sender := range w.senders {
 		w.mwg.Add(1)
@@ -45,30 +45,30 @@ func (w *multiSender) start() {
 			for event := range ch {
 				w.mch <- event
 			}
-		}(sender.monitor())
+		}(sender.Monitor())
 	}
 }
 
 // Stop stops all senders.
-func (w *multiSender) stop() {
+func (w *multiSender) Stop() {
 	for _, sender := range w.senders {
-		sender.stop()
+		sender.Stop()
 	}
 	w.mwg.Wait()
 	close(w.mch)
 }
 
 // Send forwards the payload to all registered senders.
-func (w *multiSender) send(p *payload) {
+func (w *multiSender) Send(p *payload) {
 	for _, sender := range w.senders {
-		sender.send(p)
+		sender.Send(p)
 	}
 }
 
-func (w *multiSender) monitor() <-chan monitorEvent { return w.mch }
+func (w *multiSender) Monitor() <-chan monitorEvent { return w.mch }
 
 // Run implements payloadSender.
-func (w *multiSender) run() { /* no-op */ }
+func (w *multiSender) Run() { /* no-op */ }
 
 func (w *multiSender) setEndpoint(endpoint endpoint) {
 	for _, sender := range w.senders {

--- a/writer/multi_writer.go
+++ b/writer/multi_writer.go
@@ -21,11 +21,11 @@ type multiSender struct {
 // the given endpoints, as well as funnels all monitoring channels.
 func newMultiSender(endpoints []Endpoint, cfg config.QueuablePayloadSenderConf) PayloadSender {
 	if len(endpoints) == 1 {
-		return NewCustomQueuablePayloadSender(endpoints[0], cfg)
+		return newSender(endpoints[0], cfg)
 	}
 	senders := make([]PayloadSender, len(endpoints))
 	for i, e := range endpoints {
-		senders[i] = NewCustomQueuablePayloadSender(e, cfg)
+		senders[i] = newSender(e, cfg)
 	}
 	return &multiSender{
 		senders: senders,

--- a/writer/multi_writer_test.go
+++ b/writer/multi_writer_test.go
@@ -31,7 +31,7 @@ func TestNewMultiSenderFactory(t *testing.T) {
 		sender, ok := newMultiSender([]Endpoint{endpoint}, cfg).(*QueuablePayloadSender)
 		assert := assert.New(t)
 		assert.True(ok)
-		assert.EqualValues(endpoint, sender.BasePayloadSender.endpoint)
+		assert.EqualValues(endpoint, sender.endpoint)
 		assert.EqualValues(cfg, sender.conf)
 	})
 
@@ -49,7 +49,7 @@ func TestNewMultiSenderFactory(t *testing.T) {
 		for i := range endpoints {
 			s, ok := sender.senders[i].(*QueuablePayloadSender)
 			assert.True(ok)
-			assert.EqualValues(endpoints[i], s.BasePayloadSender.endpoint)
+			assert.EqualValues(endpoints[i], s.endpoint)
 			assert.EqualValues(cfg, s.conf)
 		}
 	})

--- a/writer/multi_writer_test.go
+++ b/writer/multi_writer_test.go
@@ -28,7 +28,7 @@ func TestNewMultiSenderFactory(t *testing.T) {
 
 	t.Run("one", func(t *testing.T) {
 		endpoint := &DatadogEndpoint{Host: "host1", APIKey: "key1"}
-		sender, ok := newMultiSender([]Endpoint{endpoint}, cfg).(*QueuablePayloadSender)
+		sender, ok := newMultiSender([]Endpoint{endpoint}, cfg).(*queuableSender)
 		assert := assert.New(t)
 		assert.True(ok)
 		assert.EqualValues(endpoint, sender.endpoint)
@@ -47,7 +47,7 @@ func TestNewMultiSenderFactory(t *testing.T) {
 		assert.Len(sender.senders, 3)
 		assert.Equal(3, cap(sender.mch))
 		for i := range endpoints {
-			s, ok := sender.senders[i].(*QueuablePayloadSender)
+			s, ok := sender.senders[i].(*queuableSender)
 			assert.True(ok)
 			assert.EqualValues(endpoints[i], s.endpoint)
 			assert.EqualValues(cfg, s.conf)

--- a/writer/multi_writer_test.go
+++ b/writer/multi_writer_test.go
@@ -60,8 +60,8 @@ func TestMultiSender(t *testing.T) {
 		mock1 := newMockSender()
 		mock2 := newMockSender()
 		multi := &multiSender{senders: []payloadSender{mock1, mock2}, mch: make(chan monitorEvent)}
-		multi.start()
-		defer multi.stop()
+		multi.Start()
+		defer multi.Stop()
 
 		assert := assert.New(t)
 		assert.Equal(1, mock1.StartCalls())
@@ -72,7 +72,7 @@ func TestMultiSender(t *testing.T) {
 		mock1 := newMockSender()
 		mock2 := newMockSender()
 		multi := &multiSender{senders: []payloadSender{mock1, mock2}, mch: make(chan monitorEvent)}
-		multi.stop()
+		multi.Stop()
 
 		assert := assert.New(t)
 		assert.Equal(1, mock1.StopCalls())
@@ -90,7 +90,7 @@ func TestMultiSender(t *testing.T) {
 		mock2 := newMockSender()
 		p := &payload{creationDate: time.Now(), bytes: []byte{1, 2, 3}}
 		multi := &multiSender{senders: []payloadSender{mock1, mock2}, mch: make(chan monitorEvent)}
-		multi.send(p)
+		multi.Send(p)
 
 		assert := assert.New(t)
 		assert.Equal(p, mock1.SendCalls()[0])
@@ -101,8 +101,8 @@ func TestMultiSender(t *testing.T) {
 		mock1 := newMockSender()
 		mock2 := newMockSender()
 		multi := &multiSender{senders: []payloadSender{mock1, mock2}, mch: make(chan monitorEvent)}
-		multi.start()
-		defer multi.stop()
+		multi.Start()
+		defer multi.Stop()
 
 		event1 := monitorEvent{typ: eventTypeSuccess, stats: sendStats{host: "ABC"}}
 		event2 := monitorEvent{typ: eventTypeFailure, stats: sendStats{host: "QWE"}}
@@ -120,12 +120,12 @@ func TestMultiSender(t *testing.T) {
 func TestMockPayloadSender(t *testing.T) {
 	p := &payload{creationDate: time.Now(), bytes: []byte{1, 2, 3}}
 	mock := newMockSender()
-	mock.start()
-	mock.start()
-	mock.start()
-	mock.send(p)
-	mock.send(p)
-	mock.stop()
+	mock.Start()
+	mock.Start()
+	mock.Start()
+	mock.Send(p)
+	mock.Send(p)
+	mock.Stop()
 
 	assert := assert.New(t)
 	assert.Equal(3, mock.StartCalls())
@@ -163,7 +163,7 @@ func (m *mockPayloadSender) Reset() {
 	m.mu.Unlock()
 }
 
-func (m *mockPayloadSender) start() {
+func (m *mockPayloadSender) Start() {
 	atomic.AddUint64(&m.startCalls, 1)
 }
 
@@ -172,7 +172,7 @@ func (m *mockPayloadSender) StartCalls() int {
 }
 
 // Stop must be called only once. It closes the monitor channel.
-func (m *mockPayloadSender) stop() {
+func (m *mockPayloadSender) Stop() {
 	atomic.AddUint64(&m.stopCalls, 1)
 	close(m.monitorCh)
 }
@@ -181,7 +181,7 @@ func (m *mockPayloadSender) StopCalls() int {
 	return int(atomic.LoadUint64(&m.stopCalls))
 }
 
-func (m *mockPayloadSender) send(p *payload) {
+func (m *mockPayloadSender) Send(p *payload) {
 	m.mu.Lock()
 	m.sendCalls = append(m.sendCalls, p)
 	m.mu.Unlock()
@@ -193,11 +193,11 @@ func (m *mockPayloadSender) SendCalls() []*payload {
 	return m.sendCalls
 }
 
-func (m *mockPayloadSender) monitor() <-chan monitorEvent {
+func (m *mockPayloadSender) Monitor() <-chan monitorEvent {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.monitorCh
 }
 
-func (m *mockPayloadSender) run()                   {}
+func (m *mockPayloadSender) Run()                   {}
 func (m *mockPayloadSender) setEndpoint(_ endpoint) {}

--- a/writer/payload_test.go
+++ b/writer/payload_test.go
@@ -26,7 +26,7 @@ func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
 	workingEndpoint := &testEndpoint{}
 
 	// And a queuable sender using that endpoint
-	queuableSender := NewQueuablePayloadSender(workingEndpoint)
+	queuableSender := newDefaultSender(workingEndpoint)
 
 	// And a test monitor for that sender
 	monitor := newTestPayloadSenderMonitor(queuableSender)
@@ -72,7 +72,7 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 
 	// And a queuable sender using said endpoint and timer
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -172,7 +172,7 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max queued payloads value of 1
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedPayloads = 1
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -242,7 +242,7 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -311,7 +311,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -367,7 +367,7 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max size of 10 bytes
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxQueuedBytes = 10
-	queuableSender := NewCustomQueuablePayloadSender(workingEndpoint, conf)
+	queuableSender := newSender(workingEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -413,7 +413,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max age of 100ms
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxAge = 100 * time.Millisecond
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier
@@ -485,7 +485,7 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	// And a queuable sender using said endpoint and timer and with a meager max age of 200ms
 	conf := writerconfig.DefaultQueuablePayloadSenderConf()
 	conf.MaxAge = 200 * time.Millisecond
-	queuableSender := NewCustomQueuablePayloadSender(flakyEndpoint, conf)
+	queuableSender := newSender(flakyEndpoint, conf)
 	queuableSender.backoffTimer = testBackoffTimer
 	syncBarrier := make(chan interface{})
 	queuableSender.syncBarrier = syncBarrier

--- a/writer/payload_test.go
+++ b/writer/payload_test.go
@@ -33,22 +33,22 @@ func TestQueuablePayloadSender_WorkingEndpoint(t *testing.T) {
 
 	// When we start the sender
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// And send some payloads
 	payload1 := randomPayload()
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 	payload2 := randomPayload()
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 	payload3 := randomPayload()
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 	payload4 := randomPayload()
-	queuableSender.send(payload4)
+	queuableSender.Send(payload4)
 	payload5 := randomPayload()
-	queuableSender.send(payload5)
+	queuableSender.Send(payload5)
 
 	// And stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then we expect all sent payloads to have been successfully sent
@@ -81,14 +81,14 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// With a working endpoint
 	// We send some payloads
 	payload1 := randomPayload()
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 	payload2 := randomPayload()
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 
 	// Make sure sender processed both payloads
 	syncBarrier <- nil
@@ -99,9 +99,9 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	flakyEndpoint.SetError(&retriableError{err: fmt.Errorf("bleh"), endpoint: flakyEndpoint})
 	// We send some payloads
 	payload3 := randomPayload()
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 	payload4 := randomPayload()
-	queuableSender.send(payload4)
+	queuableSender.Send(payload4)
 	// And retry once
 	testBackoffTimer.TriggerTick()
 	// And retry twice
@@ -126,9 +126,9 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	flakyEndpoint.SetError(fmt.Errorf("non retriable bleh"))
 	// We send some payloads
 	payload5 := randomPayload()
-	queuableSender.send(payload5)
+	queuableSender.Send(payload5)
 	payload6 := randomPayload()
-	queuableSender.send(payload6)
+	queuableSender.Send(payload6)
 
 	// Make sure sender processed previous payloads
 	syncBarrier <- nil
@@ -141,7 +141,7 @@ func TestQueuablePayloadSender_FlakyEndpoint(t *testing.T) {
 	testBackoffTimer.TriggerTick()
 
 	// And stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then we expect payloads sent during working endpoint or those that were retried due to retriable errors to have
@@ -181,19 +181,19 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending a first payload
 	payload1 := randomPayload()
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 
 	// Followed by another one
 	payload2 := randomPayload()
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 
 	// Followed by a third
 	payload3 := randomPayload()
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 
 	// Ensure previous payloads were processed
 	syncBarrier <- nil
@@ -211,7 +211,7 @@ func TestQueuablePayloadSender_MaxQueuedPayloads(t *testing.T) {
 	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received only payload3. Other should have been discarded because max queued payloads
@@ -251,19 +251,19 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending a first payload of 4 bytes
 	payload1 := randomSizedPayload(4)
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 
 	// Followed by another one of 2 bytes
 	payload2 := randomSizedPayload(2)
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 
 	// Followed by a third of 8 bytes
 	payload3 := randomSizedPayload(8)
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 
 	// Ensure previous payloads were processed
 	syncBarrier <- nil
@@ -281,7 +281,7 @@ func TestQueuablePayloadSender_MaxQueuedBytes(t *testing.T) {
 	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received payload2 and payload3. Payload1 should have been discarded because keeping all
@@ -320,11 +320,11 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending a payload of 12 bytes
 	payload1 := randomSizedPayload(12)
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 
 	// Ensure previous payloads were processed
 	syncBarrier <- nil
@@ -342,7 +342,7 @@ func TestQueuablePayloadSender_DropBigPayloadsOnRetry(t *testing.T) {
 	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received no payloads because payload1 was too big to store in queue.
@@ -376,11 +376,11 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending a payload of 12 bytes
 	payload1 := randomSizedPayload(12)
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 
 	// Ensure previous payloads were processed
 	syncBarrier <- nil
@@ -389,7 +389,7 @@ func TestQueuablePayloadSender_SendBigPayloadsIfNoRetry(t *testing.T) {
 	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received payload1 because although it was big, it didn't get queued.
@@ -422,20 +422,20 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending two payloads one after the other
 	payload1 := randomPayload()
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 	payload2 := randomPayload()
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 
 	// And then sleeping for 500ms
 	time.Sleep(500 * time.Millisecond)
 
 	// And then sending a third payload
 	payload3 := randomPayload()
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 
 	// And then triggering a retry
 	testBackoffTimer.TriggerTick()
@@ -456,7 +456,7 @@ func TestQueuablePayloadSender_MaxAge(t *testing.T) {
 	assert.Equal(0, queuableSender.NumQueuedPayloads(), "We should have no queued payloads")
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then endpoint should have received only payload3. Because payload1 and payload2 were too old after the failed
@@ -494,13 +494,13 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	monitor := newTestPayloadSenderMonitor(queuableSender)
 
 	monitor.Start()
-	queuableSender.start()
+	queuableSender.Start()
 
 	// When sending two payloads one after the other
 	payload1 := randomPayload()
-	queuableSender.send(payload1)
+	queuableSender.Send(payload1)
 	payload2 := randomPayload()
-	queuableSender.send(payload2)
+	queuableSender.Send(payload2)
 
 	// And then sleeping for 500ms
 	time.Sleep(600 * time.Millisecond)
@@ -510,7 +510,7 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 
 	// Then send a third payload
 	payload3 := randomPayload()
-	queuableSender.send(payload3)
+	queuableSender.Send(payload3)
 
 	// Wait for payload to be queued
 	syncBarrier <- nil
@@ -522,7 +522,7 @@ func TestQueuablePayloadSender_RetryOfTooOldQueue(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// When we stop the sender
-	queuableSender.stop()
+	queuableSender.Stop()
 	monitor.Stop()
 
 	// Then we should have no queued payloads

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -46,7 +46,7 @@ func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.Services
 
 // Start starts the writer.
 func (w *ServiceWriter) Start() {
-	w.sender.start()
+	w.sender.Start()
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
@@ -69,7 +69,7 @@ func (w *ServiceWriter) Run() {
 
 	// Monitor sender for events
 	go func() {
-		for event := range w.sender.monitor() {
+		for event := range w.sender.Monitor() {
 			switch event.typ {
 			case eventTypeSuccess:
 				url := event.stats.host
@@ -115,7 +115,7 @@ func (w *ServiceWriter) Run() {
 func (w *ServiceWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.stop()
+	w.sender.Stop()
 }
 
 func (w *ServiceWriter) handleServiceMetadata(metadata model.ServicesMetadata) {
@@ -147,7 +147,7 @@ func (w *ServiceWriter) flush() {
 	atomic.AddInt64(&w.stats.Bytes, int64(len(data)))
 
 	payload := newPayload(data, headers)
-	w.sender.send(payload)
+	w.sender.Send(payload)
 
 	w.serviceBuffer = make(model.ServicesMetadata)
 }

--- a/writer/service_writer.go
+++ b/writer/service_writer.go
@@ -24,14 +24,14 @@ type ServiceWriter struct {
 
 	serviceBuffer model.ServicesMetadata
 
-	sender PayloadSender
+	sender payloadSender
 	exit   chan struct{}
 }
 
 // NewServiceWriter returns a new writer for services.
 func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.ServicesMetadata) *ServiceWriter {
 	cfg := conf.ServiceWriterConfig
-	endpoints := NewEndpoints(conf, pathServices)
+	endpoints := newEndpoints(conf, pathServices)
 	sender := newMultiSender(endpoints, cfg.SenderConfig)
 	log.Infof("Service writer initializing with config: %+v", cfg)
 
@@ -46,7 +46,7 @@ func NewServiceWriter(conf *config.AgentConfig, InServices <-chan model.Services
 
 // Start starts the writer.
 func (w *ServiceWriter) Start() {
-	w.sender.Start()
+	w.sender.start()
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
@@ -74,7 +74,7 @@ func (w *ServiceWriter) Run() {
 			case eventTypeSuccess:
 				url := event.stats.host
 				log.Infof("flushed service payload; url:%s, time:%s, size:%d bytes", url, event.stats.sendTime,
-					len(event.payload.Bytes))
+					len(event.payload.bytes))
 				tags := []string{"url:" + url}
 				statsd.Client.Gauge("datadog.trace_agent.service_writer.flush_duration",
 					event.stats.sendTime.Seconds(), tags, 1)
@@ -82,7 +82,7 @@ func (w *ServiceWriter) Run() {
 			case eventTypeFailure:
 				url := event.stats.host
 				log.Errorf("failed to flush service payload; url:%s, time:%s, size:%d bytes, error: %s",
-					url, event.stats.sendTime, len(event.payload.Bytes), event.err)
+					url, event.stats.sendTime, len(event.payload.bytes), event.err)
 				atomic.AddInt64(&w.stats.Errors, 1)
 			case eventTypeRetry:
 				log.Errorf("retrying flush service payload, retryNum: %d, delay:%s, error: %s",
@@ -115,7 +115,7 @@ func (w *ServiceWriter) Run() {
 func (w *ServiceWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.Stop()
+	w.sender.stop()
 }
 
 func (w *ServiceWriter) handleServiceMetadata(metadata model.ServicesMetadata) {
@@ -146,8 +146,8 @@ func (w *ServiceWriter) flush() {
 
 	atomic.AddInt64(&w.stats.Bytes, int64(len(data)))
 
-	payload := NewPayload(data, headers)
-	w.sender.Send(payload)
+	payload := newPayload(data, headers)
+	w.sender.send(payload)
 
 	w.serviceBuffer = make(model.ServicesMetadata)
 }

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -121,7 +121,7 @@ func TestServiceWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * serviceWriter.conf.FlushPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
-	testEndpoint.SetError(&RetriableError{
+	testEndpoint.SetError(&retriableError{
 		err:      fmt.Errorf("retriable error"),
 		endpoint: testEndpoint,
 	})
@@ -185,12 +185,12 @@ func calculateMetadataPayloadSize(metadata model.ServicesMetadata) int64 {
 }
 
 func assertMetadata(assert *assert.Assertions, expectedHeaders map[string]string,
-	expectedMetadata model.ServicesMetadata, payload *Payload) {
+	expectedMetadata model.ServicesMetadata, p *payload) {
 	servicesMetadata := model.ServicesMetadata{}
 
-	assert.NoError(json.Unmarshal(payload.Bytes, &servicesMetadata), "Stats payload should unmarshal correctly")
+	assert.NoError(json.Unmarshal(p.bytes, &servicesMetadata), "Stats payload should unmarshal correctly")
 
-	assert.Equal(expectedHeaders, payload.Headers, "Headers should match expectation")
+	assert.Equal(expectedHeaders, p.headers, "Headers should match expectation")
 	assert.Equal(expectedMetadata, servicesMetadata, "Service metadata should match expectation")
 }
 

--- a/writer/service_writer_test.go
+++ b/writer/service_writer_test.go
@@ -23,7 +23,7 @@ func TestServiceWriter_SenderMaxPayloads(t *testing.T) {
 	serviceWriter, _, _, _ := testServiceWriter()
 
 	// When checking its default sender configuration
-	queuableSender := serviceWriter.sender.(*QueuablePayloadSender)
+	queuableSender := serviceWriter.sender.(*queuableSender)
 
 	// Then the MaxQueuedPayloads setting should be -1 (unlimited)
 	assert.Equal(-1, queuableSender.conf.MaxQueuedPayloads)

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -18,7 +18,7 @@ const pathStats = "/api/v0.2/stats"
 
 // StatsWriter ingests stats buckets and flushes them to the API.
 type StatsWriter struct {
-	sender PayloadSender
+	sender payloadSender
 	exit   chan struct{}
 
 	// InStats is the stream of stat buckets to send out.
@@ -42,7 +42,7 @@ type StatsWriter struct {
 // NewStatsWriter returns a new writer for stats.
 func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket) *StatsWriter {
 	cfg := conf.StatsWriterConfig
-	endpoints := NewEndpoints(conf, pathStats)
+	endpoints := newEndpoints(conf, pathStats)
 	sender := newMultiSender(endpoints, cfg.SenderConfig)
 	log.Infof("Stats writer initializing with config: %+v", cfg)
 
@@ -58,7 +58,7 @@ func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket
 
 // Start starts the writer, awaiting stat buckets and flushing them.
 func (w *StatsWriter) Start() {
-	w.sender.Start()
+	w.sender.start()
 
 	go func() {
 		defer watchdog.LogOnPanic()
@@ -93,7 +93,7 @@ func (w *StatsWriter) Run() {
 func (w *StatsWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.Stop()
+	w.sender.stop()
 }
 
 func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
@@ -125,8 +125,8 @@ func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
 			return
 		}
 
-		payload := NewPayload(data, headers)
-		w.sender.Send(payload)
+		payload := newPayload(data, headers)
+		w.sender.send(payload)
 
 		atomic.AddInt64(&w.info.Bytes, int64(len(data)))
 	}
@@ -263,7 +263,7 @@ func (w *StatsWriter) monitor() {
 			case eventTypeSuccess:
 				url := e.stats.host
 				log.Infof("flushed stat payload; url: %s, time:%s, size:%d bytes", url, e.stats.sendTime,
-					len(e.payload.Bytes))
+					len(e.payload.bytes))
 				tags := []string{"url:" + url}
 				statsd.Client.Gauge("datadog.trace_agent.stats_writer.flush_duration",
 					e.stats.sendTime.Seconds(), tags, 1)
@@ -271,7 +271,7 @@ func (w *StatsWriter) monitor() {
 			case eventTypeFailure:
 				url := e.stats.host
 				log.Errorf("failed to flush stat payload; url:%s, time:%s, size:%d bytes, error: %s",
-					url, e.stats.sendTime, len(e.payload.Bytes), e.err)
+					url, e.stats.sendTime, len(e.payload.bytes), e.err)
 				atomic.AddInt64(&w.info.Errors, 1)
 			case eventTypeRetry:
 				log.Errorf("retrying flush stat payload, retryNum: %d, delay:%s, error: %s",

--- a/writer/stats_writer.go
+++ b/writer/stats_writer.go
@@ -58,7 +58,7 @@ func NewStatsWriter(conf *config.AgentConfig, InStats <-chan []model.StatsBucket
 
 // Start starts the writer, awaiting stat buckets and flushing them.
 func (w *StatsWriter) Start() {
-	w.sender.start()
+	w.sender.Start()
 
 	go func() {
 		defer watchdog.LogOnPanic()
@@ -93,7 +93,7 @@ func (w *StatsWriter) Run() {
 func (w *StatsWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.stop()
+	w.sender.Stop()
 }
 
 func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
@@ -126,7 +126,7 @@ func (w *StatsWriter) handleStats(stats []model.StatsBucket) {
 		}
 
 		payload := newPayload(data, headers)
-		w.sender.send(payload)
+		w.sender.Send(payload)
 
 		atomic.AddInt64(&w.info.Bytes, int64(len(data)))
 	}
@@ -247,7 +247,7 @@ func (w *StatsWriter) buildPayloads(stats []model.StatsBucket, maxEntriesPerPayl
 //   them, send out statsd metrics, and updates the writer info
 // - periodically dumps the writer info
 func (w *StatsWriter) monitor() {
-	monC := w.sender.monitor()
+	monC := w.sender.Monitor()
 
 	infoTicker := time.NewTicker(w.conf.UpdateInfoPeriod)
 	defer infoTicker.Stop()

--- a/writer/stats_writer_test.go
+++ b/writer/stats_writer_test.go
@@ -121,7 +121,7 @@ func TestStatsWriter_UpdateInfoHandling(t *testing.T) {
 	time.Sleep(2 * statsWriter.conf.UpdateInfoPeriod)
 
 	// And then sending a third payload with other 3 traces with an errored out endpoint with retry
-	testEndpoint.SetError(&RetriableError{
+	testEndpoint.SetError(&retriableError{
 		err:      fmt.Errorf("non retriable error"),
 		endpoint: testEndpoint,
 	})
@@ -366,11 +366,10 @@ func calculateStatPayloadSize(buckets []model.StatsBucket) int64 {
 	return int64(len(data))
 }
 
-func assertStatsPayload(assert *assert.Assertions, headers map[string]string, buckets []model.StatsBucket,
-	payload *Payload) {
+func assertStatsPayload(assert *assert.Assertions, headers map[string]string, buckets []model.StatsBucket, p *payload) {
 	statsPayload := model.StatsPayload{}
 
-	reader := bytes.NewBuffer(payload.Bytes)
+	reader := bytes.NewBuffer(p.bytes)
 	gzipReader, err := gzip.NewReader(reader)
 
 	assert.NoError(err, "Gzip reader should work correctly")
@@ -379,7 +378,7 @@ func assertStatsPayload(assert *assert.Assertions, headers map[string]string, bu
 
 	assert.NoError(jsonDecoder.Decode(&statsPayload), "Stats payload should unmarshal correctly")
 
-	assert.Equal(headers, payload.Headers, "Headers should match expectation")
+	assert.Equal(headers, p.headers, "Headers should match expectation")
 	assert.Equal(testHostName, statsPayload.HostName, "Hostname should match expectation")
 	assert.Equal(testEnv, statsPayload.Env, "Env should match expectation")
 	assert.Equal(buckets, statsPayload.Stats, "Stat buckets should match expectation")

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -70,7 +70,7 @@ func NewTraceWriter(conf *config.AgentConfig, in <-chan *SampledTrace) *TraceWri
 
 // Start starts the writer.
 func (w *TraceWriter) Start() {
-	w.sender.start()
+	w.sender.Start()
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
@@ -91,7 +91,7 @@ func (w *TraceWriter) Run() {
 
 	// Monitor sender for events
 	go func() {
-		for event := range w.sender.monitor() {
+		for event := range w.sender.Monitor() {
 			switch event.typ {
 			case eventTypeSuccess:
 				log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", event.stats.sendTime,
@@ -139,7 +139,7 @@ func (w *TraceWriter) Run() {
 func (w *TraceWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.stop()
+	w.sender.Stop()
 }
 
 func (w *TraceWriter) handleSampledTrace(sampledTrace *SampledTrace) {
@@ -258,7 +258,7 @@ func (w *TraceWriter) flush() {
 	payload := newPayload(serialized, headers)
 
 	log.Debugf("flushing traces=%v transactions=%v", len(w.traces), len(w.transactions))
-	w.sender.send(payload)
+	w.sender.Send(payload)
 	w.resetBuffer()
 }
 

--- a/writer/trace_writer.go
+++ b/writer/trace_writer.go
@@ -42,14 +42,14 @@ type TraceWriter struct {
 	transactions  []*model.Span
 	spansInBuffer int
 
-	sender PayloadSender
+	sender payloadSender
 	exit   chan struct{}
 }
 
 // NewTraceWriter returns a new writer for traces.
 func NewTraceWriter(conf *config.AgentConfig, in <-chan *SampledTrace) *TraceWriter {
 	cfg := conf.TraceWriterConfig
-	endpoints := NewEndpoints(conf, pathTraces)
+	endpoints := newEndpoints(conf, pathTraces)
 	sender := newMultiSender(endpoints, cfg.SenderConfig)
 	log.Infof("Trace writer initializing with config: %+v", cfg)
 
@@ -70,7 +70,7 @@ func NewTraceWriter(conf *config.AgentConfig, in <-chan *SampledTrace) *TraceWri
 
 // Start starts the writer.
 func (w *TraceWriter) Start() {
-	w.sender.Start()
+	w.sender.start()
 	go func() {
 		defer watchdog.LogOnPanic()
 		w.Run()
@@ -95,14 +95,14 @@ func (w *TraceWriter) Run() {
 			switch event.typ {
 			case eventTypeSuccess:
 				log.Infof("flushed trace payload to the API, time:%s, size:%d bytes", event.stats.sendTime,
-					len(event.payload.Bytes))
+					len(event.payload.bytes))
 				tags := []string{"url:" + event.stats.host}
 				statsd.Client.Gauge("datadog.trace_agent.trace_writer.flush_duration",
 					event.stats.sendTime.Seconds(), tags, 1)
 				atomic.AddInt64(&w.stats.Payloads, 1)
 			case eventTypeFailure:
 				log.Errorf("failed to flush trace payload, host:%s, time:%s, size:%d bytes, error: %s",
-					event.stats.host, event.stats.sendTime, len(event.payload.Bytes), event.err)
+					event.stats.host, event.stats.sendTime, len(event.payload.bytes), event.err)
 				atomic.AddInt64(&w.stats.Errors, 1)
 			case eventTypeRetry:
 				log.Errorf("retrying flush trace payload, retryNum: %d, delay:%s, error: %s",
@@ -139,7 +139,7 @@ func (w *TraceWriter) Run() {
 func (w *TraceWriter) Stop() {
 	w.exit <- struct{}{}
 	<-w.exit
-	w.sender.Stop()
+	w.sender.stop()
 }
 
 func (w *TraceWriter) handleSampledTrace(sampledTrace *SampledTrace) {
@@ -255,10 +255,10 @@ func (w *TraceWriter) flush() {
 		"Content-Encoding": encoding,
 	}
 
-	payload := NewPayload(serialized, headers)
+	payload := newPayload(serialized, headers)
 
 	log.Debugf("flushing traces=%v transactions=%v", len(w.traces), len(w.transactions))
-	w.sender.Send(payload)
+	w.sender.send(payload)
 	w.resetBuffer()
 }
 

--- a/writer/trace_writer_test.go
+++ b/writer/trace_writer_test.go
@@ -174,7 +174,7 @@ func TestTraceWriter(t *testing.T) {
 		time.Sleep(2 * testFlushPeriod)
 
 		// And then send a fourth payload with other 3 traces with an errored out endpoint but retriable
-		testEndpoint.SetError(&RetriableError{
+		testEndpoint.SetError(&retriableError{
 			err:      fmt.Errorf("non retriable error"),
 			endpoint: testEndpoint,
 		})
@@ -275,7 +275,7 @@ func calculateTracePayloadSize(sampledTraces []*SampledTrace) int64 {
 }
 
 func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expectedHeaders map[string]string,
-	sampledTraces []*SampledTrace, payloads []*Payload) {
+	sampledTraces []*SampledTrace, payloads []*payload) {
 
 	var expectedTraces []*model.Trace
 	var expectedTransactions []*model.Span
@@ -289,10 +289,10 @@ func assertPayloads(assert *assert.Assertions, traceWriter *TraceWriter, expecte
 	var expectedTransactionIdx int
 
 	for _, payload := range payloads {
-		assert.Equal(expectedHeaders, payload.Headers, "Payload headers should match expectation")
+		assert.Equal(expectedHeaders, payload.headers, "Payload headers should match expectation")
 
 		var tracePayload model.TracePayload
-		payloadBuffer := bytes.NewBuffer(payload.Bytes)
+		payloadBuffer := bytes.NewBuffer(payload.bytes)
 		gz, err := gzip.NewReader(payloadBuffer)
 		assert.NoError(err, "Gzip reader should work correctly")
 		uncompressedBuffer := bytes.Buffer{}


### PR DESCRIPTION
* Makes internal `writer` identifiers private
* Absorbs `BasePayloadSender` into `QueuablePayloadSender`
* Renames `QueuablePayloadSender` to `queuableSender`.