### PR TITLE
watchdog: remove high-memory consumption test

### DIFF
--- a/watchdog/info_test.go
+++ b/watchdog/info_test.go
@@ -133,7 +133,6 @@ func TestMemHigh(t *testing.T) {
 		return
 	}
 	doTestMemHigh(t, 1e7)
-	doTestMemHigh(t, 1e9)
 }
 
 type testNetHandler struct {


### PR DESCRIPTION
This change removes the 1GB memory test in order to allow our tests to
run in the "medium" resource_class of CircleCI.