### PR TITLE
internal/api: move "trace dropped" log to level DEBUG

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -248,18 +248,15 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 			}
 			log.Errorf(errorMsg)
 		} else {
-			atomic.AddInt64(&ts.SpansDropped, int64(spans-len(normTrace)))
-
 			select {
 			case r.Out <- normTrace:
-				// if our downstream consumer is slow, we drop the trace on the floor
-				// this is a safety net against us using too much memory
-				// when clients flood us
+				// ok
 			default:
+				// agent is too slow; we have to drop the trace
 				atomic.AddInt64(&ts.TracesDropped, 1)
 				atomic.AddInt64(&ts.SpansDropped, int64(spans))
 
-				log.Errorf("dropping trace reason: rate-limited")
+				log.Debug("dropping trace: traffic too high")
 			}
 		}
 	}


### PR DESCRIPTION
This change moves the log entry that notifies the user that his trace
was dropped (due to the agent being too slow) to Debug, as it has turned
out to become quite spammy in high traffic environments. It is also not
of much value to the user. Dropping is already counted as a metric and
will be visible in the app.