### PR TITLE
internal/config: add DD_APM_ prefixed env. vars duplicates

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -13,38 +13,38 @@ import (
 func applyEnv() {
 	// Warning: do not use BindEnv to bind config variables. They will be overriden
 	// when using the legacy config loader.
-	for envKey, cfgKey := range map[string]string{
+	for _, override := range []struct{ env, key string }{
 		// Core agent:
-		"DD_SITE":           "site",
-		"DD_API_KEY":        "api_key",
-		"DD_HOSTNAME":       "hostname",
-		"DD_BIND_HOST":      "bind_host",
-		"DD_DOGSTATSD_PORT": "dogstatsd_port",
-		"DD_LOG_LEVEL":      "log_level",
-		"HTTPS_PROXY":       "proxy.https", // deprecated
-		"DD_PROXY_HTTPS":    "proxy.https",
+		{"DD_SITE", "site"},
+		{"DD_API_KEY", "api_key"},
+		{"DD_HOSTNAME", "hostname"},
+		{"DD_BIND_HOST", "bind_host"},
+		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},
+		{"DD_LOG_LEVEL", "log_level"},
+		{"HTTPS_PROXY", "proxy.https"}, // deprecated
+		{"DD_PROXY_HTTPS", "proxy.https"},
 
 		// APM specific:
-		"DD_CONNECTION_LIMIT":      "apm_config.connection_limit", // deprecated
-		"DD_APM_CONNECTION_LIMIT":  "apm_config.connection_limit",
-		"DD_APM_ENABLED":           "apm_config.enabled",
-		"DD_APM_ENV":               "apm_config.env",
-		"DD_APM_NON_LOCAL_TRAFFIC": "apm_config.apm_non_local_traffic",
-		"DD_APM_DD_URL":            "apm_config.apm_dd_url",
-		"DD_RECEIVER_PORT":         "apm_config.receiver_port", // deprecated
-		"DD_APM_RECEIVER_PORT":     "apm_config.receiver_port",
-		"DD_MAX_EPS":               "apm_config.max_events_per_second", // deprecated
-		"DD_APM_MAX_EPS":           "apm_config.max_events_per_second",
-		"DD_MAX_TPS":               "apm_config.max_traces_per_second", // deprecated
-		"DD_APM_MAX_TPS":           "apm_config.max_traces_per_second",
+		{"DD_CONNECTION_LIMIT", "apm_config.connection_limit"}, // deprecated
+		{"DD_APM_CONNECTION_LIMIT", "apm_config.connection_limit"},
+		{"DD_APM_ENABLED", "apm_config.enabled"},
+		{"DD_APM_ENV", "apm_config.env"},
+		{"DD_APM_NON_LOCAL_TRAFFIC", "apm_config.apm_non_local_traffic"},
+		{"DD_APM_DD_URL", "apm_config.apm_dd_url"},
+		{"DD_RECEIVER_PORT", "apm_config.receiver_port"}, // deprecated
+		{"DD_APM_RECEIVER_PORT", "apm_config.receiver_port"},
+		{"DD_MAX_EPS", "apm_config.max_events_per_second"}, // deprecated
+		{"DD_APM_MAX_EPS", "apm_config.max_events_per_second"},
+		{"DD_MAX_TPS", "apm_config.max_traces_per_second"}, // deprecated
+		{"DD_APM_MAX_TPS", "apm_config.max_traces_per_second"},
 	} {
-		if v := os.Getenv(envKey); v != "" {
-			config.Datadog.Set(cfgKey, v)
+		if v := os.Getenv(override.env); v != "" {
+			config.Datadog.Set(override.key, v)
 		}
 	}
 	for _, envKey := range []string{
 		"DD_IGNORE_RESOURCE", // deprecated
-		"DD_APM_IGNORE_RESOURCE",
+		"DD_APM_IGNORE_RESOURCES",
 	} {
 		if v := os.Getenv(envKey); v != "" {
 			if r, err := splitString(v, ','); err != nil {

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -14,32 +14,44 @@ func applyEnv() {
 	// Warning: do not use BindEnv to bind config variables. They will be overriden
 	// when using the legacy config loader.
 	for envKey, cfgKey := range map[string]string{
-		"DD_SITE":                  "site",
-		"DD_API_KEY":               "api_key",
-		"DD_HOSTNAME":              "hostname",
-		"DD_BIND_HOST":             "bind_host",
-		"DD_DOGSTATSD_PORT":        "dogstatsd_port",
-		"DD_LOG_LEVEL":             "log_level",
-		"DD_CONNECTION_LIMIT":      "apm_config.connection_limit",
+		// Core agent:
+		"DD_SITE":           "site",
+		"DD_API_KEY":        "api_key",
+		"DD_HOSTNAME":       "hostname",
+		"DD_BIND_HOST":      "bind_host",
+		"DD_DOGSTATSD_PORT": "dogstatsd_port",
+		"DD_LOG_LEVEL":      "log_level",
+		"HTTPS_PROXY":       "proxy.https", // deprecated
+		"DD_PROXY_HTTPS":    "proxy.https",
+
+		// APM specific:
+		"DD_CONNECTION_LIMIT":      "apm_config.connection_limit", // deprecated
+		"DD_APM_CONNECTION_LIMIT":  "apm_config.connection_limit",
 		"DD_APM_ENABLED":           "apm_config.enabled",
 		"DD_APM_ENV":               "apm_config.env",
 		"DD_APM_NON_LOCAL_TRAFFIC": "apm_config.apm_non_local_traffic",
 		"DD_APM_DD_URL":            "apm_config.apm_dd_url",
-		"DD_RECEIVER_PORT":         "apm_config.receiver_port",
-		"DD_MAX_EPS":               "apm_config.max_events_per_second",
-		"DD_MAX_TPS":               "apm_config.max_traces_per_second",
-		"HTTPS_PROXY":              "proxy.https",
-		"DD_PROXY_HTTPS":           "proxy.https",
+		"DD_RECEIVER_PORT":         "apm_config.receiver_port", // deprecated
+		"DD_APM_RECEIVER_PORT":     "apm_config.receiver_port",
+		"DD_MAX_EPS":               "apm_config.max_events_per_second", // deprecated
+		"DD_APM_MAX_EPS":           "apm_config.max_events_per_second",
+		"DD_MAX_TPS":               "apm_config.max_traces_per_second", // deprecated
+		"DD_APM_MAX_TPS":           "apm_config.max_traces_per_second",
 	} {
 		if v := os.Getenv(envKey); v != "" {
 			config.Datadog.Set(cfgKey, v)
 		}
 	}
-	if v := os.Getenv("DD_IGNORE_RESOURCE"); v != "" {
-		if r, err := splitString(v, ','); err != nil {
-			log.Warn("%q value not loaded: %v", "DD_IGNORE_RESOURCE", err)
-		} else {
-			config.Datadog.Set("apm_config.ignore_resources", r)
+	for _, envKey := range []string{
+		"DD_IGNORE_RESOURCE", // deprecated
+		"DD_APM_IGNORE_RESOURCE",
+	} {
+		if v := os.Getenv(envKey); v != "" {
+			if r, err := splitString(v, ','); err != nil {
+				log.Warn("%q value not loaded: %v", envKey, err)
+			} else {
+				config.Datadog.Set("apm_config.ignore_resources", r)
+			}
 		}
 	}
 	if v := os.Getenv("DD_APM_ANALYZED_SPANS"); v != "" {

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -104,16 +104,20 @@ func TestLoadEnv(t *testing.T) {
 				assert.Equal("bindhost.com", cfg.StatsdHost)
 			})
 
-			env = "DD_RECEIVER_PORT"
-			t.Run(env, func(t *testing.T) {
-				assert := assert.New(t)
-				err := os.Setenv(env, "1234")
-				assert.NoError(err)
-				defer os.Unsetenv(env)
-				cfg, err := Load("./testdata/full." + ext)
-				assert.NoError(err)
-				assert.Equal(1234, cfg.ReceiverPort)
-			})
+			for _, envKey := range []string{
+				"DD_RECEIVER_PORT", // deprecated
+				"DD_APM_RECEIVER_PORT",
+			} {
+				t.Run(envKey, func(t *testing.T) {
+					assert := assert.New(t)
+					err := os.Setenv(envKey, "1234")
+					assert.NoError(err)
+					defer os.Unsetenv(envKey)
+					cfg, err := Load("./testdata/full." + ext)
+					assert.NoError(err)
+					assert.Equal(1234, cfg.ReceiverPort)
+				})
+			}
 
 			env = "DD_DOGSTATSD_PORT"
 			t.Run(env, func(t *testing.T) {
@@ -137,16 +141,20 @@ func TestLoadEnv(t *testing.T) {
 				assert.Equal("0.0.0.0", cfg.ReceiverHost)
 			})
 
-			env = "DD_IGNORE_RESOURCE"
-			t.Run(env, func(t *testing.T) {
-				assert := assert.New(t)
-				err := os.Setenv(env, "1,2,3")
-				assert.NoError(err)
-				defer os.Unsetenv(env)
-				cfg, err := Load("./testdata/full." + ext)
-				assert.NoError(err)
-				assert.Equal([]string{"1", "2", "3"}, cfg.Ignore["resource"])
-			})
+			for _, envKey := range []string{
+				"DD_IGNORE_RESOURCE", // deprecated
+				"DD_APM_IGNORE_RESOURCE",
+			} {
+				t.Run(envKey, func(t *testing.T) {
+					assert := assert.New(t)
+					err := os.Setenv(envKey, "1,2,3")
+					assert.NoError(err)
+					defer os.Unsetenv(envKey)
+					cfg, err := Load("./testdata/full." + ext)
+					assert.NoError(err)
+					assert.Equal([]string{"1", "2", "3"}, cfg.Ignore["resource"])
+				})
+			}
 
 			env = "DD_LOG_LEVEL"
 			t.Run(env, func(t *testing.T) {
@@ -173,38 +181,50 @@ func TestLoadEnv(t *testing.T) {
 				}, cfg.AnalyzedSpansByService)
 			})
 
-			env = "DD_CONNECTION_LIMIT"
-			t.Run(env, func(t *testing.T) {
-				assert := assert.New(t)
-				err := os.Setenv(env, "50")
-				assert.NoError(err)
-				defer os.Unsetenv(env)
-				cfg, err := Load("./testdata/full." + ext)
-				assert.NoError(err)
-				assert.Equal(50, cfg.ConnectionLimit)
-			})
+			for _, envKey := range []string{
+				"DD_CONNECTION_LIMIT", // deprecated
+				"DD_APM_CONNECTION_LIMIT",
+			} {
+				t.Run(envKey, func(t *testing.T) {
+					assert := assert.New(t)
+					err := os.Setenv(envKey, "50")
+					assert.NoError(err)
+					defer os.Unsetenv(envKey)
+					cfg, err := Load("./testdata/full." + ext)
+					assert.NoError(err)
+					assert.Equal(50, cfg.ConnectionLimit)
+				})
+			}
 
-			env = "DD_MAX_TPS"
-			t.Run(env, func(t *testing.T) {
-				assert := assert.New(t)
-				err := os.Setenv(env, "6")
-				assert.NoError(err)
-				defer os.Unsetenv(env)
-				cfg, err := Load("./testdata/full." + ext)
-				assert.NoError(err)
-				assert.Equal(6., cfg.MaxTPS)
-			})
+			for _, envKey := range []string{
+				"DD_MAX_TPS", // deprecated
+				"DD_APM_MAX_TPS",
+			} {
+				t.Run(envKey, func(t *testing.T) {
+					assert := assert.New(t)
+					err := os.Setenv(envKey, "6")
+					assert.NoError(err)
+					defer os.Unsetenv(envKey)
+					cfg, err := Load("./testdata/full." + ext)
+					assert.NoError(err)
+					assert.Equal(6., cfg.MaxTPS)
+				})
+			}
 
-			env = "DD_MAX_EPS"
-			t.Run(env, func(t *testing.T) {
-				assert := assert.New(t)
-				err := os.Setenv(env, "7")
-				assert.NoError(err)
-				defer os.Unsetenv(env)
-				cfg, err := Load("./testdata/full." + ext)
-				assert.NoError(err)
-				assert.Equal(7., cfg.MaxEPS)
-			})
+			for _, envKey := range []string{
+				"DD_MAX_EPS", // deprecated
+				"DD_APM_MAX_EPS",
+			} {
+				t.Run(envKey, func(t *testing.T) {
+					assert := assert.New(t)
+					err := os.Setenv(envKey, "7")
+					assert.NoError(err)
+					defer os.Unsetenv(envKey)
+					cfg, err := Load("./testdata/full." + ext)
+					assert.NoError(err)
+					assert.Equal(7., cfg.MaxEPS)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Adds new environment variables (correctly prefixed), marking others as deprecated:
* DD_APM_CONNECTION_LIMIT
* DD_APM_RECEIVER_PORT
* DD_APM_MAX_EPS
* DD_APM_MAX_TPS
* DD_APM_IGNORE_RESOURCES