### PR TITLE
Makefile: update cross-compilation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@ binaries:
 	# compiling release binaries for tag $(V)
 	git checkout $(V)
 	mkdir -p ./bin
-	TRACE_AGENT_VERSION=$(V) go generate ./info
-	GOOS=windows GOARCH=amd64 go build -o ./bin/trace-agent-windows-amd64-$(V).exe ./cmd/trace-agent
-	GOOS=linux GOARCH=amd64 go build -o ./bin/trace-agent-linux-amd64-$(V) ./cmd/trace-agent
-	GOOS=darwin GOARCH=amd64 go build -o ./bin/trace-agent-darwin-amd64-$(V) ./cmd/trace-agent
-	git checkout -
+	TRACE_AGENT_VERSION=$(V) go generate ./internal/info
+	go get -u github.com/karalabe/xgo
+	xgo -dest=bin -go=1.10 -out=trace-agent-$(V) -targets=windows-6.1/amd64,linux/amd64,darwin-10.11/amd64 ./cmd/trace-agent
+	mv ./bin/trace-agent-$(V)-windows-6.1-amd64.exe ./bin/trace-agent-$(V)-windows-amd64.exe
+	mv ./bin/trace-agent-$(V)-darwin-10.11-amd64 ./bin/trace-agent-$(V)-darwin-amd64 
+	git reset --hard head && git checkout -
 
 ci:
 	# task used by CI

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The APM agent (aka Trace Agent) isn't part of the OSX Datadog Agent yet, it need
 - Download the [latest OSX Trace Agent release](https://github.com/DataDog/datadog-trace-agent/releases/latest).
 - Run the Trace Agent using the Datadog Agent configuration.
 
-    `./trace-agent-darwin-amd64-X.Y.Z -config /opt/datadog-agent/etc/datadog.yaml`
+    `./trace-agent-X.Y.Z-darwin-amd64 -config /opt/datadog-agent/etc/datadog.yaml`
 
 - The Trace Agent should now be running in foreground, with an initial output similar to:
 


### PR DESCRIPTION
Since the dependency update on datadog-agent in https://github.com/DataDog/datadog-trace-agent/pull/512 resulted in `cgo` becoming part of the build, it is no longer possible to cross-compile the binaries. This change updates the cross-compilation script to make use of [xgo](https://github.com/karalabe/xgo) to help with that.