### PR TITLE
{config,flags}: change Windows paths from hard-coded to detecting program files

### DIFF
--- a/config/config_windows.go
+++ b/config/config_windows.go
@@ -1,6 +1,13 @@
 package config
 
-const (
+import (
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/util/executable"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
+
+var (
 	// DefaultLogFilePath is where the agent will write logs if not overriden in the conf
 	DefaultLogFilePath = "c:\\programdata\\datadog\\logs\\trace-agent.log"
 
@@ -16,3 +23,15 @@ const (
 // agent5Config points to the default agent 5 configuration path. It is used
 // as a fallback when no configuration is set and the new default is missing.
 const agent5Config = "c:\\programdata\\datadog\\datadog.conf"
+
+func init() {
+	pd, err := winutil.GetProgramDataDir()
+	if err == nil {
+		DefaultLogFilePath = filepath.Join(pd, "Datadog", "logs", "trace-agent.log")
+	}
+	_here, err := executable.Folder()
+	if err == nil {
+		defaultDDAgentBin = filepath.Join(_here, "..", "..", "embedded", "agent.exe")
+	}
+
+}

--- a/flags/flags_windows.go
+++ b/flags/flags_windows.go
@@ -2,10 +2,21 @@
 
 package flags
 
-import "flag"
+import (
+	"flag"
+	"path/filepath"
 
-const DefaultConfigPath = "c:\\programdata\\datadog\\datadog.yaml"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
 
+var DefaultConfigPath = "c:\\programdata\\datadog\\datadog.yaml"
+
+func init() {
+	pd, err := winutil.GetProgramDataDir()
+	if err == nil {
+		DefaultConfigPath = filepath.Join(pd, "Datadog", "datadog.yaml")
+	}
+}
 func registerOSSpecificFlags() {
 	flag.BoolVar(&Win.InstallService, "install-service", false, "Install the trace agent to the Service Control Manager")
 	flag.BoolVar(&Win.UninstallService, "uninstall-service", false, "Remove the trace agent from the Service Control Manager")


### PR DESCRIPTION
and programdata

In the process of converting the entire (windows) agent from hard-coding to proper handling.

Dependent upon https://github.com/DataDog/datadog-agent/pull/2546