### PR TITLE
event: Ensure event priorities are propagated to Datadog backend.

### DIFF
--- a/event/processor.go
+++ b/event/processor.go
@@ -84,7 +84,6 @@ func (p *Processor) Process(t model.ProcessedTrace) (events []*model.Event, numE
 		event.SetExtractionSampleRate(extractionRate)
 		event.SetMaxEPSSampleRate(epsRate)
 		if hasPriority {
-			// Make sure to set the sampling priority on the event span so that this gets propagated to the backend.
 			event.Span.SetSamplingPriority(priority)
 		}
 	}

--- a/event/processor.go
+++ b/event/processor.go
@@ -83,6 +83,10 @@ func (p *Processor) Process(t model.ProcessedTrace) (events []*model.Event, numE
 		// As well as the rates of sampling done during this processing
 		event.SetExtractionSampleRate(extractionRate)
 		event.SetMaxEPSSampleRate(epsRate)
+		if hasPriority {
+			// Make sure to set the sampling priority on the event span so that this gets propagated to the backend.
+			event.Span.SetSamplingPriority(priority)
+		}
 	}
 
 	return

--- a/event/processor_test.go
+++ b/event/processor_test.go
@@ -89,6 +89,12 @@ func TestProcessor(t *testing.T) {
 				assert.EqualValues(test.expectedSampledPct, event.GetMaxEPSSampleRate())
 				assert.EqualValues(testClientSampleRate, event.GetClientTraceSampleRate())
 				assert.EqualValues(testPreSampleRate, event.GetPreSampleRate())
+
+				eventSpanPriority, ok := event.Span.GetSamplingPriority()
+				if !ok {
+					eventSpanPriority = model.PriorityNone
+				}
+				assert.EqualValues(test.priority, eventSpanPriority)
 			}
 		})
 	}

--- a/event/processor_test.go
+++ b/event/processor_test.go
@@ -90,11 +90,11 @@ func TestProcessor(t *testing.T) {
 				assert.EqualValues(testClientSampleRate, event.GetClientTraceSampleRate())
 				assert.EqualValues(testPreSampleRate, event.GetPreSampleRate())
 
-				eventSpanPriority, ok := event.Span.GetSamplingPriority()
+				priority, ok := event.Span.GetSamplingPriority()
 				if !ok {
-					eventSpanPriority = model.PriorityNone
+					priority = model.PriorityNone
 				}
-				assert.EqualValues(test.priority, eventSpanPriority)
+				assert.EqualValues(test.priority, priority)
 			}
 		})
 	}


### PR DESCRIPTION
Trace priority is stored as a metric on the root span.

Therefore, events extracted from the root span (the usual case) already include it by default. However, if events are extracted from non-root spans, they would not include the priority metric when sent to the backend so the backend would not know what priority they were associated with.

This PR ensures priorities are set on extracted event spans if the trace from which they were extracted contained a priority.