### PR TITLE
cmd/trace-agent: reduce histogram calls in concentrator

### DIFF
--- a/cmd/trace-agent/concentrator.go
+++ b/cmd/trace-agent/concentrator.go
@@ -8,7 +8,6 @@ import (
 	log "github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-trace-agent/model"
-	"github.com/DataDog/datadog-trace-agent/statsd"
 	"github.com/DataDog/datadog-trace-agent/watchdog"
 )
 
@@ -155,12 +154,6 @@ func (c *Concentrator) flushNow(now int64) []model.StatsBucket {
 		}
 
 		log.Debugf("flushing bucket %d", ts)
-		for _, d := range bucket.Distributions {
-			statsd.Client.Histogram("datadog.trace_agent.distribution.len", float64(d.Summary.N), nil, 1)
-		}
-		for _, d := range bucket.ErrDistributions {
-			statsd.Client.Histogram("datadog.trace_agent.err_distribution.len", float64(d.Summary.N), nil, 1)
-		}
 		sb = append(sb, bucket)
 		delete(c.buckets, ts)
 	}

--- a/cmd/trace-agent/concentrator.go
+++ b/cmd/trace-agent/concentrator.go
@@ -144,17 +144,14 @@ func (c *Concentrator) flushNow(now int64) []model.StatsBucket {
 
 	c.mu.Lock()
 	for ts, srb := range c.buckets {
-		bucket := srb.Export()
-
 		// Always keep `bufferLen` buckets (default is 2: current + previous one).
 		// This is a trade-off: we accept slightly late traces (clock skew and stuff)
 		// but we delay flushing by at most `bufferLen` buckets.
 		if ts > now-int64(c.bufferLen)*c.bsize {
 			continue
 		}
-
 		log.Debugf("flushing bucket %d", ts)
-		sb = append(sb, bucket)
+		sb = append(sb, srb.Export())
 		delete(c.buckets, ts)
 	}
 


### PR DESCRIPTION
Attemtp to reduce UDP hits and flooding.

We had reports of excessive UDP packets (>3000 per 10 seconds) for metric `datadog.trace_agent.err_distribution.len`, all with values of zero. Seems uncalled for. This change should hopefully alleviate.