### PR TITLE
config: enable to set "MaxTPS" from environment variable

### DIFF
--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -11,22 +11,22 @@ import (
 )
 
 const (
-	envAPIKey             = "DD_API_KEY"                   // API KEY
-	envSite               = "DD_SITE"                      // server site (us, eu)
-	envAPMEnabled         = "DD_APM_ENABLED"               // APM enabled
-	envURL                = "DD_APM_DD_URL"                // APM URL
-	envProxyDeprecated    = "HTTPS_PROXY"                  // (deprecated) proxy URL
-	envProxy              = "DD_PROXY_HTTPS"               // proxy URL (overrides deprecated)
-	envHostname           = "DD_HOSTNAME"                  // agent hostname
-	envBindHost           = "DD_BIND_HOST"                 // statsd & receiver hostname
-	envReceiverPort       = "DD_RECEIVER_PORT"             // receiver port
-	envDogstatsdPort      = "DD_DOGSTATSD_PORT"            // dogstatsd port
-	envRemoteTraffic      = "DD_APM_NON_LOCAL_TRAFFIC"     // alow non-local traffic
-	envIgnoreResources    = "DD_IGNORE_RESOURCE"           // ignored resources
-	envLogLevel           = "DD_LOG_LEVEL"                 // logging level
-	envAnalyzedSpans      = "DD_APM_ANALYZED_SPANS"        // spans to analyze for transactions
-	envConnectionLimit    = "DD_CONNECTION_LIMIT"          // (deprecated) limit of unique connections
-	envMaxTracesPerSecond = "DD_APM_MAX_TRACES_PER_SECOND" // maximum limit to the total number of traces per second to sample (MaxTPS)
+	envAPIKey          = "DD_API_KEY"               // API KEY
+	envSite            = "DD_SITE"                  // server site (us, eu)
+	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled
+	envURL             = "DD_APM_DD_URL"            // APM URL
+	envProxyDeprecated = "HTTPS_PROXY"              // (deprecated) proxy URL
+	envProxy           = "DD_PROXY_HTTPS"           // proxy URL (overrides deprecated)
+	envHostname        = "DD_HOSTNAME"              // agent hostname
+	envBindHost        = "DD_BIND_HOST"             // statsd & receiver hostname
+	envReceiverPort    = "DD_RECEIVER_PORT"         // receiver port
+	envDogstatsdPort   = "DD_DOGSTATSD_PORT"        // dogstatsd port
+	envRemoteTraffic   = "DD_APM_NON_LOCAL_TRAFFIC" // alow non-local traffic
+	envIgnoreResources = "DD_IGNORE_RESOURCE"       // ignored resources
+	envLogLevel        = "DD_LOG_LEVEL"             // logging level
+	envAnalyzedSpans   = "DD_APM_ANALYZED_SPANS"    // spans to analyze for transactions
+	envConnectionLimit = "DD_CONNECTION_LIMIT"      // (deprecated) limit of unique connections
+	envMaxTPS          = "DD_MAX_TPS"               // maximum limit to the total number of traces per second to sample (MaxTPS)
 )
 
 // loadEnv applies overrides from environment variables to the trace agent configuration
@@ -124,10 +124,10 @@ func (c *AgentConfig) loadEnv() {
 		}
 	}
 
-	if v := os.Getenv(envMaxTracesPerSecond); v != "" {
+	if v := os.Getenv(envMaxTPS); v != "" {
 		maxTPS, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			log.Errorf("Failed to parse %s: it should be a float number", envMaxTracesPerSecond)
+			log.Errorf("Failed to parse %s: it should be a float number", envMaxTPS)
 		} else {
 			c.MaxTPS = maxTPS
 		}

--- a/config/merge_env.go
+++ b/config/merge_env.go
@@ -11,21 +11,22 @@ import (
 )
 
 const (
-	envAPIKey          = "DD_API_KEY"               // API KEY
-	envSite            = "DD_SITE"                  // server site (us, eu)
-	envAPMEnabled      = "DD_APM_ENABLED"           // APM enabled
-	envURL             = "DD_APM_DD_URL"            // APM URL
-	envProxyDeprecated = "HTTPS_PROXY"              // (deprecated) proxy URL
-	envProxy           = "DD_PROXY_HTTPS"           // proxy URL (overrides deprecated)
-	envHostname        = "DD_HOSTNAME"              // agent hostname
-	envBindHost        = "DD_BIND_HOST"             // statsd & receiver hostname
-	envReceiverPort    = "DD_RECEIVER_PORT"         // receiver port
-	envDogstatsdPort   = "DD_DOGSTATSD_PORT"        // dogstatsd port
-	envRemoteTraffic   = "DD_APM_NON_LOCAL_TRAFFIC" // alow non-local traffic
-	envIgnoreResources = "DD_IGNORE_RESOURCE"       // ignored resources
-	envLogLevel        = "DD_LOG_LEVEL"             // logging level
-	envAnalyzedSpans   = "DD_APM_ANALYZED_SPANS"    // spans to analyze for transactions
-	envConnectionLimit = "DD_CONNECTION_LIMIT"      // (deprecated) limit of unique connections
+	envAPIKey             = "DD_API_KEY"                   // API KEY
+	envSite               = "DD_SITE"                      // server site (us, eu)
+	envAPMEnabled         = "DD_APM_ENABLED"               // APM enabled
+	envURL                = "DD_APM_DD_URL"                // APM URL
+	envProxyDeprecated    = "HTTPS_PROXY"                  // (deprecated) proxy URL
+	envProxy              = "DD_PROXY_HTTPS"               // proxy URL (overrides deprecated)
+	envHostname           = "DD_HOSTNAME"                  // agent hostname
+	envBindHost           = "DD_BIND_HOST"                 // statsd & receiver hostname
+	envReceiverPort       = "DD_RECEIVER_PORT"             // receiver port
+	envDogstatsdPort      = "DD_DOGSTATSD_PORT"            // dogstatsd port
+	envRemoteTraffic      = "DD_APM_NON_LOCAL_TRAFFIC"     // alow non-local traffic
+	envIgnoreResources    = "DD_IGNORE_RESOURCE"           // ignored resources
+	envLogLevel           = "DD_LOG_LEVEL"                 // logging level
+	envAnalyzedSpans      = "DD_APM_ANALYZED_SPANS"        // spans to analyze for transactions
+	envConnectionLimit    = "DD_CONNECTION_LIMIT"          // (deprecated) limit of unique connections
+	envMaxTracesPerSecond = "DD_APM_MAX_TRACES_PER_SECOND" // maximum limit to the total number of traces per second to sample (MaxTPS)
 )
 
 // loadEnv applies overrides from environment variables to the trace agent configuration
@@ -122,6 +123,16 @@ func (c *AgentConfig) loadEnv() {
 			}
 		}
 	}
+
+	if v := os.Getenv(envMaxTracesPerSecond); v != "" {
+		maxTPS, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			log.Errorf("Failed to parse %s: it should be a float number", envMaxTracesPerSecond)
+		} else {
+			c.MaxTPS = maxTPS
+		}
+	}
+
 }
 
 func parseNameAndRate(token string) (string, float64, error) {

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -47,20 +47,22 @@ func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 	})
 }
 
-func TestLoadEnvMaxTracesPerSecond(t *testing.T) {
+func TestLoadEnvMaxTPS(t *testing.T) {
 	assert := assert.New(t)
 
-	t.Run("not exist DD_APM_MAX_TRACES_PER_SECOND envvar", func(t *testing.T) {
-		ac := &AgentConfig{}
+	t.Run("default", func(t *testing.T) {
+		ac := New()
 		ac.loadEnv()
-		assert.EqualValues(0.0, ac.MaxTPS)
+		assert.EqualValues(10.0, ac.MaxTPS)
 	})
 
-	t.Run("exist DD_APM_MAX_TRACES_PER_SECOND envvar", func(t *testing.T) {
-		if err := os.Setenv("DD_APM_MAX_TRACES_PER_SECOND", "123.4"); err != nil {
+	t.Run("env", func(t *testing.T) {
+		if err := os.Setenv("DD_MAX_TPS", "123.4"); err != nil {
 			t.Fatal(err)
 		}
-		ac := &AgentConfig{}
+		defer os.Unsetenv("DD_MAX_TPS")
+
+		ac := New()
 		ac.loadEnv()
 		assert.EqualValues(123.4, ac.MaxTPS)
 	})

--- a/config/merge_env_test.go
+++ b/config/merge_env_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,5 +44,24 @@ func TestAnalyzedSpansEnvConfigParsing(t *testing.T) {
 
 		_, err = parseAnalyzedSpans("service|operation=1,")
 		assert.NotNil(err)
+	})
+}
+
+func TestLoadEnvMaxTracesPerSecond(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("not exist DD_APM_MAX_TRACES_PER_SECOND envvar", func(t *testing.T) {
+		ac := &AgentConfig{}
+		ac.loadEnv()
+		assert.EqualValues(0.0, ac.MaxTPS)
+	})
+
+	t.Run("exist DD_APM_MAX_TRACES_PER_SECOND envvar", func(t *testing.T) {
+		if err := os.Setenv("DD_APM_MAX_TRACES_PER_SECOND", "123.4"); err != nil {
+			t.Fatal(err)
+		}
+		ac := &AgentConfig{}
+		ac.loadEnv()
+		assert.EqualValues(123.4, ac.MaxTPS)
 	})
 }


### PR DESCRIPTION
I'm opening this pull request because the same motivation as https://github.com/DataDog/docker-dd-agent/pull/291 . 
We are heavy users of APM and require a higher max_traces_per_second than what the default provides (10).

I know we can specify the value in datadog.yaml (tracer.sampler > max_traces_per_second), but it would be great if we can use an environment variable for it. Especially under container environment like Kubernetes, it's really useful and convenient.