### PR TITLE
Tag APM events with associated rate metrics.

### DIFF
--- a/event/sampler_max_eps.go
+++ b/event/sampler_max_eps.go
@@ -48,6 +48,7 @@ func (s *maxEPSSampler) Sample(event *model.APMEvent) bool {
 
 	// Events with sampled traces are always kept even if that means going a bit above max eps.
 	if event.TraceSampled {
+		event.SetEventSamplerSampleRate(1)
 		return true
 	}
 
@@ -60,7 +61,9 @@ func (s *maxEPSSampler) Sample(event *model.APMEvent) bool {
 
 	sampled := sampler.SampleByRate(event.Span.TraceID, maxEPSRate)
 
-	// TODO: Set maxEPSRate on the event
+	if sampled {
+		event.SetEventSamplerSampleRate(maxEPSRate)
+	}
 
 	return sampled
 }

--- a/event/sampler_max_eps_test.go
+++ b/event/sampler_max_eps_test.go
@@ -42,6 +42,7 @@ func TestMaxEPSSampler(t *testing.T) {
 
 			for _, event := range testCase.events {
 				if sampler.Sample(event) {
+					assert.EqualValues(testCase.expectedSampledPct, event.GetEventSamplerSampleRate())
 					sampled++
 				}
 			}
@@ -74,7 +75,7 @@ func generateTestEvents(numEvents int, pctWithSampledTrace int32) []*model.APMEv
 	for i, _ := range testEvents {
 		testEvents[i] = &model.APMEvent{
 			Span:         testutil.RandomSpan(),
-			TraceSampled: rand.Int31n(100) <= pctWithSampledTrace,
+			TraceSampled: rand.Int31n(100) < pctWithSampledTrace,
 		}
 	}
 

--- a/model/event.go
+++ b/model/event.go
@@ -1,7 +1,75 @@
 package model
 
+const (
+	keySamplingRateClientTrace  = "_dd.v1.rate.iusr"
+	keySamplingRateExtraction   = "_dd.v1.rate.extr"
+	keySamplingRatePreSampler   = "_dd.v1.rate.apre"
+	keySamplingRateEventSampler = "_dd.v1.rate.alim"
+)
+
 // APMEvent is an event extracted from received traces and sent to Datadog's Trace Search functionality.
 type APMEvent struct {
 	Span         *Span
 	TraceSampled bool
+}
+
+// GetClientTraceSampleRate gets the rate at which the trace from which we extracted this event was sampled at the tracer.
+// NOTE: This defaults to 1 if no rate is stored.
+func (e *APMEvent) GetClientTraceSampleRate() float64 {
+	return e.Span.GetMetricDefault(keySamplingRateClientTrace, 1.0)
+}
+
+// SetClientTraceSampleRate sets the rate at which the trace from which we extracted this event was sampled at the tracer.
+func (e *APMEvent) SetClientTraceSampleRate(rate float64) {
+	if rate < 1 {
+		e.Span.SetMetric(keySamplingRateClientTrace, rate)
+	} else {
+		delete(e.Span.Metrics, keySamplingRateClientTrace)
+	}
+}
+
+// GetExtractionSampleRate gets the rate at which the trace from which we extracted this event was sampled at the tracer.
+// NOTE: This defaults to 1 if no rate is stored.
+func (e *APMEvent) GetExtractionSampleRate() float64 {
+	return e.Span.GetMetricDefault(keySamplingRateExtraction, 1.0)
+}
+
+// SetExtractionSampleRate sets the rate at which the trace from which we extracted this event was sampled at the tracer.
+func (e *APMEvent) SetExtractionSampleRate(rate float64) {
+	if rate < 1 {
+		e.Span.SetMetric(keySamplingRateExtraction, rate)
+	} else {
+		delete(e.Span.Metrics, keySamplingRateExtraction)
+	}
+}
+
+// GetPreSamplerSampleRate gets the rate at which the trace from which we extracted this event was sampled by the
+// agent's presampler.
+// NOTE: This defaults to 1 if no rate is stored.
+func (e *APMEvent) GetPreSamplerSampleRate() float64 {
+	return e.Span.GetMetricDefault(keySamplingRatePreSampler, 1.0)
+}
+
+// SetPreSamplerSampleRate sets the rate at which the trace from which we extracted this event was sampled by the
+// agent's presampler.
+func (e *APMEvent) SetPreSamplerSampleRate(rate float64) {
+	if rate < 1 {
+		e.Span.SetMetric(keySamplingRatePreSampler, rate)
+	} else {
+		delete(e.Span.Metrics, keySamplingRatePreSampler)
+	}
+}
+
+// GetEventSamplerSampleRate gets the rate at which this event was sampled by the event sampler.
+func (e *APMEvent) GetEventSamplerSampleRate() float64 {
+	return e.Span.GetMetricDefault(keySamplingRateEventSampler, 1.0)
+}
+
+// SetEventSamplerSampleRate sets the rate at which this event was sampled by the event sampler.
+func (e *APMEvent) SetEventSamplerSampleRate(rate float64) {
+	if rate < 1 {
+		e.Span.SetMetric(keySamplingRateEventSampler, rate)
+	} else {
+		delete(e.Span.Metrics, keySamplingRateEventSampler)
+	}
 }

--- a/model/span.go
+++ b/model/span.go
@@ -48,6 +48,26 @@ func (s *Span) Weight() float64 {
 	return 1.0 / sampleRate
 }
 
+// GetMetric gets a value in the span Metrics map.
+func (s *Span) GetMetric(k string) (float64, bool) {
+	if s == nil || s.Metrics == nil {
+		return 0, false
+	}
+
+	val, ok := s.Metrics[k]
+
+	return val, ok
+}
+
+// GetMetricDefault gets a value in the span Metrics map or default if no value is stored there.
+func (s *Span) GetMetricDefault(k string, def float64) float64 {
+	if val, ok := s.GetMetric(k); ok {
+		return val
+	}
+
+	return def
+}
+
 // SetMetric sets a value in the span Metrics map.
 func (s *Span) SetMetric(key string, val float64) {
 	if s.Metrics == nil {
@@ -59,10 +79,7 @@ func (s *Span) SetMetric(key string, val float64) {
 // GetSamplingPriority returns the value of the sampling priority metric set on this span and a boolean indicating if
 // such a metric was actually found or not.
 func (s *Span) GetSamplingPriority() (int, bool) {
-	if s == nil {
-		return 0, false
-	}
-	p, ok := s.Metrics[SamplingPriorityKey]
+	p, ok := s.GetMetric(SamplingPriorityKey)
 	return int(p), ok
 }
 


### PR DESCRIPTION
This PR adds rate metrics to sampled APM events, one for each step at which an event could have been dropped:

* Trace (and thus event) could have been dropped at the client/tracer because we are not sampling at full rate there.
* Trace (and thus event) could have been dropped by our performance-guided presampler.
* Event could have been dropped at event extraction time.
* Event could have been dropped by our event samplers.